### PR TITLE
Add Cairo Arc for Board Library

### DIFF
--- a/src/Board/Shapes.cpp
+++ b/src/Board/Shapes.cpp
@@ -1372,6 +1372,56 @@ Circle::flushCairo( cairo_t *cr,
 #endif
 
 /*
+ * Arc
+ */
+
+const std::string Arc::_name("Arc");
+
+const std::string &
+Arc::name() const
+{
+    return _name;
+}
+
+#ifdef WITH_CAIRO
+void
+Arc::flushCairo( cairo_t *cr,
+		 const TransformCairo & transform ) const
+{
+    cairo_save (cr);
+
+      cairo_set_source_rgba (cr, _fillColor.red()/255.0, _fillColor.green()/255.0, _fillColor.blue()/255.0, 1.);
+
+      if (_negative)
+	cairo_arc_negative (cr, transform.mapX( _center.x ), transform.mapY( _center.y ), transform.scale( _xRadius ), _angle1, _angle2);
+      else
+	cairo_arc (cr, transform.mapX( _center.x ), transform.mapY( _center.y ), transform.scale( _xRadius ), _angle1, _angle2);
+      
+      if ( filled() )
+	if ( _penColor != Color::None )
+	  cairo_fill_preserve (cr);
+	else
+	  cairo_fill (cr);
+      
+      //
+      
+      if ( _penColor != Color::None )
+      {
+	cairo_set_source_rgba (cr, _penColor.red()/255.0, _penColor.green()/255.0, _penColor.blue()/255.0, 1.);
+    
+	cairo_set_line_width (cr, _lineWidth);
+	cairo_set_line_cap (cr, cairoLineCap[_lineCap]);
+	cairo_set_line_join (cr, cairoLineJoin[_lineJoin]);
+	setCairoDashStyle (cr, _lineStyle);
+
+	cairo_stroke (cr);
+      }
+    
+    cairo_restore (cr);
+}
+#endif
+
+/*
  * Polyline
  */
 

--- a/src/Board/Shapes.h
+++ b/src/Board/Shapes.h
@@ -1397,6 +1397,41 @@ private:
 };
 
 /**
+ * The arc structure.
+ * @brief An arc.
+ */
+struct Arc : public Circle {
+
+  Arc( double x, double y, double radius, double angle1, double angle2, bool negative,
+	  Color pen, Color fill,
+	  double lineWidth,
+	  const LineStyle style = SolidStyle,
+	  int depthValue = -1 )
+    : Circle( x, y, radius, pen, fill, lineWidth, style, depthValue )
+  { _angle1 = angle1; _angle2 = angle2; _negative = negative; }
+
+  /** 
+   * Returns the generic name of the shape (e.g., Circle, Rectangle, etc.)
+   * 
+   * @return 
+   */
+  const std::string & name() const;
+
+#ifdef WITH_CAIRO
+  void flushCairo( cairo_t *cr,
+		 const TransformCairo & transform ) const;
+#endif
+
+private:
+  static const std::string _name; /**< The generic name of the shape. */
+  
+protected:
+  double _angle1;
+  double _angle2;
+  bool _negative;
+};
+
+/**
  * The text structure.
  * @brief A piece of text.
  */

--- a/src/DGtal/io/CairoViewers/DGtalCairo.cpp
+++ b/src/DGtal/io/CairoViewers/DGtalCairo.cpp
@@ -111,18 +111,6 @@ static void normalize (float vec[3])
 }
 
 /**
- * Scale the 3d vector by a given vector.
- * @param v source & destination vector.
- * @param s scale parameter.
- */
-static void scale (float v[3], float s)
-{
-    v[0] *= s;
-    v[1] *= s;
-    v[2] *= s;
-}
-
-/**
  * Transpose a 4x4 matrix.
  * @param tmat destination matrix.
  * @param mat source matrix.


### PR DESCRIPTION
Arc derived from Circle.
Ask by David for now (quick add, only with Cairo).
Will be in the new CairoDGtalBoard (3d->2d and 2d only).
