### PR TITLE
Fix build ticket80

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ endif (BUILD_TESTING)
 # Configuration of the Config.h
 #------------------------------------------------------------------------------
 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/src/DGtal/base/Config.h.in" 
-  "${PROJECT_BINARY_DIR}/src/DGtal/base/Config.h" IMMEDIATE)
+  "${PROJECT_SOURCE_DIR}/src/DGtal/base/Config.h" IMMEDIATE)
 
 #------------------------------------------------------------------------------
 # Some directories and files should also be cleaned when invoking 'make clean'

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,7 +21,7 @@ link_directories (${PROJECT_BINARY_DIR})
 
 # ConfigTest.h instanciation.
 configure_file(${PROJECT_SOURCE_DIR}/examples/ConfigExamples.h.in 
-  ${PROJECT_BINARY_DIR}/examples/ConfigExamples.h IMMEDIATE)
+  ${PROJECT_SOURCE_DIR}/examples/ConfigExamples.h IMMEDIATE)
 
 #------TESTS subdirectories ------
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ link_directories (${PROJECT_BINARY_DIR})
 
 # ConfigTest.h instanciation.
 configure_file(${PROJECT_SOURCE_DIR}/tests/ConfigTest.h.in 
-  ${PROJECT_BINARY_DIR}/tests/ConfigTest.h IMMEDIATE)
+  ${PROJECT_SOURCE_DIR}/tests/ConfigTest.h IMMEDIATE)
 
 
 #------TESTS subdirectories ------

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -29,7 +29,7 @@ add_subdirectory(imageTools)
 #------ Basic tools ------
 
 ##-- Cmake configuration for dgtal-config tool
-CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/tools/dgtal-config.cpp.in" "${PROJECT_BINARY_DIR}/tools/dgtal-config.cpp" IMMEDIATE)
+CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/tools/dgtal-config.cpp.in" "${PROJECT_SOURCE_DIR}/tools/dgtal-config.cpp" IMMEDIATE)
 
 
 SET(DGTAL_TOOLS_SRC


### PR DESCRIPTION
Config.h and other cmake configured files now stay in the source tree. This should fix #80 and #81
