### PR TITLE
Board2D: font variants for TikZ output

### DIFF
--- a/src/Board/Shapes.cpp
+++ b/src/Board/Shapes.cpp
@@ -2603,7 +2603,7 @@ Text::flushTikZ( std::ostream & stream,
 	   << (fontTraits[ _font ] & BOLD_FONT ? "\\bfseries " : "")
 	   << (fontTraits[ _font ] & MONOSPACE_FONT ? "\\ttfamily " : "")
 	   << (fontTraits[ _font ] & SANSSERIF_FONT ? "\\sffamily " : "")
-           << _text << ' ' << (int)fontTraits[_font] << ' ' << (int)_font
+           << _text
            << "};" << std::endl;
 }
 


### PR DESCRIPTION
The font family specified in LibBoard::Board is not actually honored in TikZ outputs but a LaTeX font variant is chosen according to its characteristics (italic/bold/monospace/sans serif).
