### PR TITLE
Correcting issues #289 and #290

### DIFF
--- a/src/DGtal/topology/DigitalSetBoundary.h
+++ b/src/DGtal/topology/DigitalSetBoundary.h
@@ -78,7 +78,7 @@ namespace DGtal
       // -------------------- associated types --------------------
       typedef Tracker Self;
       typedef DigitalSetBoundary<TKSpace,TDigitalSet> DigitalSurfaceContainer;
-      typedef typename DigitalSurfaceContainer::Surfel Surfel;
+      typedef typename TKSpace::SCell Surfel;
 
       // -------------------- inner types --------------------
       typedef TKSpace KSpace;

--- a/src/DGtal/topology/DigitalSetBoundary.ih
+++ b/src/DGtal/topology/DigitalSetBoundary.ih
@@ -251,7 +251,7 @@ inline
 DGtal::Connectedness
 DGtal::DigitalSetBoundary<TKSpace,TDigitalSet>::connectedness() const
 {
-  return Connectedness::UNKNOWN;
+  return UNKNOWN;
 }
 
 // ------------------------- Hidden services ------------------------------

--- a/src/DGtal/topology/DigitalSurface.ih
+++ b/src/DGtal/topology/DigitalSurface.ih
@@ -544,7 +544,7 @@ void
 DGtal::DigitalSurface<TDigitalSurfaceContainer>::
 exportSurfaceAs3DOFF ( std::ostream & out ) const
 {
-  typedef unsigned long long Number;
+  typedef DGtal::uint64_t Number;
   // Numbers all vertices.
   std::map<Vertex, Number> index;
   Number nbv = 0;
@@ -606,7 +606,7 @@ exportEmbeddedSurfaceAs3DOFF
 ( std::ostream & out,
   const CellEmbedder & cembedder ) const
 {
-  typedef unsigned long long Number;
+  typedef DGtal::uint64_t Number;
   // Numbers all vertices.
   std::map<Vertex, Number> index;
   Number nbv = 0;
@@ -668,7 +668,7 @@ exportEmbeddedSurfaceAs3DNOFF
 ( std::ostream & out,
   const CellEmbedder & cembedder ) const
 {
-  typedef unsigned long long Number;
+  typedef DGtal::uint64_t Number;
   // Numbers all vertices.
   std::map<Vertex, Number> index;
   Number nbv = 0;

--- a/src/DGtal/topology/ExplicitDigitalSurface.h
+++ b/src/DGtal/topology/ExplicitDigitalSurface.h
@@ -84,7 +84,7 @@ namespace DGtal
       typedef Tracker Self;
       typedef ExplicitDigitalSurface<TKSpace,TSurfelPredicate>
       DigitalSurfaceContainer;
-      typedef typename DigitalSurfaceContainer::Surfel Surfel;
+      typedef typename TKSpace::SCell Surfel;
 
       // -------------------- inner types --------------------
       typedef TKSpace KSpace;

--- a/src/DGtal/topology/ExplicitDigitalSurface.ih
+++ b/src/DGtal/topology/ExplicitDigitalSurface.ih
@@ -241,7 +241,7 @@ inline
 DGtal::Connectedness
 DGtal::ExplicitDigitalSurface<TKSpace,TSurfelPredicate>::connectedness() const
 {
-  return Connectedness::CONNECTED;
+  return CONNECTED;
 }
 
 // ------------------------- Hidden services ------------------------------

--- a/src/DGtal/topology/ImplicitDigitalSurface.h
+++ b/src/DGtal/topology/ImplicitDigitalSurface.h
@@ -81,7 +81,7 @@ namespace DGtal
       typedef Tracker Self;
       typedef ImplicitDigitalSurface<TKSpace,TPointPredicate>
       DigitalSurfaceContainer;
-      typedef typename DigitalSurfaceContainer::Surfel Surfel;
+      typedef typename TKSpace::SCell Surfel;
 
       // -------------------- inner types --------------------
       typedef TKSpace KSpace;

--- a/src/DGtal/topology/ImplicitDigitalSurface.ih
+++ b/src/DGtal/topology/ImplicitDigitalSurface.ih
@@ -253,7 +253,7 @@ inline
 DGtal::Connectedness
 DGtal::ImplicitDigitalSurface<TKSpace,TPointPredicate>::connectedness() const
 {
-  return Connectedness::CONNECTED;
+  return CONNECTED;
 }
 
 // ------------------------- Hidden services ------------------------------

--- a/src/DGtal/topology/LightExplicitDigitalSurface.h
+++ b/src/DGtal/topology/LightExplicitDigitalSurface.h
@@ -89,7 +89,7 @@ namespace DGtal
       typedef Tracker Self;
       typedef LightExplicitDigitalSurface<TKSpace,TSurfelPredicate>
       DigitalSurfaceContainer;
-      typedef typename DigitalSurfaceContainer::Surfel Surfel;
+      typedef typename TKSpace::SCell Surfel;
 
       // -------------------- inner types --------------------
       typedef TKSpace KSpace;

--- a/src/DGtal/topology/LightExplicitDigitalSurface.ih
+++ b/src/DGtal/topology/LightExplicitDigitalSurface.ih
@@ -247,7 +247,7 @@ inline
 DGtal::Connectedness
 DGtal::LightExplicitDigitalSurface<TKSpace,TSurfelPredicate>::connectedness() const
 {
-  return Connectedness::CONNECTED;
+  return CONNECTED;
 }
 //-----------------------------------------------------------------------------
 // ----------------- UndirectedSimplePreGraph realization --------------------

--- a/src/DGtal/topology/LightImplicitDigitalSurface.h
+++ b/src/DGtal/topology/LightImplicitDigitalSurface.h
@@ -87,7 +87,7 @@ namespace DGtal
       typedef Tracker Self;
       typedef LightImplicitDigitalSurface<TKSpace,TPointPredicate>
       DigitalSurfaceContainer;
-      typedef typename DigitalSurfaceContainer::Surfel Surfel;
+      typedef typename TKSpace::SCell Surfel;
 
       // -------------------- inner types --------------------
       typedef TKSpace KSpace;

--- a/src/DGtal/topology/LightImplicitDigitalSurface.ih
+++ b/src/DGtal/topology/LightImplicitDigitalSurface.ih
@@ -259,7 +259,7 @@ inline
 DGtal::Connectedness
 DGtal::LightImplicitDigitalSurface<TKSpace,TPointPredicate>::connectedness() const
 {
-  return Connectedness::CONNECTED;
+  return CONNECTED;
 }
 //-----------------------------------------------------------------------------
 // ----------------- UndirectedSimplePreGraph realization --------------------

--- a/src/DGtal/topology/SetOfSurfels.h
+++ b/src/DGtal/topology/SetOfSurfels.h
@@ -81,7 +81,7 @@ namespace DGtal
       // -------------------- associated types --------------------
       typedef Tracker Self;
       typedef SetOfSurfels<TKSpace,TSurfelSet> DigitalSurfaceContainer;
-      typedef typename DigitalSurfaceContainer::Surfel Surfel;
+      typedef typename TKSpace::SCell Surfel;
       
       // -------------------- inner types --------------------
       typedef TKSpace KSpace;

--- a/src/DGtal/topology/SetOfSurfels.ih
+++ b/src/DGtal/topology/SetOfSurfels.ih
@@ -256,7 +256,7 @@ inline
 DGtal::Connectedness
 DGtal::SetOfSurfels<TKSpace,TSurfelSet>::connectedness() const
 {
-  return Connectedness::UNKNOWN;
+  return UNKNOWN;
 }
 
 // ------------------------- Hidden services ------------------------------

--- a/tests/math/testMPolynomial.cxx
+++ b/tests/math/testMPolynomial.cxx
@@ -160,7 +160,7 @@ bool testMPolynomial()
   trace.info() << l << std::endl;
   trace.info() << derivative<0>(l) << std::endl;
   trace.info() << gcd(l, derivative<0>(l)) << " (gcd of two previous polys is 1)" << std::endl;
-  nbok += gcd(l, derivative<0>(l)) == 1 * mmonomial<double>(0) ? 1 : 0; 
+  nbok += gcd(l, derivative<0>(l)) == 1.0 * mmonomial<double>(0) ? 1 : 0; 
   nb++;
   trace.info() << "Durchblick (x3y+xz3+y3z+z3+5z)= " << durchblick<double>() << std::endl;
   nbok += true ? 1 : 0; 

--- a/tools/volumetric/3dVolMarchingCubes.cpp
+++ b/tools/volumetric/3dVolMarchingCubes.cpp
@@ -18,8 +18,6 @@
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
-#include <QImageReader>
-#include <QtGui/qapplication.h>
 #include "DGtal/kernel/sets/SetPredicate.h"
 #include "DGtal/io/readers/VolReader.h"
 #include "DGtal/images/ImageSelector.h"


### PR DESCRIPTION
Change definitions of Surfels within Tracker (g++-4.2 is a bit old with forward definition).
Change unsigned long long to uint64_t (valid only since c++11).
In testMPolynomial, multiply by 1.0 (double) instead of 1 (int) for multiplication.
