### PR TITLE
removing typename (build error on mac with i686-apple-darwin11-llvm-gcc-...

### DIFF
--- a/examples/topology/trackImplicitPolynomialSurfaceToOFF.cpp
+++ b/examples/topology/trackImplicitPolynomialSurfaceToOFF.cpp
@@ -82,8 +82,8 @@ int main( int argc, char** argv )
 
   //! [trackImplicitPolynomialSurfaceToOFF-makeSurface]
   trace.beginBlock( "Making polynomial surface." );
-  typedef typename Space::RealPoint RealPoint;
-  typedef typename RealPoint::Coordinate Ring;
+  typedef Space::RealPoint RealPoint;
+  typedef RealPoint::Coordinate Ring;
   typedef MPolynomial<3, Ring> Polynomial3;
   typedef MPolynomialReader<3, Ring> Polynomial3Reader;
   typedef ImplicitPolynomial3Shape<Space> ImplicitShape;


### PR DESCRIPTION
...4.2 )

Tiny pull request but just to check if the removed typename well works on others arch... ;)
