### PR TITLE
Fixing links in documentation.

### DIFF
--- a/src/DGtal/base/Config.h.in
+++ b/src/DGtal/base/Config.h.in
@@ -121,5 +121,8 @@ M. Tola (LIRIS, Lyon), X. Provençal (LAMA, Chambéry).
    @defgroup Tests DGtal Test Files
    @defgroup Examples DGtal Examples
   
+
+[imagene]: https://gforge.liris.cnrs.fr/projects/imagene "ImaGene"
+
  */
 

--- a/src/DGtal/base/Statistic.h
+++ b/src/DGtal/base/Statistic.h
@@ -49,16 +49,17 @@
 namespace DGtal
 {
   /**
-   * Description of class 'Statistic' <p> \brief Aim: This class processes a
-   * set of sample values for one variable and can then compute
-   * different statistics, like sample mean, sample variance, sample
-   * unbiased variance, etc. It is minimalistic for space
-   * efficiency. For multiple variables, sample storage and others,
-   * see Statistics class.
-   *
-   * Backported from  \cite ImaGene . \cite Lachaud03b
-   *
-   * @see testStatistics.cpp
+
+    Description of class 'Statistic' <p> \brief Aim: This class processes a
+    set of sample values for one variable and can then compute
+    different statistics, like sample mean, sample variance, sample
+    unbiased variance, etc. It is minimalistic for space
+    efficiency. For multiple variables, sample storage and others,
+    see Statistics class.
+
+    Backported from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene). \cite Lachaud03b
+    
+    @see testStatistics.cpp
    */
   template <typename RealNumberType>
   class Statistic

--- a/src/DGtal/math/Signal.h
+++ b/src/DGtal/math/Signal.h
@@ -155,8 +155,8 @@ namespace DGtal
      @tparam TValue the type chosen for each sample (generally float
      or double).
      
-     This class is a backport from <a
-     href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+     This class is a backport from
+     [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
   */
   template <typename TValue>
   class Signal

--- a/src/DGtal/math/arithmetic/SternBrocot.h
+++ b/src/DGtal/math/arithmetic/SternBrocot.h
@@ -156,7 +156,7 @@ namespace DGtal
           
           @return the corresponding fraction in the Stern-Brocot tree.
           
-          NB: Complexity is bounded by \f$ 2 \sum_ u_i \f$, where u_i
+          NB: Complexity is bounded by \f$ 2 \sum_i u_i \f$, where u_i
           are the partial quotients of aP/aQ.
       */
       Fraction( Integer aP, Integer aQ,
@@ -336,7 +336,7 @@ namespace DGtal
 	
 	@return the corresponding fraction in the Stern-Brocot tree.
 
-        NB: Complexity is bounded by \f$ 2 \sum_ u_i \f$, where u_i
+        NB: Complexity is bounded by \f$ 2 \sum_i u_i \f$, where u_i
         are the partial quotients of p/q.
     */
     static Fraction fraction( Integer p, Integer q,

--- a/src/DGtal/shapes/parametric/AccFlower2D.h
+++ b/src/DGtal/shapes/parametric/AccFlower2D.h
@@ -58,8 +58,7 @@ namespace DGtal
    * \brief Aim: Model of the concept StarShaped
    * represents any accelerated flower in the plane.
    *
-   * NB: A backport from <a
-   href="http://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
    */
   template <typename TSpace>
   class AccFlower2D:  public StarShaped2D<TSpace>

--- a/src/DGtal/shapes/parametric/Ellipse2D.h
+++ b/src/DGtal/shapes/parametric/Ellipse2D.h
@@ -58,8 +58,7 @@ namespace DGtal
    * \brief Aim: Model of the concept StarShaped
    * represents any ellipse in the plane.
    *
-   * NB: A backport from <a
-   href="http://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
    */
   template <typename TSpace>
   class Ellipse2D:  public StarShaped2D<TSpace>

--- a/src/DGtal/shapes/parametric/Flower2D.h
+++ b/src/DGtal/shapes/parametric/Flower2D.h
@@ -58,8 +58,7 @@ namespace DGtal
    * \brief Aim: Model of the concept StarShaped
    * represents any flower with k-petals in the plane.
    *
-   * NB: A backport from <a
-   href="http://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
    */
   template <typename TSpace>
   class Flower2D:  public StarShaped2D<TSpace>

--- a/src/DGtal/shapes/parametric/NGon2D.h
+++ b/src/DGtal/shapes/parametric/NGon2D.h
@@ -57,8 +57,7 @@ namespace DGtal
    * \brief Aim: Model of the concept StarShaped
    * represents any regular k-gon in the plane.
    *
-   * NB: A backport from <a
-   href="http://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
    */
   template <typename TSpace>
   class NGon2D:  public StarShaped2D<TSpace>

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -64,8 +64,7 @@ namespace DGtal
    * StarShaped2D and its derived classes are models of
    * CEuclideanBoundedShape and CEuclideanOrientedShape. 
    *
-   * NB: A backport from <a
-   href="http://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
    *
    *  
    * @tparam TSpace space in which the shape is defined.

--- a/src/DGtal/topology/KhalimskySpaceND.h
+++ b/src/DGtal/topology/KhalimskySpaceND.h
@@ -340,8 +340,7 @@ namespace DGtal
    *
    * @tparam dim the dimension of the digital space.
    * @tparam TInteger the Integer class used to specify the arithmetic computations (default type = int32).
-   * NB: Essentially a backport from <a
-   href="http://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+   * NB: Essentially a backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
   */
   template < Dimension dim,
              typename TInteger = DGtal::int32_t >

--- a/src/DGtal/topology/SurfelAdjacency.h
+++ b/src/DGtal/topology/SurfelAdjacency.h
@@ -59,7 +59,7 @@ namespace DGtal
      
      @tparam dim the number of dimension of the space.
 
-     NB: backported from ImaGene. http://gforge.liris.cnrs.fr/projects/imagene
+     NB: backported from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
   */
   template <Dimension dim>
   class SurfelAdjacency

--- a/src/DGtal/topology/SurfelNeighborhood.h
+++ b/src/DGtal/topology/SurfelNeighborhood.h
@@ -62,8 +62,7 @@ namespace DGtal
    * @tparam TKSpace the type of celluler grid space (for instance, a
    * KhalimskySpaceND).
    *
-   * Essentially a backport from <a
-   href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+   * Essentially a backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
    */
   template <typename TKSpace>
   class SurfelNeighborhood

--- a/src/DGtal/topology/UmbrellaComputer.h
+++ b/src/DGtal/topology/UmbrellaComputer.h
@@ -78,8 +78,8 @@ namespace DGtal
     
      Uses delegation with DigitalSurfaceTracker.
 
-     Essentially a backport from <a
-     href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+     Essentially a backport from
+     [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
 
      @tparam TDigitalSurfaceTracker the type of the domain in which shapes are created.
    */

--- a/src/DGtal/topology/helpers/Surfaces.h
+++ b/src/DGtal/topology/helpers/Surfaces.h
@@ -72,8 +72,7 @@ namespace DGtal
      function. This is to be more generic than a simple
      DigitalSet. With this approach, shapes can be defined implicitly.
 
-     Essentially a backport from <a
-     href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+     Essentially a backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
    */
   template <typename TKSpace>
   class Surfaces


### PR DESCRIPTION
Use new doxygen links [..](...). Note that link definition [...]: does not seem to work.
