### PR TITLE
Removing ambiguous int64_t

### DIFF
--- a/examples/math/arithmetic/approximation.cpp
+++ b/examples/math/arithmetic/approximation.cpp
@@ -45,8 +45,8 @@ int main( int argc, char** argv )
     }
 
   //! [approximation-types]
-  typedef int64_t Integer;
-  typedef int64_t Size;
+  typedef DGtal::int64_t Integer;
+  typedef DGtal::int64_t Size;
   typedef LighterSternBrocot<Integer, Size, StdMapRebinder> SB; // the type of the Stern-Brocot tree
   typedef SB::Fraction Fraction; // the type for fractions
   typedef Fraction::ConstIterator ConstIterator; // the iterator type for visiting quotients
@@ -67,13 +67,13 @@ int main( int argc, char** argv )
       long double int_part = floorl( number );
       Size u = NumberTraits<long double>::castToInt64_t( int_part );
       *itback++ = std::make_pair( u, i++ );
-      long double approx = 
+      long double approx =
         ( (long double) NumberTraits<Integer>::castToDouble( f.p() ) )
         / ( (long double) NumberTraits<Integer>::castToDouble( f.q() ) );
-      std::cout << "z = " << f.p() << " / " << f.q() 
+      std::cout << "z = " << f.p() << " / " << f.q()
                 << " =~ " << setprecision( 16 ) << approx << std::endl;
       number -= int_part;
-      if ( ( (number0 - epsilon ) < approx ) 
+      if ( ( (number0 - epsilon ) < approx )
            && ( approx < (number0 + epsilon ) ) ) break;
       number = 1.0 / number;
     }

--- a/examples/math/arithmetic/convergents-biginteger.cpp
+++ b/examples/math/arithmetic/convergents-biginteger.cpp
@@ -44,7 +44,7 @@ int main( int argc, char** argv )
 
   //! [convergents-biginteger-types]
   typedef BigInteger Integer;
-  typedef int64_t Size;
+  typedef DGtal::int64_t Size;
   typedef LighterSternBrocot<Integer, Size, StdMapRebinder> SB; // the type of the Stern-Brocot tree
   typedef SB::Fraction Fraction; // the type for fractions
   typedef Fraction::ConstIterator ConstIterator; // the iterator type for visiting quotients
@@ -65,9 +65,9 @@ int main( int argc, char** argv )
     {
       Value u = *it;
       std::cout << ( ( it == itbegin ) ? "[" : "," )
-                << u.first; 
+                << u.first;
     }
-  std::cout << "]" << std::endl; 
+  std::cout << "]" << std::endl;
   //! [convergents-biginteger-cfrac]
 
   //! [convergents-biginteger-convergents]

--- a/examples/math/arithmetic/convergents.cpp
+++ b/examples/math/arithmetic/convergents.cpp
@@ -41,15 +41,15 @@ int main( int argc, char** argv )
     }
 
   //! [convergents-types]
-  typedef LighterSternBrocot<int64_t, int64_t, StdMapRebinder> SB; // the type of the Stern-Brocot tree
+  typedef LighterSternBrocot<DGtal::int64_t, DGtal::int64_t, StdMapRebinder> SB; // the type of the Stern-Brocot tree
   typedef SB::Fraction Fraction; // the type for fractions
   typedef Fraction::ConstIterator ConstIterator; // the iterator type for visiting quotients
   typedef Fraction::Value Value; // the value of the iterator, a pair (quotient,depth).
   //! [convergents-types]
 
   //! [convergents-instantiation]
-  int64_t p = atoll( argv[ 1 ] );
-  int64_t q = atoll( argv[ 2 ] );
+  DGtal::int64_t p = atoll( argv[ 1 ] );
+  DGtal::int64_t q = atoll( argv[ 2 ] );
   Fraction f( p, q ); // fraction p/q
   //! [convergents-instantiation]
 
@@ -61,9 +61,9 @@ int main( int argc, char** argv )
     {
       Value u = *it;
       std::cout << ( ( it == itbegin ) ? "[" : "," )
-                << u.first; 
+                << u.first;
     }
-  std::cout << "]" << std::endl; 
+  std::cout << "]" << std::endl;
   //! [convergents-cfrac]
 
   //! [convergents-convergents]

--- a/examples/math/arithmetic/fraction.cpp
+++ b/examples/math/arithmetic/fraction.cpp
@@ -41,8 +41,8 @@ int main( int argc, char** argv )
     }
 
   //! [fraction-types]
-  typedef int64_t Integer;
-  typedef int64_t Size;
+  typedef DGtal::int64_t Integer;
+  typedef DGtal::int64_t Size;
   typedef LighterSternBrocot<Integer, Size, StdMapRebinder> SB; // the type of the Stern-Brocot tree
   typedef SB::Fraction Fraction; // the type for fractions
   typedef Fraction::ConstIterator ConstIterator; // the iterator type for visiting quotients

--- a/examples/math/arithmetic/pattern.cpp
+++ b/examples/math/arithmetic/pattern.cpp
@@ -47,16 +47,16 @@ int main( int argc, char** argv )
     }
 
   //! [pattern-types]
-  typedef int32_t Integer;
-  typedef int32_t Size;
+  typedef DGtal::int32_t Integer;
+  typedef DGtal::int32_t Size;
   typedef LighterSternBrocot<Integer, Size, StdMapRebinder> SB; // the type of the Stern-Brocot tree
   typedef SB::Fraction Fraction; // the type for fractions
   typedef Pattern<Fraction> MyPattern; // the type for patterns
   //! [pattern-types]
 
   //! [pattern-instantiation]
-  int32_t p = atoi( argv[ 1 ] );
-  int32_t q = atoi( argv[ 2 ] );
+  DGtal::int32_t p = atoi( argv[ 1 ] );
+  DGtal::int32_t q = atoi( argv[ 2 ] );
   MyPattern pattern( p, q );
   //! [pattern-instantiation]
 


### PR DESCRIPTION
explict use of DGtal::int64_t in cpp. Otherwise it won't compile with older g++ (eg 4.4)
