### PR TITLE
Master comp4.2.1

### DIFF
--- a/src/DGtal/base/InputIteratorWithRankOnSequence.h
+++ b/src/DGtal/base/InputIteratorWithRankOnSequence.h
@@ -227,7 +227,8 @@ namespace DGtal
    * @param object the object of class 'InputIteratorWithRankOnSequence' to write.
    * @return the output stream after the writing.
    */
-  template <typename TSequence, typename TRank >
+  //  template <typename TSequence, typename TRank = typename TSequence::difference_type>
+  template <typename TSequence, typename TRank>
   std::ostream&
   operator<< ( std::ostream & out, const InputIteratorWithRankOnSequence<TSequence, TRank> & object );
 


### PR DESCRIPTION
Removing template default parameter in  InputIteratorWithRankOnSequence (does not work on gcc 4.2.1)
