### PR TITLE
Correct problems with MPolynomialReader. Especially, some terms were not...

### DIFF
--- a/doc/mpolynomial.dox
+++ b/doc/mpolynomial.dox
@@ -335,7 +335,9 @@ you just have to separate them with newlines. The input stream is read
 as long as the input is valid for the multivariate polynomial grammar.
 
 If you wish to handle better error recovery when creating a
-polynomial, you can use the method MPolynomialReader::read directly.
+polynomial, you can use the method MPolynomialReader::read
+directly. You may look at example polynomial-read.cpp for a more
+concrete example.
 
 In input, you may write the variables either simply \c x, \c y, \c z,
 \c t for the first four variables, or more generically \c X_0, \c X_1,
@@ -368,8 +370,9 @@ d/dX_1 dP/dX_1(X_0,X_1) = 2
 @endverbatim
 
 
-@see polynomial-derivative.cpp, polynomial2-derivative.cpp.
-@see testMPolynomial.cpp, trackImplicitPolynomialSurfaceToOFF.cpp.
+@see polynomial-read.cpp, polynomial-derivative.cpp, polynomial2-derivative.cpp.
+@see trackImplicitPolynomialSurfaceToOFF.cpp.
+@see testMPolynomial.cpp, testMPolynomialReader.cpp.
 
 */
 

--- a/examples/math/CMakeLists.txt
+++ b/examples/math/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(DGTAL_EXAMPLES_MATH_SRC
         polynomial-derivative
         polynomial2-derivative
+	polynomial-read
 )
 
 FOREACH(FILE ${DGTAL_EXAMPLES_MATH_SRC})

--- a/examples/math/polynomial-read.cpp
+++ b/examples/math/polynomial-read.cpp
@@ -1,0 +1,77 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file polynomial-read.cpp
+ * @ingroup Examples
+ * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr )
+ * Laboratory of Mathematics (CNRS, UMR 5807), University of Savoie, France
+ *
+ * @date 2012/02/12
+ *
+ * Functions for testing class Signal.
+ *
+ * This file is part of the DGtal library.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include "DGtal/base/Common.h"
+#include "DGtal/math/MPolynomial.h"
+#include "DGtal/io/readers/MPolynomialReader.h"
+///////////////////////////////////////////////////////////////////////////////
+
+using namespace std;
+using namespace DGtal;
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Standard services - public :
+
+/**
+   A simple example to show how to read a multivariate-polynomial from stdin.
+*/
+int main( int /*argc*/, char** /*argv*/ )
+{
+  typedef double Ring;
+  MPolynomial<3,Ring,std::allocator<Ring> > P;
+  MPolynomialReader<3,Ring> reader;
+  string str;
+
+  std::cout << "Type any multi-variate polynomial, then press return." << std::endl
+	    << "Examples: xyz^3-4yz, (x+y+z)*(x-y-z)^2." << std::endl;
+  do {
+    getline( cin, str );
+    if ( cin.good() && ( ! str.empty() ) )
+      {
+	std::string::const_iterator iter 
+	  = reader.read( P, str.begin(), str.end() );
+	bool ok = iter == str.end();
+	if ( ! ok )
+	  {
+	    std::cerr << "ERROR: I read only <" 
+		      << str.substr( 0, iter - str.begin() )
+		      << ">, and I built P=" << P << std::endl;
+	  }
+	std::cout << (ok ? "Ok : " : "Err: ") << P << std::endl;
+      }
+  } while ( ! str.empty() );
+  return 0;
+}
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////

--- a/tests/io/readers/CMakeLists.txt
+++ b/tests/io/readers/CMakeLists.txt
@@ -3,7 +3,8 @@ SET(DGTAL_TESTS_SRC_IO_READERS
        testVolReader
        testRawReader     
        testPointListReader 
-       testMeshReader )
+       testMeshReader
+       testMPolynomialReader )
 
 
 FOREACH(FILE ${DGTAL_TESTS_SRC_IO_READERS})

--- a/tests/io/readers/testMPolynomialReader.cpp
+++ b/tests/io/readers/testMPolynomialReader.cpp
@@ -1,0 +1,128 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file testMPolynomialReader.cpp
+ * @ingroup Tests
+ * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr )
+ * Laboratory of Mathematics (CNRS, UMR 5807), University of Savoie, France
+ *
+ * @date 2012/02/12
+ *
+ * Functions for testing class Signal.
+ *
+ * This file is part of the DGtal library.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include "DGtal/base/Common.h"
+#include "DGtal/math/MPolynomial.h"
+#include "DGtal/io/readers/MPolynomialReader.h"
+///////////////////////////////////////////////////////////////////////////////
+
+using namespace std;
+using namespace DGtal;
+
+///////////////////////////////////////////////////////////////////////////////
+// Functions for testing class MPolynomialReader.
+///////////////////////////////////////////////////////////////////////////////
+
+bool testMPolynomialReader()
+{
+
+  MPolynomial<2,double,std::allocator<double> > Q1;
+  MPolynomial<2,double,std::allocator<double> > Q2;
+  MPolynomial<2,double,std::allocator<double> > Q = Q1 * Q2;
+
+  typedef int Ring;
+  MPolynomial<3,Ring,std::allocator<Ring> > P;
+  MPolynomialReader<3,Ring> reader;
+  string s1 = "1.5 X_0^2 X_2^3 X_1^5 * (4 X_0^3 + X_1^2)^2";
+  //string s1 = "1.5 X_0^2 X_2^3 X_1^5";
+  string s2 = "2 X_0^2 X_2 X_1^5";
+  string s3 = s1 + " * " + s2;
+  string s4 = "(" + s2 + ")^4 * (" + s1 + ")^1 - 3 X_2^3";
+  string s5 = "x^3y+xz^3+y^3z+z^3+5z"; // Durchblick
+  string s6 = "(y^2+z^2-1)^2 +(x^2+y^2-1)^3"; // Crixxi 
+  string s7 = "(y^2+z^2-1)^2 Abrahamovitch"; 
+  bool ok1 = reader.read( P, s1.begin(), s1.end() ) == s1.end();
+  trace.info() << "- Parsing " << s1 << " : " << ok1 << " " << P << std::endl;
+  bool ok2 = reader.read( P, s2.begin(), s2.end() ) == s2.end();
+  trace.info() << "- Parsing " << s2 << " : " << ok2 << " " << P << std::endl;
+  bool ok3 = reader.read( P, s3.begin(), s3.end() ) == s3.end();
+  trace.info() << "- Parsing " << s3 << " : " << ok3 << " " << P << std::endl;
+  bool ok4 = reader.read( P, s4.begin(), s4.end() ) == s4.end();
+  trace.info() << "- Parsing " << s4 << " : " << ok4 << " " << P << std::endl;
+  bool ok5 = reader.read( P, s5.begin(), s5.end() ) == s5.end();
+  trace.info() << "- Parsing " << s5 << " : " << ok5 << " " << P << std::endl;
+  bool ok6 = reader.read( P, s6.begin(), s6.end() ) == s6.end();
+  trace.info() << "- Parsing " << s6 << " : " << ok6 << " " << P << std::endl;
+  bool ok7 = reader.read( P, s7.begin(), s7.end() ) == s7.end();
+  trace.info() << "- Parsing " << s7 << " : " << ok7 << " " << P << std::endl;
+
+  string s8 = "(zyx^2+x^2-1)^2 + xy AVERTY"; 
+  std::istringstream sin( s8 );
+  std::string other;
+  sin >> P >> other;
+  trace.info() << "- Read " << P << " and " << other << std::endl;
+
+  return ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && (!ok7);
+}
+
+bool testMPolynomialReader2()
+{
+
+  typedef double Ring;
+  MPolynomial<3,Ring,std::allocator<Ring> > P1, P2, Q1, Q2, Q3, Q4;
+  MPolynomialReader<3,Ring> reader;
+  string s1 = "  x^4";
+  string s2 = "1*y^4";
+  string s3 = s1 + "+" + s2 + "-2";
+  string s4 = "(" + s1 + ")+(" + s2 + ")-2";
+  string s5 = "(" + s1 + ")+ " + s2 + " -2";
+  bool ok1 = reader.read( P1, s1.begin(), s1.end() ) == s1.end();
+  bool ok2 = reader.read( P2, s2.begin(), s2.end() ) == s2.end();
+  Q1 = P1 + P2 - 2;
+  bool ok3 = reader.read( Q2, s3.begin(), s3.end() ) == s3.end();
+  bool ok4 = reader.read( Q3, s4.begin(), s4.end() ) == s4.end();
+  bool ok4b= reader.read( Q4, s5.begin(), s5.end() ) == s5.end();
+
+  trace.info() << "- Read Q1=" << Q1 << " from addition of monomials. " << std::endl;
+  trace.info() << "- Read Q2=" << Q2 << " from string: " << s3 << std::endl;
+  trace.info() << "- Read Q3=" << Q3 << " from string: " << s4 << std::endl;
+  trace.info() << "- Read Q4=" << Q4 << " from string: " << s5 << std::endl;
+  bool ok5 = Q1 == Q2;
+  bool ok6 = Q1 == Q3;
+  return ok1 && ok2 && ok3 && ok4 && ok5 && ok6;
+}
+///////////////////////////////////////////////////////////////////////////////
+// Standard services - public :
+
+int main( int /*argc*/, char** /*argv*/ )
+{
+  trace.beginBlock ( "Testing class MPolynomialReader" );
+
+  bool res = testMPolynomialReader()
+    && testMPolynomialReader2();
+  trace.emphase() << ( res ? "Passed." : "Error." ) << endl;
+  trace.endBlock();
+  return res ? 0 : 1;
+}
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////

--- a/tests/math/testMPolynomial.cpp
+++ b/tests/math/testMPolynomial.cpp
@@ -188,47 +188,7 @@ bool testMPolynomial()
   return nbok == nb;
 }
 
-bool testMPolynomialReader()
-{
 
-  MPolynomial<2,double,std::allocator<double> > Q1;
-  MPolynomial<2,double,std::allocator<double> > Q2;
-  MPolynomial<2,double,std::allocator<double> > Q = Q1 * Q2;
-
-  typedef int Ring;
-  MPolynomial<3,Ring,std::allocator<Ring> > P;
-  MPolynomialReader<3,Ring> reader;
-  string s1 = "1.5 X_0^2 X_2^3 X_1^5 * (4 X_0^3 + X_1^2)^2";
-  //string s1 = "1.5 X_0^2 X_2^3 X_1^5";
-  string s2 = "2 X_0^2 X_2 X_1^5";
-  string s3 = s1 + " * " + s2;
-  string s4 = "(" + s2 + ")^4 * (" + s1 + ")^1 - 3 X_2^3";
-  string s5 = "x^3y+xz^3+y^3z+z^3+5z"; // Durchblick
-  string s6 = "(y^2+z^2-1)^2 +(x^2+y^2-1)^3"; // Crixxi 
-  string s7 = "(y^2+z^2-1)^2 Abrahamovitch"; 
-  bool ok1 = reader.read( P, s1.begin(), s1.end() ) == s1.end();
-  trace.info() << "- Parsing " << s1 << " : " << ok1 << " " << P << std::endl;
-  bool ok2 = reader.read( P, s2.begin(), s2.end() ) == s2.end();
-  trace.info() << "- Parsing " << s2 << " : " << ok2 << " " << P << std::endl;
-  bool ok3 = reader.read( P, s3.begin(), s3.end() ) == s3.end();
-  trace.info() << "- Parsing " << s3 << " : " << ok3 << " " << P << std::endl;
-  bool ok4 = reader.read( P, s4.begin(), s4.end() ) == s4.end();
-  trace.info() << "- Parsing " << s4 << " : " << ok4 << " " << P << std::endl;
-  bool ok5 = reader.read( P, s5.begin(), s5.end() ) == s5.end();
-  trace.info() << "- Parsing " << s5 << " : " << ok5 << " " << P << std::endl;
-  bool ok6 = reader.read( P, s6.begin(), s6.end() ) == s6.end();
-  trace.info() << "- Parsing " << s6 << " : " << ok6 << " " << P << std::endl;
-  bool ok7 = reader.read( P, s7.begin(), s7.end() ) == s7.end();
-  trace.info() << "- Parsing " << s7 << " : " << ok7 << " " << P << std::endl;
-
-  string s8 = "(zyx^2+x^2-1)^2 + xy AVERTY"; 
-  std::istringstream sin( s8 );
-  std::string other;
-  sin >> P >> other;
-  trace.info() << "- Read " << P << " and " << other << std::endl;
-
-  return ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && (!ok7);
-}
 ///////////////////////////////////////////////////////////////////////////////
 // Standard services - public :
 
@@ -237,8 +197,7 @@ int main( int /*argc*/, char** /*argv*/ )
   trace.beginBlock ( "Testing class MPolynomial" );
 
   bool res = testMPolynomial()
-    //&& testMPolynomialSpeed( 0.01 )
-    && testMPolynomialReader();
+    && testMPolynomialSpeed( 0.05 );
   trace.emphase() << ( res ? "Passed." : "Error." ) << endl;
   trace.endBlock();
   return res ? 0 : 1;


### PR DESCRIPTION
... read with the correct priority. Now 45xy and 45_xy and 45_x*y are equivalent expressions.
The problem is due to the fact that boost::spirit does not handle correctly BNR forms like:
expr := mulexpr 
            | expr '+' mulexpr;

In the new version, we use a trick like:
expr := mulexpr ( '+' mulexpr )*;

The drawback is that nodes have an arbitrary number of children, instead of two with the usual representation. Especially ugly is the mix of '+' and '-' at the same node !
