### PR TITLE
specialization of CUnaryFunctor

### DIFF
--- a/src/DGtal/base/CUnaryFunctor.h
+++ b/src/DGtal/base/CUnaryFunctor.h
@@ -101,12 +101,13 @@ Description of \b concept '\b CUnaryFunctor' <p>
   template <typename X, typename A, typename R>
   struct CUnaryFunctor : boost::Assignable<X>
   {
+
     // ----------------------- Concept checks ------------------------------
   public:
 
     BOOST_CONCEPT_USAGE( CUnaryFunctor )
     {
-      // x( p ) returns myV.
+      // x( a ) returns r.
       ConceptUtils::sameType( r, x.operator() ( a ) );
     }
     // ------------------------- Private Datas --------------------------------
@@ -116,6 +117,33 @@ Description of \b concept '\b CUnaryFunctor' <p>
     R r;
     // ------------------------- Internals ------------------------------------
   private:
+
+  }; // end of concept CUnaryFunctor
+
+  //specialization for references
+  template <typename X, typename A, typename R>
+  struct CUnaryFunctor<X, A&, R&> : boost::Assignable<X>
+  {
+
+    // ----------------------- Concept checks ------------------------------
+  public:
+
+    BOOST_CONCEPT_USAGE( CUnaryFunctor )
+    {
+      ConceptUtils::sameType( getRef(r), x.operator() ( getRef(a) ) );
+    }
+    // ------------------------- Private Datas --------------------------------
+  private:
+    X x;
+    A a;
+    R r;
+    // ------------------------- Internals ------------------------------------
+  private:
+    template<typename T>
+    T& getRef(T& t) 
+    {
+      return t; 
+    }
 
   }; // end of concept CUnaryFunctor
 


### PR DESCRIPTION
CUnaryFunctor is now specialized for references as argument and return types.
This removes warning reported in #388 when compiling OutputIteratorAdapter.
