### PR TITLE
Fixes cites and bibliography in doxygen

### DIFF
--- a/doc/doxy.config.Board.in
+++ b/doc/doxy.config.Board.in
@@ -52,7 +52,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @DOC_DIR@
+OUTPUT_DIRECTORY       = 
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output

--- a/doc/doxy.config.in
+++ b/doc/doxy.config.in
@@ -52,7 +52,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @DOC_DIR@
+OUTPUT_DIRECTORY       =
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output


### PR DESCRIPTION
Finally discovered the crappy doxygen bug: when specifying an output, the citelist generates error...
With thispull, the gneratred doc is not anymore iin DGTal/doc/html but DGtal/build/html

We could now split the global.bib into package bibs.
