### PR TITLE
inversion boost check functor on domain

### DIFF
--- a/src/DGtal/images/ConstImageAdapter.h
+++ b/src/DGtal/images/ConstImageAdapter.h
@@ -118,8 +118,9 @@ public:
     typedef typename TNewDomain::Point Point;
     typedef TNewValue Value;
 
-    BOOST_CONCEPT_ASSERT(( CUnaryFunctor<TFunctorD, typename TImageContainer::Point, Point> )); 
-    BOOST_CONCEPT_ASSERT(( CUnaryFunctor<TFunctorV, typename TImageContainer::Value, Value> ));
+  
+    BOOST_CONCEPT_ASSERT(( CUnaryFunctor<TFunctorD, Point, typename TImageContainer::Point> )); 
+    BOOST_CONCEPT_ASSERT(( CUnaryFunctor<TFunctorV, typename TImageContainer::Value,Value  > ));
 
     ///Types copied from the container
     typedef TImageContainer ImageContainer;


### PR DESCRIPTION
It looks better with the definition of the CUnaryFunctor concept r=x(a)
It works to the construction of slice image and other DGtal tests/examples
