### PR TITLE
Bug fix when Clock used wihtout UNIX, unix or linux defined

### DIFF
--- a/src/DGtal/base/Clock.h
+++ b/src/DGtal/base/Clock.h
@@ -30,13 +30,13 @@
  * This file is part of the DGtal library (backported from Imagene)
  */
 
-#if defined(Clock_RECURSES)
+#ifdef Clock_RECURSES
 #error Recursive header files inclusion detected in Clock.h
 #else // defined(Clock_RECURSES)
 /** Prevents recursive inclusion of headers. */
 #define Clock_RECURSES
 
-#if !defined Clock_h
+#ifndef Clock_h
 /** Prevents repeated inclusion of headers. */
 #define Clock_h
 
@@ -55,7 +55,7 @@
 #include <mach/mach.h>
 #endif
 
-#if ( (defined(WIN32)) )
+#ifdef WIN32
 #include <time.h>
 #endif
 
@@ -138,12 +138,10 @@ namespace DGtal
   private:
 
     ///internal timer object;
-#if ( (defined(UNIX)||defined(unix)||defined(linux) || defined(__MACH__) ) )
-    struct timespec myTimerStart;
-#endif
-
-#if ( (defined(WIN32)) )
+#ifdef WIN32
     clock_t myFirstTick;
+#else
+    struct timespec myTimerStart;
 #endif
     
   }; // end of class Clock

--- a/src/DGtal/base/Clock.ih
+++ b/src/DGtal/base/Clock.ih
@@ -48,7 +48,7 @@ void
 DGtal::Clock::startClock()
 {
 
-#if ( (defined(WIN32)) )
+#ifdef WIN32
   myFirstTick = clock();
   if (myFirstTick == (clock_t) -1)
     {
@@ -76,7 +76,7 @@ double
 DGtal::Clock::stopClock()
 {
 
-#if ( (defined(WIN32)) )
+#ifdef WIN32
   clock_t last_tick = clock();
   if (last_tick == (clock_t) -1)
     {


### PR DESCRIPTION
Restriction around the line "struct timespec myTimerStart;" implies an error when I compiled a personnal software.
Indeed, it seems that "(defined(UNIX)||defined(unix)||defined(linux) || defined(**MACH**)" is wrong on my computer, althought I use Ubuntu.
