### PR TITLE
Updating doc for Clone, Alias, ConstAlias

### DIFF
--- a/src/DGtal/base/Alias.h
+++ b/src/DGtal/base/Alias.h
@@ -63,6 +63,8 @@ argument parameter must be at least as long as the object
 itself. Note that an instance of Alias<T> is itself a light
 object (it holds only an enum and a pointer).
 
+(For a complete description, see \ref moduleCloneAndReference).
+
 It is used in methods or functions to encapsulate the parameter
 types. The following conversion from input parameter to data
 member or variable are possible:
@@ -72,6 +74,10 @@ member or variable are possible:
 |To: \c T&         | Shared. O(1)  | Shared. O(1)  |                |                     |
 |To: \c T*         | Shared. O(1)  | Shared. O(1)  |                |                     |
 |To: \ref CountedPtrOrPtr<T>| Shared. O(1)| Shared. O(1)| Shared. O(1), \b secure | Shared. O(1), \b secure |
+
+Argument conversion to member is \b automatic except when converting
+to a pointer \c T*: the \b address operator (\c operator&) must be used in
+this case.
 
 For the last row (case where the \e programmer choose a \ref
 CountedPtrOrPtr to hold the const alias), the \e user
@@ -142,7 +148,7 @@ struct B1_v2_1 {
 // Aliasing for a long lifetime is visible.
 struct B1_v2_2 {
   B1_v2_2( Alias<A> a ) // not ambiguous, cost is O(1) here and lifetime of a should be long enough
-  : myA( &a ) {}
+  : myA( &a ) {} // Note the use of the address operator because of the pointer member
 ...
   A* myA;
 };
@@ -150,7 +156,7 @@ struct B1_v2_2 {
 // Aliasing for a long lifetime is visible.
 struct B1_v2_3 {
   B1_v2_3( Alias<A> a ) // not ambiguous, cost is O(1) here and lifetime of a should be long enough
-  : myA( &a ) {}
+  : myA( a ) {}
 ...
   CountedPtrOrPtr<A> myA;
 };

--- a/src/DGtal/base/Clone.h
+++ b/src/DGtal/base/Clone.h
@@ -52,199 +52,215 @@ namespace DGtal
   /////////////////////////////////////////////////////////////////////////////
   // template class Clone
   /**
+     Description of template class 'Clone' <p> \brief Aim: This class
+     encapsulates its parameter class to indicate that the given
+     parameter is required to be duplicated (generally, this is done
+     to have a longer lifetime than the function itself). On one hand,
+     the user is reminded of the possible cost of duplicating the
+     argument parameter, while he is also aware that the lifetime of
+     the parameter is not a problem for the function. On the other
+     hand, the Clone class is smart enough to enforce duplication \b
+     only \b if \b needed. Substantial speed-up can be achieve through
+     this mechanism. 
 
-Description of template class 'Clone' <p> \brief Aim: This class
-encapsulates its parameter class to indicate that the given
-parameter is required to be duplicated (generally, this is done
-to have a longer lifetime than the function itself). On one hand,
-the user is reminded of the possible cost of duplicating the
-argument parameter, while he is also aware that the lifetime of
-the parameter is not a problem for the function. On the other
-hand, the Clone class is smart enough to enforce duplication \b
-only \b if \b needed. Substantial speed-up can be achieve through
-this mechanism. This is sumed up in the following table
+     (For a complete description, see \ref moduleCloneAndReference).
 
-|Argument type     |\c const \c T& |    \c T*      |\c CountedPtr<T>| \c CowPtr<T>   |\c T&& (c++11)|
-|------------------|---------------|---------------|----------------|----------------|--------------|
-|To:\c T           | Dupl.  O(N)   |Acq. Dupl. O(N)| Dupl. O(N)     | Dupl. O(N)     | Move. O(1)   |
-|To:\c CowPtr<T>   | Dupl.  O(N)   |   Acq. O(1)   | Lazy. O(1)/O(N)| Lazy. O(1)/O(N)| Move. O(1)   |
-|To:\c T*          | Dupl.  O(N)   |   Acq. O(1)   | Dupl. O(N)     | Dupl. O(N)     | Move. O(1)   |
+     The class Clone is used in methods or functions to encapsulate
+     the parameter types. The following conversion from input
+     parameter to data member or variable are sumed up in the
+     following table:
 
-with abbreviations:
-- \b Dupl. Object is duplicated.
-- \b Lazy. Object is lazily duplicated, meaning only when the user writes on it (which may be never).
-- \b Acq. Dynamically allocated pointer is acquired. User should take care himself of deletion only if storing the parameter with a pointer.
-- \b Move. The object is moved into the new object. This is  generally much faster than copy. This is true for instance for all classical STL containers. You can also write a specific \c  move constructor for your class.
+     |Argument type:    |\c const \c T& |    \c T*      |\c CountedPtr<T>| \c CowPtr<T>   |\c T&& (c++11)|
+     |------------------|---------------|---------------|----------------|----------------|--------------|
+     |To:\c T           | Dupl.  O(N)   |Acq. Dupl. O(N)| Dupl. O(N)     | Dupl. O(N)     | Move. O(1)   |
+     |To:\c T*          | Dupl.  O(N)   |   Acq. O(1)   | Dupl. O(N)     | Dupl. O(N)     | Move. O(1)   |
+     |To:\ref CowPtr<T>   | Dupl.  O(N)   |   Acq. O(1)   | Lazy. O(1)/O(N)| Lazy. O(1)/O(N)| Move. O(1)   |
 
-It is clear that worst case is duplication while sometimes \ref Clone
-is constant time (while guaranteeing object invariance and
-life-time).
+     with abbreviations:
+     - \b Dupl. Object is duplicated.
+     - \b Lazy. Object is lazily duplicated, meaning only when the user writes on it (which may be never).
+     - \b Acq. Dynamically allocated pointer is acquired. User should take care himself of deletion only if storing the parameter with a pointer.
+     - \b Move. The object is moved into the new object. This is  generally much faster than copy. This is true for instance for all classical STL containers. You can also write a specific \c  move constructor for your class.
 
-@note The usage of \c Clone<T> instead of \c const \c T \c & or
-\c const \c T \c * in parameters is \b always \b recommended when
-the user duplicates the parameter and stores a clone of it as a
-data member for later use. The usage \c Clone<T> instead of \c T
-is \b recommended whenever \c T is big (the object is sometimes
-duplicated twice). When the object is small, writing either \c
-Clone<T> or \c T is acceptable. If your member is a CowPtr<T>,
-then you should use a Clone<T> as parameter.  Depending on your
-data member, we advise the following \a parameter \a definition
-when \b duplication is asked for.
-
-| member   |     \c T          |  big \c T |\c CowPtr<T>|     \c T* |
-|----------|-------------------|-----------|------------|-----------|
-| parameter|\c T or \c Clone<T>|\c Clone<T>|\c Clone<T> |\c Clone<T>|
-|member deletion|  automatic   | automatic | automatic  | \b manual |
-
-@note Note that an instance of Clone<T> is itself a light object (it
-holds only a const enum and const pointer), the duplication (if
-necessary) takes place when the user instantiates its member of
-type T (or CowPtr<T> or T* member).
+     It is clear that worst case is duplication while sometimes \ref Clone
+     is constant time (while guaranteeing object invariance and
+     life-time).
 
 
-@tparam T is any type.
+     @note The usage of \c Clone<T> instead of \c const \c T \c & or
+     \c const \c T \c * in parameters is \b always \b recommended when
+     the user duplicates the parameter and stores a clone of it as a
+     data member for later use. The usage \c Clone<T> instead of \c T
+     is \b recommended whenever \c T is big (the object is sometimes
+     duplicated twice). When the object is small, writing either \c
+     Clone<T> or \c T is acceptable. If your member is a CowPtr<T>,
+     then you should use a Clone<T> as parameter.  Depending on your
+     data member, we advise the following \a parameter \a definition
+     when \b duplication is asked for.
 
-@see Alias
-@see ConstAlias
+     |member type:|     \c T          |  big \c T |\c CowPtr<T>|     \c T* |
+     |----------|-------------------|-----------|------------|-----------|
+     |parameter|\c T or \c Clone<T>|\c Clone<T>|\c Clone<T> |\c Clone<T>|
 
-@note (Speed) Even on a small type (here a pair<int,int>), it is
-much faster than NClone and has the advantage (wrt Clone<T>) to
-handle nicely both const T& and CowPtr<T> as input. It may be
-slightly slower than deprecated::Clone (and by value or by const ref
-parameter passing) for small objects like a pair<int,int>. This
-is certainly due to the fact that it uses one more integer
-register for \a myParam data member.
+     \note A conversion to \c T* means pointer acquisition. Hence the programmer should take care of deletion of the object.
+     Otherwise, deletion is automatic for \c T or \c CowPtr<T> member. Furthermore, a conversion to a \c T* requires the use of the address operator (\c operator&) by the \e developer. If argument is `Clone<T> a`, and member name is `b`:
 
-| Type   | Context  | value    | const ref | deprecated::Clone  | Clone |
-|--------|----------|----------|-----------|--------|--------|
-| 2xint  |i7 2.4GHz |    48ms |     48ms  |   48ms |   59ms |
-|2xdouble|i7 2.4GHz |    48ms |     48ms  |   48ms |   49ms |
-| 2xint  |Xeon 2.67GHz|    54ms |     54ms  |   54ms |   54ms |
-|2xdouble|Xeon 2.67GHz|    54ms |     54ms  |   54ms | 53.5ms |
+     |member type:|     \c T          |     \c T*  |\c CowPtr<T>|
+     |-----------|-------------------|------------|-----------|
+     |member deletion:|  automatic   |  \b manual | automatic |
+     |conversion:| automatic: `b(a)` |  address: `b(&a)`| automatic: `b(a)` |
 
+     \note When choosing a `Clone<T>` parameter, the \e programmer should really consider using a `CowPtr<T>` member to store it, since it is the most versatile and optimizable variant. The only advantage of the two others storing methods (\c T  and  \c T*) is that there is one less indirection. 
 
-@note It prevents direct assignment to CountedPtr<T> since their
-meaning is "shared_ptr". 
+     @note Note that an instance of Clone<T> is itself a light object (it
+     holds only a const enum and const pointer), the duplication (if
+     necessary) takes place when the user instantiates its member of
+     type T (or CowPtr<T> or T* member).
 
 
-It can be used as follows. Consider this simple example where
-class \e A is a big object. Then we define three classes \e B1,
-\e B2 and \e B3, that uses some instance of \e A.
+     @tparam T is any type.
 
-@code
-const int N = 10000;
-struct A { ...
-  int table[N];
-};
+     @see Alias
+     @see ConstAlias
 
-// Each B1, B2 or B3 uses A, but we do not know if A will be copied
-// or just referenced by only looking at the declaration of
-// the method. Generally the ambiguity is removed by adding
-// comments or, for the experienced developper, by looking at
-// other parts of the code.
+     @note (Speed) Even on a small type (here a pair<int,int>), it is
+     much faster than NClone and has the advantage (wrt Clone<T>) to
+     handle nicely both const T& and CowPtr<T> as input. It may be
+     slightly slower than deprecated::Clone (and by value or by const ref
+     parameter passing) for small objects like a pair<int,int>. This
+     is certainly due to the fact that it uses one more integer
+     register for \a myParam data member.
 
-// Only aliasing, but for a long lifetime.
-struct B1 {
-  B1( const A & a ) // ambiguous, cost is O(1) here and lifetime of a should exceed constructor.
-  : myA( a ) {}
-...
-  const A & myA;
-};
-// Copying as data member (stack or heap depending on B2 instance)
-struct B2 {
-  B2( const A & a ) // ambiguous, cost is O(N) here
-  : myA( a ) {}
-...
-  A myA;
-};
-// Copying on heap and data member pointing on it.
-struct B3 {
-  B3( const A & a ) // ambiguous, cost is O(N) here
-  { myA = new A( a ); }
-  ~B3() 
-  { if ( myA != 0 ) delete myA; }
-...
-  A* myA;
-};
-@endcode
+     | Type   | Context  | value    | const ref | deprecated::Clone  | Clone |
+     |--------|----------|----------|-----------|--------|--------|
+     | 2xint  |i7 2.4GHz |    48ms |     48ms  |   48ms |   59ms |
+     |2xdouble|i7 2.4GHz |    48ms |     48ms  |   48ms |   49ms |
+     | 2xint  |Xeon 2.67GHz|    54ms |     54ms  |   54ms |   54ms |
+     |2xdouble|Xeon 2.67GHz|    54ms |     54ms  |   54ms | 53.5ms |
 
-Sometimes it is also very important that the developper that uses
-the library is conscious that an object, say \a b, may require
-that an instance \a a given as parameter should have a lifetime
-longer than \a b itself (case for an instance of \a B1
-above). Classes Clone, Alias, ConstAlias exist for these
-reasons. The classes above may be rewritten as follows.
 
-@code
-// Aliasing for a long lifetime is visible.
-struct B1 {
-  B1( ConstAlias<A> a ) // not ambiguous, cost is O(1) here and lifetime of a should be long enough
-  : myA( a ) {}
-...
-  const A & myA; 
-  // or Const A* myA;
-};
-// Cloning as data member is visible.
-struct B2 {
-  B2( Clone<A> a ) // not ambiguous, cost is O(N) here and lifetime of a is whatever.
-  : myA( a ) {}
-...
-  A myA;
-};
-// Cloning on the heap requires address operator, so that the user remembers calling \c delete.
-struct B3_v1 {
-  B3_v1( Clone<A> a ) // not ambiguous, cost is O(N) here and lifetime of a is whatever.
-  : myA( &a ) {}
-  ~B3_v1() { if ( myA != 0 ) delete myA; }
-...
-  A* myA;
-};
-// Cloning on the heap with CountedPtr mechanism is straightforward.
-struct B3_v2 {
-  B3_v2( Clone<A> a ) // not ambiguous, cost is O(N) here and lifetime of a is whatever.
-  : myA( a ) {}
-  ~B3_v2() {} // CountedPtr takes care of delete.
-...
-  CountedPtr<A> myA;
-};
-// Cloning on the heap with CowPtr mechanism is straightforward.
-struct B3_v3 {
-  B3_v3( Clone<A> a ) // not ambiguous, cost is O(N) here and lifetime of a is whatever.
-  : myA( a ) {}
-  ~B3_v3() {} // CountedPtr takes care of delete.
-...
-  CowPtr<A> myA;
-};
-...
-A a1;
-B1 b( a1 );    // do not duplicate a1
-B2 bb( a1 );   // duplicate a1
-B2 bbb( &a1 ); // also duplicate a1 !
-B3_v1 c1( a1 ); // duplicate a1 on the heap
-B3_v2 c1( a1 ); // duplicate a1 on the heap
-B3_v3 c1( a1 ); // duplicate a1 on the heap
-@endcode
+     @note It prevents direct assignment to CountedPtr<T> since their
+     meaning is "shared_ptr". 
 
-A last question could be why are we not just passing the instance
-of A by value. This, for sure, would tell the developper that the
-instance is duplicated somehow. The problem is that it induces
-generally two duplications, and not only one ! It may be possible
-that the compiler optimizes things nicely but it is unclear if
-the compiler will always do it. Furthermore, sometimes, no
-duplication is needed (when duplicating a CowPtr for instance).
 
-@code
-struct B4 {
-  B4( A a ) // not ambiguous, but cost is O(2N) here. 
-  : myA( a ) {}
-...
-  A myA;
-};
-A a1;
-B4 b4( a1 ) // The object \a a1 is copied once on the heap as the parameter \a a, and once as the member \a b3.myA.
-@endcode
+     It can be used as follows. Consider this simple example where
+     class \e A is a big object. Then we define three classes \e B1,
+     \e B2 and \e B3, that uses some instance of \e A.
 
-@note The user should not used Clone<T> for data members, only as a type for parameters.
+     @code
+     const int N = 10000;
+     struct A { ...
+     int table[N];
+     };
+
+     // Each B1, B2 or B3 uses A, but we do not know if A will be copied
+     // or just referenced by only looking at the declaration of
+     // the method. Generally the ambiguity is removed by adding
+     // comments or, for the experienced developper, by looking at
+     // other parts of the code.
+
+     // Only aliasing, but for a long lifetime.
+     struct B1 {
+     B1( const A & a ) // ambiguous, cost is O(1) here and lifetime of a should exceed constructor.
+     : myA( a ) {}
+     ...
+     const A & myA;
+     };
+     // Copying as data member (stack or heap depending on B2 instance)
+     struct B2 {
+     B2( const A & a ) // ambiguous, cost is O(N) here
+     : myA( a ) {}
+     ...
+     A myA;
+     };
+     // Copying on heap and data member pointing on it.
+     struct B3 {
+     B3( const A & a ) // ambiguous, cost is O(N) here
+     { myA = new A( a ); }
+     ~B3() 
+     { if ( myA != 0 ) delete myA; }
+     ...
+     A* myA;
+     };
+     @endcode
+
+     Sometimes it is also very important that the developper that uses
+     the library is conscious that an object, say \a b, may require
+     that an instance \a a given as parameter should have a lifetime
+     longer than \a b itself (case for an instance of \a B1
+     above). Classes Clone, Alias, ConstAlias exist for these
+     reasons. The classes above may be rewritten as follows.
+
+     @code
+     // Aliasing for a long lifetime is visible.
+     struct B1 {
+     B1( ConstAlias<A> a ) // not ambiguous, cost is O(1) here and lifetime of a should be long enough
+     : myA( a ) {}
+     ...
+     const A & myA; 
+     // or Const A* myA;
+     };
+     // Cloning as data member is visible.
+     struct B2 {
+     B2( Clone<A> a ) // not ambiguous, cost is O(N) here and lifetime of a is whatever.
+     : myA( a ) {}
+     ...
+     A myA;
+     };
+     // Cloning on the heap requires address operator, so that the user remembers calling \c delete.
+     struct B3_v1 {
+     B3_v1( Clone<A> a ) // not ambiguous, cost is O(N) here and lifetime of a is whatever.
+     : myA( &a ) {}
+     ~B3_v1() { if ( myA != 0 ) delete myA; }
+     ...
+     A* myA;
+     };
+     // Cloning on the heap with CountedPtr mechanism is straightforward.
+     struct B3_v2 {
+     B3_v2( Clone<A> a ) // not ambiguous, cost is O(N) here and lifetime of a is whatever.
+     : myA( a ) {}
+     ~B3_v2() {} // CountedPtr takes care of delete.
+     ...
+     CountedPtr<A> myA;
+     };
+     // Cloning on the heap with CowPtr mechanism is straightforward.
+     struct B3_v3 {
+     B3_v3( Clone<A> a ) // not ambiguous, cost is O(N) here and lifetime of a is whatever.
+     : myA( a ) {}
+     ~B3_v3() {} // CountedPtr takes care of delete.
+     ...
+     CowPtr<A> myA;
+     };
+     ...
+     A a1;
+     B1 b( a1 );    // do not duplicate a1
+     B2 bb( a1 );   // duplicate a1
+     B2 bbb( &a1 ); // also duplicate a1 !
+     B3_v1 c1( a1 ); // duplicate a1 on the heap
+     B3_v2 c1( a1 ); // duplicate a1 on the heap
+     B3_v3 c1( a1 ); // duplicate a1 on the heap
+     @endcode
+
+     A last question could be why are we not just passing the instance
+     of A by value. This, for sure, would tell the developper that the
+     instance is duplicated somehow. The problem is that it induces
+     generally two duplications, and not only one ! It may be possible
+     that the compiler optimizes things nicely but it is unclear if
+     the compiler will always do it. Furthermore, sometimes, no
+     duplication is needed (when duplicating a CowPtr for instance).
+
+     @code
+     struct B4 {
+     B4( A a ) // not ambiguous, but cost is O(2N) here. 
+     : myA( a ) {}
+     ...
+     A myA;
+     };
+     A a1;
+     B4 b4( a1 ) // The object \a a1 is copied once on the heap as the parameter \a a, and once as the member \a b3.myA.
+     @endcode
+
+     @note The user should not used Clone<T> for data members, only as a type for parameters.
 */
   template <typename T>
   class Clone

--- a/src/DGtal/base/ConstAlias.h
+++ b/src/DGtal/base/ConstAlias.h
@@ -64,6 +64,8 @@ namespace DGtal
      as the object itself. Note that an instance of ConstAlias<T> is
      itself a light object (it holds only an enum and a pointer).
 
+     (For a complete description, see \ref moduleCloneAndReference).
+
      It is used in methods or functions to encapsulate the parameter
      types. The following conversion from input parameter to data
      member or variable are possible:
@@ -74,6 +76,10 @@ namespace DGtal
      |To: \c const T*   | Shared. O(1)  | Shared. O(1)  |                |            |   |
      |To: \ref CountedConstPtrOrConstPtr<T>|Shared. O(1)|Shared. O(1)|Shared. O(1), \b secure |Shared. O(1), \b secure| Shared. O(1), \b secure |
 
+     Argument conversion to member is \b automatic except when
+     converting to a pointer \c const \c T*: the \b address operator
+     (\c operator&) must be used in this case.
+
      For the last row (case where the \e programmer choose a \ref
      CountedConstPtrOrConstPtr to hold the const alias), the \e user
      can thus enforce a \b secure const aliasing by handling a variant
@@ -81,11 +87,11 @@ namespace DGtal
      object is destroyed in the caller context, it still exists in the
      callee context.
 
-     @note The usage of \ref ConstAlias<T> instead of \c const \c T \c & or \c const \c T \c *
-     in parameters is \b recommended when the lifetime of the
-     parameter must exceed the lifetime of the called
+     @note The usage of \ref ConstAlias<T> instead of \c const \c T \c
+     & or \c const \c T \c * in parameters is \b recommended when the
+     lifetime of the parameter must exceed the lifetime of the called
      method/function/constructor (often the case in constructor or
-     init methods). 
+     init methods).
 
      @note The usage of \c const \c T \c & or \c const \c T \c *
      instead of \ref ConstAlias<T> is \b recommended when the lifetime
@@ -147,7 +153,7 @@ namespace DGtal
      // ConstAliasing for a long lifetime is visible.
      struct B1_v2_2 {
        B1_v2_2( ConstAlias<A> a ) // not ambiguous, cost is O(1) here and lifetime of a should be long enough
-       : myA( &a ) {}
+       : myA( &a ) {} // Note the use of the address operator because of the pointer member
      ...
        const A* myA;
      };
@@ -155,7 +161,7 @@ namespace DGtal
      // ConstAliasing for a long lifetime is visible.
      struct B1_v2_3 {
        B1_v2_3( ConstAlias<A> a ) // not ambiguous, cost is O(1) here and lifetime of a should be long enough
-       : myA( &a ) {}
+       : myA( a ) {}
      ...
        CountedConstPtrOrConstPtr<A> myA;
      };

--- a/src/DGtal/base/doc/moduleCloneAndReference.dox
+++ b/src/DGtal/base/doc/moduleCloneAndReference.dox
@@ -150,11 +150,12 @@ is constant time (while guaranteeing object invariance and
 life-time).
 
 \note A conversion to \c T* means pointer acquisition. Hence the programmer should take care of deletion of the object.
-Otherwise, deletion is automatic for \c T or \c CowPtr<T> member.
+Otherwise, deletion is automatic for \c T or \c CowPtr<T> member. Furthermore, a conversion to a \c T* requires the use of the address operator (\c operator&) by the \e developer. If argument is `Clone<T> a`, and member name is `b`:
 
-| member:   |     \c T          |\c CowPtr<T>|     \c T* |
+|member type:|     \c T          |     \c T*  |\c CowPtr<T>|
 |-----------|-------------------|------------|-----------|
-|member deletion:|  automatic   | automatic  | \b manual |
+|member deletion:|  automatic   |  \b manual | automatic |
+|conversion:| automatic: `b(a)` |  address: `b(&a)`| automatic: `b(a)` |
 
 \note When choosing a `Clone<T>` parameter, the \e programmer should really consider using a `CowPtr<T>` member to store it, since it is the most versatile and optimizable variant. The only advantage of the two others storing methods (\c T  and  \c T*) is that there is one less indirection. 
 
@@ -173,9 +174,29 @@ B b1( a1 ); // cloned
 B b2( new BigFatA( "I am the one " ) ); // acquired 
 CountedPtr<BigFatA> counted_ptr = new BigFatA( "I am the other one" ); 
 B b3( counted_ptr ); // O(1) since lazy duplication (waiting for a write).
-B b4( BigFatA( "Moving one" ) ); // this one is created directly in b4.
+B b4( BigFatA( "Moving one" ) ); // this one is created directly in b4 (with c++11).
 @endcode
 
+This version acquires the given argument. Note the use of the address operator \c operator& and the \c delete in the destructor.
+
+@code
+struct BigFatA { ... };
+
+struct B {
+  // versatile constructor. Accepts 5 different versions.
+  B( Clone<BigFatA> a ) : myAcquiredFat( &a ) {} // note the address operator
+  ~B() { delete myAcquiredFat; }                 // required because of pointer acquisition
+  void f() { myOwnFat->do(); }
+  BigFatA* myAcquiredFat;
+};
+
+BigFatA a1;
+B b1( a1 ); // cloned
+B b2( new BigFatA( "I am the one " ) ); // acquired 
+CountedPtr<BigFatA> counted_ptr = new BigFatA( "I am the other one" ); 
+B b3( counted_ptr ); // duplicated
+B b4( BigFatA( "Moving one" ) ); // this one is created directly in b4 (with c++11).
+@endcode
 
 \subsection moduleCloneAndReference_sec23 User passing an argument to an Alias parameter
 
@@ -190,6 +211,13 @@ A parameter `( Alias<T> cT )` accepts several types of arguments constructed fro
 |To: \ref CountedPtrOrPtr<T>| Shared. O(1)| Shared. O(1)| Shared. O(1), \b secure | Shared. O(1), \b secure |
 
 \note When choosing an `Alias<T>` parameter, the \e programmer should really consider using a `CountedPtrOrPtr<T>` member to store it, since it is the most secure-able variant. The only advantage of the two others storing methods (\c T&  and  \c T*) is that there is one less boolean test and indirection. 
+
+\note A conversion to a \c T* requires the use of the address operator (\c operator&) by the \e developer. If argument is `Alias<T> a`, and member name is `b`:
+
+|member type:|    \c T&         |     \c T*        |\c CountedPtrOrPtr<T>|
+|-----------|-------------------|------------------|-----------|
+|conversion:| automatic: `b(a)` |  address: `b(&a)`| automatic: `b(a)` |
+
 
 
 \advanced As one can see, if the \e programmer has chosen a `CountedPtrOrPtr<T>` for storing the alias, the \e user can choose between a \b secure \b long-term \b aliasing (with a `CountedPtr<T>` or `CountedPtrOrPtr<T>` argument) or \b non \b secure \b long-term \b aliasing (with a \c T& or \c T* argument).
@@ -227,6 +255,12 @@ A parameter `( ConstAlias<T> cT )` accepts several types of arguments constructe
 |To: \ref CountedConstPtrOrConstPtr<T>|Shared. O(1)|Shared. O(1)|Shared. O(1), \b secure|Shared. O(1), \b secure| Shared. O(1), \b secure|
 
 \note When choosing a `ConstAlias<T>` parameter, the \e programmer should really consider using a `CountedConstPtrOrConstPtr<T>` member to store it, since it is the most secure-able variant. The only advantage of the two others storing methods (\c const \c T&  and \c const \c T*) is that there is one less boolean test and indirection. 
+
+\note A conversion to a `const T*` requires the use of the address operator (\c operator&) by the \e developer. If argument is `ConstAlias<T> a`, and member name is `b`:
+
+|member type:| \c const \c T&   |  \c const \c T*  |\c CountedConstPtrOrConstPtr<T>|
+|-----------|-------------------|------------------|-----------|
+|conversion:| automatic: `b(a)` |  address: `b(&a)`| automatic: `b(a)` |
 
 
 \advanced  As one can see, if the \e programmer has chosen a `CountedConstPtrOrConstPtr<T>` for storing the const alias, the \e user can choose between a \b secure \b long-term \b const-aliasing (with a `CountedPtr<T>` or `CountedPtrOrPtr<T>` or `CountedConstPtrOrConstPtr<T>` argument) or \b non \b secure \b long-term \b const-aliasing (with a \c T& or \c T* argument).


### PR DESCRIPTION
This PR modifies only the documentation of classes Clone, Alias, ConstAlias and the doc of moduleCloningAndReferencing to clarify the uses of pointer as members.
