### PR TITLE
const static members 

### DIFF
--- a/src/DGtal/images/ImageContainerByHashTree.h
+++ b/src/DGtal/images/ImageContainerByHashTree.h
@@ -149,15 +149,16 @@ namespace DGtal
     typedef Point Vertex;
 
     /// static constants
-    static const typename Domain::Dimension dimension;
-    static const typename Domain::Dimension dim ;
-    static const unsigned int NbChildrenPerNode ;
-    static const HashKey ROOT_KEY;
+    BOOST_STATIC_CONSTANT( Dimension, dimension = Domain::dimension); 
+    BOOST_STATIC_CONSTANT( Dimension, dim = Domain::dimension);
+    typedef POW<2, dimension> PowHelper;  
+    BOOST_STATIC_CONSTANT( unsigned int, NbChildrenPerNode = PowHelper::VALUE); 
+    BOOST_STATIC_CONSTANT( HashKey, ROOT_KEY = static_cast<THashKey>(1)); 
 
     /// domain should be rectangular
     //(since constructed from two points as a bounding box)
     BOOST_STATIC_ASSERT ((boost::is_same< Domain,
-                                          HyperRectDomain<SpaceND<dimension, Integer> > >::value));
+                                          HyperRectDomain<typename Domain::Space > >::value));
 
     /// values range
     BOOST_CONCEPT_ASSERT(( CLabel<TValue> ));
@@ -775,7 +776,7 @@ namespace DGtal
 
 
     // myN is number of children per node.
-    static const unsigned int myN;
+    BOOST_STATIC_CONSTANT( unsigned int, myN = NbChildrenPerNode );
 
 
   public:

--- a/src/DGtal/images/ImageContainerByHashTree.ih
+++ b/src/DGtal/images/ImageContainerByHashTree.ih
@@ -53,32 +53,6 @@ namespace DGtal
 
   namespace experimental
   {
-    template < typename TDomain, typename TValue, typename THashKey >
-    const typename TDomain::Dimension   ImageContainerByHashTree<TDomain, 
-								 TValue, 
-								 THashKey>::dimension = TDomain::dimension;
-    
-    template < typename TDomain, typename TValue, typename THashKey >
-    const typename TDomain::Dimension   ImageContainerByHashTree<TDomain, 
-								 TValue, 
-								 THashKey>::dim = TDomain::dimension;
-
-    template < typename TDomain, typename TValue, typename THashKey >
-    const unsigned int   ImageContainerByHashTree<TDomain, 
-						  TValue, 
-						  THashKey>::NbChildrenPerNode = POW<2, dimension>::VALUE;
-
-    template < typename TDomain, typename TValue, typename THashKey >
-    const THashKey   ImageContainerByHashTree<TDomain, 
-					     TValue, 
-					     THashKey>::ROOT_KEY = static_cast<THashKey>(1);
-
-    template < typename TDomain, typename TValue, typename THashKey >
-    const unsigned int ImageContainerByHashTree<TDomain, 
-						       TValue, 
-						       THashKey>::myN=POW<2,dim>::VALUE;
-    
-
 
   // ---------------------------------------------------------------------
   // constructor

--- a/src/DGtal/images/ImageContainerBySTLVector.h
+++ b/src/DGtal/images/ImageContainerBySTLVector.h
@@ -140,12 +140,11 @@ namespace DGtal
     typedef typename Domain::Dimension Dimension;
     typedef Point Vertex;
 
-    /// static constants
-    static const typename Domain::Dimension dimension;
+    BOOST_STATIC_CONSTANT( Dimension, dimension = Domain::dimension ); 
 
     /// domain should be rectangular
     BOOST_STATIC_ASSERT ( ( boost::is_same< Domain,
-                            HyperRectDomain<SpaceND<dimension, Integer> > >::value ) );
+					    HyperRectDomain< typename Domain::Space > >::value ) );
 
     /// range of values
     BOOST_CONCEPT_ASSERT ( ( CLabel<TValue> ) );

--- a/src/DGtal/images/ImageContainerBySTLVector.ih
+++ b/src/DGtal/images/ImageContainerBySTLVector.ih
@@ -40,10 +40,6 @@
 #include <cstdlib>
 //////////////////////////////////////////////////////////////////////////////
 
-template <typename Domain, typename T>
-const typename Domain::Dimension 
-DGtal::ImageContainerBySTLVector<Domain, T>::dimension = Domain::dimension;
-
 //------------------------------------------------------------------------------
 template <typename Domain, typename T>
 inline

--- a/src/DGtal/kernel/BasicPointFunctors.h
+++ b/src/DGtal/kernel/BasicPointFunctors.h
@@ -112,7 +112,7 @@ namespace DGtal
     
     typedef S Space; 
     typedef typename Space::Dimension Dimension;
-    static const Dimension dimension;
+    BOOST_STATIC_CONSTANT( Dimension, dimension = Space::dimension );
     typedef typename Space::Integer Integer; 
     typedef typename Space::Point Point; 
 
@@ -161,9 +161,9 @@ namespace DGtal
      * the input point to its projection (order matters)
      */
 #ifdef CPP11_ARRAY
-    std::array<Dimension, Space::dimension> myDims; 
+    std::array<Dimension, dimension> myDims; 
 #else
-    boost::array<Dimension, Space::dimension> myDims; 
+    boost::array<Dimension, dimension> myDims; 
 #endif
     /**
      * Default integer set to coordinates of the projected point

--- a/src/DGtal/kernel/BasicPointFunctors.ih
+++ b/src/DGtal/kernel/BasicPointFunctors.ih
@@ -31,10 +31,6 @@
 //////////////////////////////////////////////////////////////////////////////
 
 
-
-template <typename S> 
-const typename S::Dimension DGtal::Projector<S>::dimension = S::dimension;
-
 ///////////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION of inline methods.
 ///////////////////////////////////////////////////////////////////////////////
@@ -100,12 +96,13 @@ void
 DGtal::Projector<S>::initAddOneDim( const Dimension &newDim)
 { 
   std::vector<Dimension> vectDims;
+  Dimension maxIndex = dimension; 
   Dimension aCurrentPos = 0;
   Dimension k=0;
   for ( ; k < dimension; ++k)
   {
     if(k==newDim){
-      vectDims.push_back(dimension);
+      vectDims.push_back(maxIndex);
     }else{
       vectDims.push_back(aCurrentPos);
       aCurrentPos++;

--- a/src/DGtal/kernel/domains/HyperRectDomain.h
+++ b/src/DGtal/kernel/domains/HyperRectDomain.h
@@ -102,9 +102,6 @@ namespace DGtal
     // typedef TSpace Space;
     typedef TSpace Space;
 
-    // static constants
-    static const typename Space::Dimension dimension;
-
     typedef HyperRectDomain<Space> Domain;
     typedef typename Space::Point Point;
     typedef typename Space::Integer Integer;
@@ -112,6 +109,8 @@ namespace DGtal
     typedef typename Space::Dimension Dimension;
     typedef typename Space::Size Size;
     typedef typename Point::Coordinate Coordinate; // TODO REVOIR LES NOMS.... RECUPERER DANS SPACE
+
+    BOOST_STATIC_CONSTANT(Dimension, dimension = Space::dimension); 
 
     ///Typedef of domain iterators
     typedef HyperRectDomain_Iterator<Point> Iterator;

--- a/src/DGtal/kernel/domains/HyperRectDomain.ih
+++ b/src/DGtal/kernel/domains/HyperRectDomain.ih
@@ -35,9 +35,6 @@
 #include <cstdlib>
 #include "DGtal/io/Color.h"
 
-template<typename TSpace>
-const typename TSpace::Dimension DGtal::HyperRectDomain<TSpace>::dimension = TSpace::dimension;
-
 //-----------------------------------------------------------------------------
 template<typename TSpace>
 inline


### PR DESCRIPTION
I add definitions of CONST static member into the class definition of some classes so that the master can be compiled with clang++ (fix of issue #739)

The rule is that: 
- non-const static member should be declared outside the class definition. Otherwise, you get the following error: "ISO C++ forbids in-class initialization of non-const static member".
- It's however different for const static method. Indeed, "9.4.2/4 - If a static data member is of const integral or const enumeration type, its declaration in the class definition can specify a constant-initializer which shall be an integral constant expression (5.19). In that case, the member can appear in integral constant expressions".

Even if the master can now be compiled with clang++, the following tests FAILED:
     23 - testClone2 (Failed)
     79 - testFMM (OTHER_FAULT)
     89 - testIntegralInvariantMeanCurvatureEstimator3D (Failed)
     91 - testLocalEstimatorFromFunctorAdapter (OTHER_FAULT)
because of a bad use of ConstAlias: 
e.g. in testFMM [ERR] Assertion Error - assertion (( false && "[ConstAlias::ConstAlias( T&& )] Const-aliasing a rvalue ref has no meaning. Consider Clone instead." )) failed in DGtal::ConstAlias<BallPredicate<DGtal::PointVector<2, int, boost::array<int, 2> > > >::ConstAlias(BallPredicate<DGtal::PointVector<2, int, boost::array<int, 2> > > &&): /home/roussillon/Git/DGtal/src/DGtal/base/ConstAlias.h(259)
Abandon

I created a new issue for that ( #742)
