### PR TITLE
Processing color as usual when no face color are given in a Mesh

### DIFF
--- a/src/DGtal/io/Display3DFactory.ih
+++ b/src/DGtal/io/Display3DFactory.ih
@@ -111,13 +111,15 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsFaces( Display3D<Space, KSpace
 							 const DGtal::Mesh<TPoint> & aMesh )
 {
   DGtal::Color fillColorSave = display.getFillColor();
+  bool useGlobalColor =  !aMesh.isStoringFaceColors();
   display.createNewQuadList(aMesh.className());
   for(unsigned int i=0; i< aMesh.nbFaces(); i++)
     {
       typename Mesh<TPoint>::MeshFace aFace = aMesh.getFace(i);
       unsigned int aNum = aFace.size();
-      display.setFillColor(aMesh.getFaceColor(i));
-
+      if(!useGlobalColor){
+        display.setFillColor(aMesh.getFaceColor(i));
+      }
       if(aNum==4)
         {
           TPoint p1 = aMesh.getVertex(aFace.at(0));
@@ -139,9 +141,6 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsFaces( Display3D<Space, KSpace
           for(unsigned int j=0; j< aFace.size(); j++)
             {
               typename Display3D<Space, KSpace>::RealPoint point(aMesh.getVertex(aFace.at(j)));
-              //point.x= aMesh.getVertex(aFace.at(j))[0];
-              //point.y= aMesh.getVertex(aFace.at(j))[1];
-              //point.z= aMesh.getVertex(aFace.at(j))[2];
               vectPoly.push_back(point);
             }
           display.addPolygon(vectPoly);

--- a/src/DGtal/shapes/Mesh.h
+++ b/src/DGtal/shapes/Mesh.h
@@ -235,6 +235,12 @@ namespace DGtal
     
 
 
+    /**
+     * @return true if the Mesh is storing a color for each faces. 
+     * 
+     **/
+    bool isStoringFaceColors() const;
+
 
     /**
      * @return an iterator pointing to the first vertex of the mesh.  

--- a/src/DGtal/shapes/Mesh.ih
+++ b/src/DGtal/shapes/Mesh.ih
@@ -222,7 +222,8 @@ DGtal::Mesh<TPoint>::nbVertex() const
 template<typename TPoint>
 inline
 const DGtal::Color & 
-DGtal::Mesh<TPoint>::getFaceColor(unsigned int i) const{
+DGtal::Mesh<TPoint>::getFaceColor(unsigned int i) const
+{
   if(mySaveFaceColor){
     return myFaceColorList.at(i);
   }else{
@@ -231,8 +232,13 @@ DGtal::Mesh<TPoint>::getFaceColor(unsigned int i) const{
 }
 
 
-
-
+template<typename TPoint>
+inline
+bool 
+DGtal::Mesh<TPoint>::isStoringFaceColors() const
+{
+  return mySaveFaceColor;
+}
 
 
 


### PR DESCRIPTION
Small PR to improve Mesh color specification when no face color are given (actually the only way to change mesh display was to change default color in construction).
