### PR TITLE
Fix OTHER_FAULT for tests

### DIFF
--- a/tests/geometry/surfaces/testLocalEstimatorFromFunctorAdapter.cpp
+++ b/tests/geometry/surfaces/testLocalEstimatorFromFunctorAdapter.cpp
@@ -133,12 +133,15 @@ bool testLocalEstimatorFromFunctorAdapter()
 
   typedef LocalEstimatorFromSurfelFunctorAdapter<Surface, Z3i::L2Metric, Functor, GaussianKernelFunctor> ReporterGaussian;
 
-  Functor estimator(CanonicSCellEmbedder<KSpace>(surface.space()), 1);
+  CanonicSCellEmbedder<KSpace> embedder(surface.space());
+  Functor estimator(embedder, 1);
 
-  Reporter reporter(surface, l2Metric, estimator , ConvFunctor(1.0));
+  ConvFunctor convFunc(1.0);
+  Reporter reporter(surface, l2Metric, estimator , convFunc);
 
   //We just test the init for Gaussian
-  ReporterGaussian reporterGaussian(surface, l2Metric, estimator , GaussianKernelFunctor(1.0));
+  GaussianKernelFunctor gaussKernelFunc(1.0);
+  ReporterGaussian reporterGaussian(surface, l2Metric, estimator , gaussKernelFunc);
   reporterGaussian.init(1,5);
 
   reporter.init(1, 5);

--- a/tests/geometry/surfaces/testMonge.cpp
+++ b/tests/geometry/surfaces/testMonge.cpp
@@ -119,15 +119,17 @@ bool testLocalEstimatorFromFunctorAdapter()
   typedef LocalEstimatorFromSurfelFunctorAdapter<Surface, Z3i::L2Metric, FunctorNormal, ConvFunctor> ReporterNormal;
   typedef LocalEstimatorFromSurfelFunctorAdapter<Surface, Z3i::L2Metric, FunctorNormalLeast, ConvFunctor> ReporterNormalLeast;
 
-  FunctorGaussian estimatorK(CanonicSCellEmbedder<KSpace>(surface.space()),1);
-  FunctorMean estimatorH(CanonicSCellEmbedder<KSpace>(surface.space()), 1);
-  FunctorNormal estimatorN(CanonicSCellEmbedder<KSpace>(surface.space()),1);
-  FunctorNormalLeast estimatorL(CanonicSCellEmbedder<KSpace>(surface.space()),1);
+  CanonicSCellEmbedder<KSpace> embedder(surface.space());
+  FunctorGaussian estimatorK(embedder,1);
+  FunctorMean estimatorH(embedder, 1);
+  FunctorNormal estimatorN(embedder,1);
+  FunctorNormalLeast estimatorL(embedder,1);
 
-  ReporterK reporterK(surface, l2Metric, estimatorK , ConvFunctor(1.0));
-  ReporterH reporterH(surface, l2Metric, estimatorH , ConvFunctor(1.0));
-  ReporterNormal reporterN(surface, l2Metric, estimatorN , ConvFunctor(1.0));
-  ReporterNormalLeast reporterL(surface, l2Metric, estimatorL , ConvFunctor(1.0));
+  ConvFunctor convFunc(1.0);
+  ReporterK reporterK(surface, l2Metric, estimatorK , convFunc);
+  ReporterH reporterH(surface, l2Metric, estimatorH , convFunc);
+  ReporterNormal reporterN(surface, l2Metric, estimatorN , convFunc);
+  ReporterNormalLeast reporterL(surface, l2Metric, estimatorL , convFunc);
 
   reporterK.init(1, 5);
   reporterH.init(1, 5);


### PR DESCRIPTION
```
The following tests FAILED:
      9 - testClock (Failed)
     90 - testIntegralInvariantMeanCurvatureEstimator3D (Failed)
     92 - testLocalEstimatorFromFunctorAdapter (OTHER_FAULT)
     93 - testMonge (OTHER_FAULT)
Errors while running CTest
make: *** [test] Erreur 8
```

In this PR, I fix testLocalEstimatorFromFunctorAdapter and testMonge OTHER_FAULT error.
Note that testLocalEstimatorFromFunctorAdapter will not passed the test. @dcoeurjo can you check this ?

testIntegralInvariantMeanCurvatureEstimator3D failed the test, but will be fixed in PR #716
I haven't modify testClock. It still failed the test.
