### PR TITLE
cleaning up some traces

### DIFF
--- a/src/DGtal/base/Trace.h
+++ b/src/DGtal/base/Trace.h
@@ -120,14 +120,14 @@ namespace DGtal
      * Create a string with an indentation prefix for a normal trace.
      * @return the cerr output stream with the prefix
      */
-    std::ostream & info() const;
+    std::ostream & info();
 
     /**
      * Create a string with an indentation prefix for a warning trace.
      *  the string is postfixed by the keyword "[WRNG]"
      * @return the cerr output stream with the prefix
      */
-     std::ostream & warning() const;
+     std::ostream & warning();
 
 
     /**
@@ -135,7 +135,7 @@ namespace DGtal
      *  the string is postfixed by the keyword "[ERR]"
      * @return the cerr output stream with the prefix
      */
-    std::ostream &  error() const;
+    std::ostream &  error();
 
 
     /**
@@ -143,7 +143,7 @@ namespace DGtal
      *
      * @return the cerr output stream with the prefix
      */
-    std::ostream &  emphase() const;
+    std::ostream &  emphase();
 
     /**
      * Display a progress bar in the terminal.
@@ -193,6 +193,9 @@ namespace DGtal
 
     ///Progress bar rotation position
     unsigned int myProgressBarRotation;
+
+    ///True if the style has changed
+    bool myStyle;
 
     // ------------------------- Hidden services ------------------------------
   protected:

--- a/src/DGtal/base/Trace.ih
+++ b/src/DGtal/base/Trace.ih
@@ -50,7 +50,7 @@
  */
 inline
 DGtal::Trace::Trace(DGtal::TraceWriter &writer):
-  myCurrentLevel(0), myCurrentPrefix (""),  myWriter(writer), myProgressBarCurrent(-1), myProgressBarRotation(0)
+  myCurrentLevel(0), myCurrentPrefix (""),  myWriter(writer), myProgressBarCurrent(-1), myProgressBarRotation(0), myStyle(false)
 {
 }
 
@@ -63,7 +63,8 @@ DGtal::Trace::Trace(DGtal::TraceWriter &writer):
 inline
 DGtal::Trace::~Trace()
 {
-  myWriter.outputStream() << myWriter.postfixReset();
+  if (myStyle)
+    myWriter.outputStream() << myWriter.postfixReset();
 }
 
 
@@ -176,9 +177,10 @@ DGtal::Trace::endBlock()
  * @return the output stream with the prefix
  */
 inline std::ostream &
-DGtal::Trace::warning() const
+DGtal::Trace::warning()
 {
   myWriter.outputStream() <<  myCurrentPrefix << myWriter.prefixWarning();
+  myStyle = true;
   return  myWriter.outputStream();
 }
 
@@ -189,9 +191,10 @@ DGtal::Trace::warning() const
  * @return the output stream with the prefix
  */
 inline std::ostream &
-DGtal::Trace::error() const
+DGtal::Trace::error()
 {
   myWriter.outputStream() <<  myCurrentPrefix << myWriter.prefixError();
+  myStyle = true;
   return  myWriter.outputStream();
 }
 
@@ -202,9 +205,10 @@ DGtal::Trace::error() const
  * @return the output stream with the prefix
  */
 inline std::ostream &
-DGtal::Trace::emphase() const
+DGtal::Trace::emphase()
 {
   myWriter.outputStream() <<  myCurrentPrefix << myWriter.prefixEmphase();
+  myStyle = true;
   return  myWriter.outputStream();
 }
 
@@ -213,9 +217,14 @@ DGtal::Trace::emphase() const
  * @return the cerr output stream with the prefix
  */
 inline std::ostream &
-DGtal::Trace::info() const
+DGtal::Trace::info()
 {
-  myWriter.outputStream() <<  myCurrentPrefix << myWriter.prefixInfo();
+  myWriter.outputStream() <<  myCurrentPrefix;
+
+  if (myStyle)
+    myWriter.outputStream() << myWriter.prefixInfo();
+
+  myStyle = false;
   return  myWriter.outputStream();
 }
 
@@ -279,5 +288,3 @@ DGtal::operator<<( std::ostream & out,
 
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
-
-


### PR DESCRIPTION
Cleaning up some "color" tags on traces. Now, special codes are inserted only if necessary. 
