### PR TITLE
Fixing type issue in trace.endBlock()

### DIFF
--- a/src/DGtal/base/Trace.h
+++ b/src/DGtal/base/Trace.h
@@ -114,7 +114,7 @@ namespace DGtal
      *
      * @return  the ellapsed time in the block in milliseconds (Class Clock).
      */
-    long endBlock();
+    double endBlock();
 
     /**
      * Create a string with an indentation prefix for a normal trace.

--- a/src/DGtal/base/Trace.ih
+++ b/src/DGtal/base/Trace.ih
@@ -144,7 +144,7 @@ DGtal::Trace::beginBlock(const std::string &keyword)
  * @return  the ellapsed time in the block in milliseconds (Class Clock).
  *
  */
-inline long
+inline double
 DGtal::Trace::endBlock()
 {
   double tick;


### PR DESCRIPTION
returns now a double instead of a "long"
