### PR TITLE
Minor edit doc KhalimskySpaceND

### DIFF
--- a/src/DGtal/topology/KhalimskySpaceND.h
+++ b/src/DGtal/topology/KhalimskySpaceND.h
@@ -517,7 +517,7 @@ namespace DGtal
      *
      * @param kp an integer point (Khalimsky coordinates of cell).
      * @param sign the sign of the cell (either POS or NEG).
-     * @return the unsigned cell.
+     * @return the signed cell.
      */
     SCell sCell( const Point & kp, Sign sign = POS ) const;
 


### PR DESCRIPTION
It's seems like their is an issue with the documentation of function sCell of KhalimskySpaceND ( http://dgtal.org/doc/nightly/classDGtal_1_1KhalimskySpaceND.html#a1223cf533c27e6670e4c3455f27fdac1 ):

>   From the Khalimsky coordinates of a cell and a sign, builds the corresponding unsigned cell.

but returns a signed cell (SCell)

(See Issue https://github.com/DGtal-team/DGtal/issues/872 ) 
