### PR TITLE
Fix issue906

### DIFF
--- a/tests/topology/testSurfaceHelper.cpp
+++ b/tests/topology/testSurfaceHelper.cpp
@@ -79,12 +79,11 @@ bool testComputeInterior()
   int minx, miny, maxx, maxy; 
   fc.computeBoundingBox(minx, miny, maxx, maxy);
 
-  trace.error() << minx << " " << miny << " " << maxx << " " << maxy << std::endl;
-  trace.info() << "Domain defined by :" << Z2i::Point(minx-5,miny-5) << " " << Z2i::Point(maxx+5, maxy+5) << std::endl;
-  K.init(Z2i::Point(minx-5,miny-5), Z2i::Point(maxx+5, maxy+5), false);
+  BoolImage2D::Domain dom(Z2i::Point(minx-5,miny-5), Z2i::Point(maxx+5, maxy+5));
+  trace.info() << "Domain defined by :" << dom.lowerBound() << " " << dom.upperBound() << std::endl;
+  K.init(dom.lowerBound(), dom.upperBound(), false);
   FreemanChain<Z2i::Space::Integer>::getInterPixelLinels(K, fc, boundaryCell );
 
-  BoolImage2D::Domain dom(Z2i::Point(minx-5,miny-5), Z2i::Point(maxx+5, maxy+5));
   BoolImage2D interiorImage(dom);
   unsigned int nbInt = Surfaces<DGtal::KhalimskySpaceND< 2, int > >::uFillInterior(K, SurfelSetPredicate<std::set<SCell>, SCell>(boundaryCell), 
                                                                                    interiorImage, 1, false);
@@ -99,10 +98,10 @@ bool testComputeInterior()
   DGtal::KhalimskySpaceND< 2, int > K2; 
   int minx2, miny2, maxx2, maxy2; 
   fc2.computeBoundingBox(minx2, miny2, maxx2, maxy2); 
-  K2.init(Z2i::Point(minx2-5,miny2-5), Z2i::Point(maxx2+5, maxy2+5), false);
+  BoolImage2D::Domain dom2(Z2i::Point(minx2-5,miny2-5), Z2i::Point(maxx2+5, maxy2+5));
+  K2.init(dom2.lowerBound(), dom2.upperBound(), false);
   FreemanChain<Z2i::Space::Integer>::getInterPixelLinels(K2, fc2, boundaryCell2 ); 
 
-  BoolImage2D::Domain dom2(Z2i::Point(minx2-5,miny2-5), Z2i::Point(maxx2+5, maxy2+5));
   BoolImage2D interiorImage2(dom2);
   unsigned int nbInt2 = Surfaces<DGtal::KhalimskySpaceND< 2, int > >::uFillInterior(K2, SurfelSetPredicate<std::set<SCell>,SCell>(boundaryCell2), 
                                                                                     interiorImage2, 1, false);
@@ -110,8 +109,7 @@ bool testComputeInterior()
   
   // Displaying interiorCell
   Board2D aBoard, aBoard2, aBoard3; 
-  trace.error() << "img " << interiorImage << std::endl; 
-  trace.error() << "domain " << interiorImage.domain() << std::endl;
+
   for( BoolImage2D::Domain::ConstIterator it = interiorImage.domain().begin();  it!= interiorImage.domain().end(); ++it){
     if(interiorImage(*it)){
       aBoard << *it;


### PR DESCRIPTION
Fixing Issue https://github.com/DGtal-team/DGtal/issues/906

Domain given at constructor of BoolImage2D are deleted after the call, but stored as pointer inside BoolImage2D. Then, the "pointed Domain" is wrong and can be deleted, resulting an assertion when scanning the domain.

I don't know why Travis doesn't get this behavior....

:octocat: 
