### PR TITLE
Minor patch for BezoutVector computation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -55,6 +55,7 @@
    (Tristan Roussillon, [#939](https://github.com/DGtal-team/DGtal/pull/939))
  - Fixing DSS based length estimator on open curves. (David
    Coeurjolly, [#941](https://github.com/DGtal-team/DGtal/pull/941))
+ - Fix Bezout Vector computation (Isabelle Sivignon, [#948](https://github.com/DGtal-team/DGtal/pull/948))
 
 # DGtal 0.8
 

--- a/src/DGtal/geometry/curves/ArithmeticalDSSFactory.ih
+++ b/src/DGtal/geometry/curves/ArithmeticalDSSFactory.ih
@@ -232,18 +232,34 @@ bezoutVector(const Coordinate& aA,
   //compute the one whose component
   //have a sign equal to the direction
   //vector components
-  if ( (aB >= 0)&&(v[0] < 0) )
-    v += Vector(aB,aA); 
-  else if ( (aB < 0)&&(v[0] >= 0) )
-    v += Vector(aB,aA); 
-  else if ( ( aA >= 0 )&&(v[1] < 0) )
-    v += Vector(aB,aA);
-  else if ( ( aA < 0 )&&(v[1] >= 0) )
-    v += Vector(aB,aA);
-  ASSERT( (aA*v[0]-aB*v[1]) == aR );
-  ASSERT( (( aA >= 0 )&&(v[1] >= 0))||(( aA < 0 )&&(v[1] < 0)) ); 
-  ASSERT( (( aB >= 0 )&&(v[0] >= 0))||(( aB < 0 )&&(v[0] < 0)) ); 
+  // if ( (aB >= 0)&&(v[0] < 0) )
+  //   v += Vector(aB,aA); 
+  // else if ( (aB < 0)&&(v[0] >= 0) )
+  //   v += Vector(aB,aA); 
+  // else if ( ( aA >= 0 )&&(v[1] < 0) )
+  //   v += Vector(aB,aA);
+  // else if ( ( aA < 0 )&&(v[1] >= 0) )
+  //   v += Vector(aB,aA);
 
+   // Erratum: modify v if and only if aB and v[0] or aA and v[1] have strictly different signs
+  if ( (aB > 0)&&(v[0] < 0) )
+    v += Vector(aB,aA); 
+  else if ( (aB < 0)&&(v[0] > 0) )
+    v += Vector(aB,aA); 
+  else if ( ( aA > 0 )&&(v[1] < 0) )
+    v += Vector(aB,aA);
+  else if ( ( aA < 0 )&&(v[1] > 0) )
+    v += Vector(aB,aA);
+  
+  ASSERT( (aA*v[0]-aB*v[1]) == aR );
+ 
+  // Too restrictive asserts: cases where one v component is null are rejected while they should be accepted. See for instance bezoutVector(-3,-1,-1)
+  //ASSERT( (( aA >= 0 )&&(v[1] >= 0))||(( aA < 0 )&&(v[1] < 0)) ); 
+  //ASSERT( (( aB >= 0 )&&(v[0] >= 0))||(( aB < 0 )&&(v[0] < 0)) ); 
+
+  // Assert that for the pairs (aA,v[1]) and (aB,v[0]) either one member is null, or they have the same sign
+  ASSERT( (aA ==0 || v[1] == 0 || (aA > 0 && v[1] > 0) || (aA < 0 && v[1] <0)) && (aB ==0 || v[0] == 0 || (aB > 0 && v[0] > 0) || (aB < 0 && v[0] <0)));
+  
   return v; 
 }
 

--- a/src/DGtal/geometry/curves/ArithmeticalDSSFactory.ih
+++ b/src/DGtal/geometry/curves/ArithmeticalDSSFactory.ih
@@ -229,19 +229,10 @@ bezoutVector(const Coordinate& aA,
   Vector v = computer.extendedEuclid(aA, -aB, aR); 
   ASSERT( (aA*v[0]-aB*v[1]) == aR );
 
-  //compute the one whose component
-  //have a sign equal to the direction
-  //vector components
-  // if ( (aB >= 0)&&(v[0] < 0) )
-  //   v += Vector(aB,aA); 
-  // else if ( (aB < 0)&&(v[0] >= 0) )
-  //   v += Vector(aB,aA); 
-  // else if ( ( aA >= 0 )&&(v[1] < 0) )
-  //   v += Vector(aB,aA);
-  // else if ( ( aA < 0 )&&(v[1] >= 0) )
-  //   v += Vector(aB,aA);
-
-   // Erratum: modify v if and only if aB and v[0] or aA and v[1] have strictly different signs
+  // compute the one whose component
+  // have a sign equal to the direction
+  // vector components
+  // modify v if and only if aB and v[0] or aA and v[1] have strictly different signs
   if ( (aB > 0)&&(v[0] < 0) )
     v += Vector(aB,aA); 
   else if ( (aB < 0)&&(v[0] > 0) )
@@ -253,10 +244,6 @@ bezoutVector(const Coordinate& aA,
   
   ASSERT( (aA*v[0]-aB*v[1]) == aR );
  
-  // Too restrictive asserts: cases where one v component is null are rejected while they should be accepted. See for instance bezoutVector(-3,-1,-1)
-  //ASSERT( (( aA >= 0 )&&(v[1] >= 0))||(( aA < 0 )&&(v[1] < 0)) ); 
-  //ASSERT( (( aB >= 0 )&&(v[0] >= 0))||(( aB < 0 )&&(v[0] < 0)) ); 
-
   // Assert that for the pairs (aA,v[1]) and (aB,v[0]) either one member is null, or they have the same sign
   ASSERT( (aA ==0 || v[1] == 0 || (aA > 0 && v[1] > 0) || (aA < 0 && v[1] <0)) && (aB ==0 || v[0] == 0 || (aB > 0 && v[0] > 0) || (aB < 0 && v[0] <0)));
   

--- a/tests/geometry/curves/testArithmeticalDSS.cpp
+++ b/tests/geometry/curves/testArithmeticalDSS.cpp
@@ -876,6 +876,30 @@ bool comparisonSubsegment(typename DSL::Coordinate a, typename DSL::Coordinate b
 }
 
 
+bool testPatchCreatePattern()
+{
+  unsigned int nbok = 0;
+  unsigned int nb = 0;
+
+  trace.beginBlock("Test patch bezoutVector/CreatePattern");
+
+  typedef DGtal::ArithmeticalDSSFactory<DGtal::int32_t> Factory;
+  typedef DGtal::ArithmeticalDSS<DGtal::int32_t> DSS8;
+  typedef DSS8::Point Point;
+  DSS8 dss = Factory::createPattern(DSS8::Point(0,0), DSS8::Point(-1,-3));
+  nb++;
+  nbok += (dss == DSS8(-3,-1,Point(0,0), Point(-1,-3), Point(0,0), Point(-1,-3), Point(-1,-1), Point(-1,-1)));
+  
+  dss = Factory::createPattern(DSS8::Point(0,0), DSS8::Point(10,-1));
+  nb++;
+  nbok += (dss == DSS8(-1,10, Point(0,0), Point(10,-1), Point(0,0), Point(10,-1), Point(1,-1), Point(1,-1)));
+  
+  trace.endBlock();
+
+  return (nb == nbok);
+
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////
 int main( int argc, char** argv )
@@ -1013,6 +1037,11 @@ int main( int argc, char** argv )
 #endif
       ;
   }
+
+  {
+    res = res && testPatchCreatePattern();
+  }
+  
 
   trace.emphase() << ( res ? "Passed." : "Error." ) << endl;
   trace.endBlock();


### PR DESCRIPTION
Bezout vector computation was not correct for some particular cases and led to incorrect createPattern computations. For instance createPattern(Point(0,0),Point(-1,-3)) calls bezoutVector(-3,-1,-1) which returned v=(-1,-4) before this patch, instead of the vector (0,-1), thus missing the lower leaning point (-1,-1).   