### PR TITLE
Using ~0 instead of -1 as magic number for end().

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -62,6 +62,8 @@
  Lachaud, [#926](https://github.com/DGtal-team/DGtal/pull/926))
 
 - *Base Package*
+ - Fix bug with Labels iterator when first index is set (Roland Denis,
+ [#972](https://github.com/DGtal-team/DGtal/pull/972))
  - Iterator category fix for boost > 1.57 (David Coeurjolly,
  [#938](https://github.com/DGtal-team/DGtal/pull/938))
 

--- a/src/DGtal/base/Labels.h
+++ b/src/DGtal/base/Labels.h
@@ -43,6 +43,8 @@
 #include <iostream>
 #include <vector>
 #include "DGtal/base/Common.h"
+#include "DGtal/kernel/CUnsignedNumber.h"
+#include "DGtal/kernel/CIntegralNumber.h"
 //////////////////////////////////////////////////////////////////////////////
 
 namespace DGtal
@@ -69,7 +71,8 @@ namespace DGtal
   class Labels
   {
     BOOST_STATIC_ASSERT(( L >= 1 ));
-    // BOOST_CONCEPT_ASSERT(( CUnsignedInteger<TWord> ));
+    BOOST_CONCEPT_ASSERT(( concepts::CUnsignedNumber<TWord> ));
+    BOOST_CONCEPT_ASSERT(( concepts::CIntegralNumber<TWord> ));
 
   public:
     typedef TWord Word;

--- a/src/DGtal/base/Labels.ih
+++ b/src/DGtal/base/Labels.ih
@@ -30,6 +30,7 @@
 //////////////////////////////////////////////////////////////////////////////
 #include <cstdlib>
 #include <algorithm>
+#include <limits>
 #include "DGtal/base/Bits.h"
 //////////////////////////////////////////////////////////////////////////////
 
@@ -72,7 +73,7 @@ ConstEnumerator( const Word* address, SizeType firstWord )
   else
     {
       myWord = 0;
-      myLabel = ~0;
+      myLabel = std::numeric_limits<Label>::max();
     }
 }
 //-----------------------------------------------------------------------------
@@ -132,7 +133,7 @@ operator++()
       if ( myWordLabel == ( __DGTAL_LABELS_NBWORDS
                             * __DGTAL_WORD_NBDIGITS ) )
         {
-          myLabel = ~0;
+          myLabel = std::numeric_limits<Label>::max();
           return *this;
         }
       myWord = *myWordAddress++;

--- a/src/DGtal/base/Labels.ih
+++ b/src/DGtal/base/Labels.ih
@@ -72,7 +72,7 @@ ConstEnumerator( const Word* address, SizeType firstWord )
   else
     {
       myWord = 0;
-      myLabel = -1;
+      myLabel = ~0;
     }
 }
 //-----------------------------------------------------------------------------
@@ -132,7 +132,7 @@ operator++()
       if ( myWordLabel == ( __DGTAL_LABELS_NBWORDS
                             * __DGTAL_WORD_NBDIGITS ) )
         {
-          myLabel = -1;
+          myLabel = ~0;
           return *this;
         }
       myWord = *myWordAddress++;

--- a/tests/base/testLabels.cpp
+++ b/tests/base/testLabels.cpp
@@ -128,12 +128,53 @@ int main()
   std::cout << "(" << nbok << "/" << nb << ") l=" << l << std::endl; 
   checkErase( v, l, 200 );
   ++nb, nbok += isEqual( v, l ) ? 1 : 0;
-  std::cout << "(" << nbok << "/" << nb << ") l=" << l << std::endl; 
+  std::cout << "(" << nbok << "/" << nb << ") l=" << l << std::endl;
   for ( LabelsConstIterator it = l.begin(), it_end = l.end();
         it != it_end; ++it )
     std::cout << " " << *it;
   std::cout << std::endl;
+
   trace.endBlock();
+
+  // Test related to pull request #971 & #972
+  typedef Labels<32, DGtal::uint32_t> MySmallLabels;
+  typedef MySmallLabels::ConstIterator SmallLabelsConstIterator;
+  typedef std::bitset<32> MySmallBitset;
+  
+  trace.beginBlock ( "Testing one word long Labels" );
+  MySmallLabels ll;
+  MySmallBitset vv;
+
+  ++nb, nbok += isEqual( vv, ll ) ? 1 : 0;
+  std::cout << "(" << nbok << "/" << nb << ") small_l=" << ll << std::endl; 
+
+  insert( vv, ll, 15 );
+  insert( vv, ll, 4 );
+  insert( vv, ll, 31 );
+  ++nb, nbok += isEqual( vv, ll ) ? 1 : 0;
+  std::cout << "(" << nbok << "/" << nb << ") small_l=" << ll << std::endl; 
+
+  erase( vv, ll, 15 );
+  ++nb, nbok += isEqual( vv, ll ) ? 1 : 0;
+  std::cout << "(" << nbok << "/" << nb << ") small_l=" << ll << std::endl; 
+  
+  // Check insertion at index 0
+  insert( vv, ll, 0 );
+  ++nb, nbok += isEqual( vv, ll ) ? 1 : 0;
+  std::cout << "(" << nbok << "/" << nb << ") small_l=" << ll << std::endl; 
+
+  // Check bit count computation
+  ++nb, nbok += ll.count() == 3 ? 1 : 0;
+  std::cout << "(" << nbok << "/" << nb << ") small_l.count()=" << ll.count() << std::endl;
+
+  // Compare with size computed with iterators
+  unsigned int cnt = 0;
+  for ( SmallLabelsConstIterator it = ll.begin(), it_end = ll.end(); it != it_end; ++cnt, ++it) {}
+  ++nb, nbok += cnt == 3 ? 1 : 0;
+  std::cout << "(" << nbok << "/" << nb << ") small_l bit count with iterators=" << cnt << std::endl;
+  
+  trace.endBlock();
+
   return ( nb == nbok ) ? 0 : 1;
 }
 /** @ingroup Tests **/


### PR DESCRIPTION
Using -1 as magic number for unsigned int is implementation dependant.
~0 is a better choice and is type-size independant.