### PR TITLE
Fixing LabelledMap copy constructor and copy operator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -62,6 +62,8 @@
  Lachaud, [#926](https://github.com/DGtal-team/DGtal/pull/926))
 
 - *Base Package*
+ - Fix bug with LabelledMap copy constructor and copy iterator. (Roland
+   Denis, [#973](https://github.com/DGtal-team/DGtal/pull/973))
  - Fix bug with Labels iterator when first index is set (Roland Denis,
  [#972](https://github.com/DGtal-team/DGtal/pull/972))
  - Iterator category fix for boost > 1.57 (David Coeurjolly,

--- a/src/DGtal/base/LabelledMap.h
+++ b/src/DGtal/base/LabelledMap.h
@@ -72,17 +72,17 @@ namespace DGtal
      V[ 1 ] is the data of the second set label.
      ...
 
-     if less than 3 datas and N = 2
+     if less than 4 datas and N = 3
      +------+------+------+------+------+
      |labels| V[0] | V[1] | ...  |  0   |
      +------+------+------+------+------+
 
-     if only 3 datas and N = 2
+     if only 4 datas and N = 3
      +------+------+------+------+------+
      |labels| V[0] | V[1] | V[2] | V[3] |
      +------+------+------+------+------+
 
-     if more than 3 datas and N = 2, M = 4
+     if more than 4 datas and N = 3, M = 4
      +------+------+------+------+------+        +------+------+------+------+------+
      |labels| V[0] | V[1] | V[2] | ptr --------> | V[3] | V[4] | V[5] | V[6] | ptr --------> ...
      +------+------+------+------+------+        +------+------+------+------+------+

--- a/src/DGtal/base/LabelledMap.ih
+++ b/src/DGtal/base/LabelledMap.ih
@@ -552,8 +552,8 @@ template <typename TData, unsigned int L, typename TWord, unsigned int N, unsign
 inline
 DGtal::LabelledMap<TData, L, TWord, N, M>::
 LabelledMap( const LabelledMap & other )
-  : myFirstBlock( other.myFirstBlock ),
-    myLabels( other.myLabels )
+  : myLabels( other.myLabels ),
+    myFirstBlock( other.myFirstBlock )
 {
   const unsigned int theSize = other.size();
   if ( theSize > N + 1 )

--- a/src/DGtal/base/LabelledMap.ih
+++ b/src/DGtal/base/LabelledMap.ih
@@ -552,18 +552,22 @@ template <typename TData, unsigned int L, typename TWord, unsigned int N, unsign
 inline
 DGtal::LabelledMap<TData, L, TWord, N, M>::
 LabelledMap( const LabelledMap & other )
-  : myFirstBlock( other.myFirstBlock )
+  : myFirstBlock( other.myFirstBlock ),
+    myLabels( other.myLabels )
 {
-  unsigned int s = N + 1; // there is one more stored data in the last block.
-  const __AnyBlock* nextBlock = other.myFirstBlock.data.nextBlock;
-  __AnyBlock** currentPointer = & myFirstBlock.data.nextBlock;
-  myLabels = other.myLabels;
-  while ( s < size() )
+  const unsigned int theSize = other.size();
+  if ( theSize > N + 1 )
     {
-      *currentPointer = new __AnyBlock( *nextBlock );
-      s += M;
-      currentPointer = & ( (*currentPointer)->next );
-      nextBlock = nextBlock->next;
+      unsigned int s = N;
+      const __AnyBlock* nextBlock = other.myFirstBlock.data.nextBlock;
+      __AnyBlock** currentPointer = & myFirstBlock.data.nextBlock;
+      while ( s < theSize )
+        {
+          *currentPointer = new __AnyBlock( *nextBlock );
+          s += M;
+          currentPointer = & ( (*currentPointer)->next );
+          nextBlock = nextBlock->next;
+        }
     }
 }
 //-----------------------------------------------------------------------------
@@ -590,18 +594,21 @@ operator=( const LabelledMap & other )
     {
       blockClear( size() );
       myLabels = other.myLabels;
-      unsigned int theSize = other.size();
       myFirstBlock = other.myFirstBlock;
-      // there is one more stored data in the last block.
-      unsigned int s = N + 1; 
-      const __AnyBlock* nextBlock = other.myFirstBlock.data.nextBlock;
-      __AnyBlock** currentPointer = & myFirstBlock.data.nextBlock;
-      while ( s < theSize  )
+
+      const unsigned int theSize = other.size();
+      if ( theSize > N + 1 )
         {
-          *currentPointer = new __AnyBlock( *nextBlock );
-          s += M;
-          currentPointer = & ( (*currentPointer)->next );
-          nextBlock = nextBlock->next;
+          unsigned int s = N; 
+          const __AnyBlock* nextBlock = other.myFirstBlock.data.nextBlock;
+          __AnyBlock** currentPointer = & myFirstBlock.data.nextBlock;
+          while ( s < theSize  )
+            {
+              *currentPointer = new __AnyBlock( *nextBlock );
+              s += M;
+              currentPointer = & ( (*currentPointer)->next );
+              nextBlock = nextBlock->next;
+            }
         }
     }
   return *this;

--- a/src/DGtal/base/LabelledMap.ih
+++ b/src/DGtal/base/LabelledMap.ih
@@ -562,7 +562,8 @@ LabelledMap( const LabelledMap & other )
     {
       *currentPointer = new __AnyBlock( *nextBlock );
       s += M;
-      currentPointer = & ( currentPointer->data.nextBlock );
+      currentPointer = & ( (*currentPointer)->next );
+      nextBlock = nextBlock->next;
     }
 }
 //-----------------------------------------------------------------------------
@@ -600,6 +601,7 @@ operator=( const LabelledMap & other )
           *currentPointer = new __AnyBlock( *nextBlock );
           s += M;
           currentPointer = & ( (*currentPointer)->next );
+          nextBlock = nextBlock->next;
         }
     }
   return *this;

--- a/tests/base/testLabelledMap.cpp
+++ b/tests/base/testLabelledMap.cpp
@@ -161,7 +161,7 @@ int main()
   
   trace.endBlock();
 
-  // Test related to pull request #??? about copy constructor & operator when using at less 3 blocks.
+  // Test related to pull request #973 about copy constructor & operator when using at less 3 blocks.
   typedef LabelledMap<double, 32, DGtal::uint16_t, 2, 3> MyOtherLabelledMap;
   trace.beginBlock ( "Testing LabelledMap copy constructor and copy operator" );
   MyOtherLabelledMap ll;

--- a/tests/base/testLabelledMap.cpp
+++ b/tests/base/testLabelledMap.cpp
@@ -161,6 +161,39 @@ int main()
   
   trace.endBlock();
 
+  // Test related to pull request #??? about copy constructor & operator when using at less 3 blocks.
+  typedef LabelledMap<double, 32, DGtal::uint16_t, 2, 3> MyOtherLabelledMap;
+  trace.beginBlock ( "Testing LabelledMap copy constructor and copy operator" );
+  MyOtherLabelledMap ll;
+
+  for ( unsigned int size = 0; size <= 2 + 3 + 2; ++size )
+    {
+      for (unsigned int i = 0; i < size; ++i)
+        ll[i] = i;
+      
+      MyOtherLabelledMap ll_ccopy(ll);
+      MyOtherLabelledMap ll_ocopy; ll_ocopy = ll;
+
+      for (unsigned int i = 0; i < size; ++i)
+        ll[i] = 10*i+1;
+
+      bool csuccess = true;
+      bool osuccess = true;
+      for (unsigned int i = 0; i < size; ++i)
+        {
+          csuccess &= ll_ccopy[i] == i;
+          osuccess &= ll_ocopy[i] == i;
+        }
+
+      ++nb; nbok += csuccess ? 1 : 0;
+      std::cout << "(" << nbok << "/" << nb << ") ll_copy_constructed=" << ll_ccopy << std::endl;
+      
+      ++nb; nbok += osuccess ? 1 : 0;
+      std::cout << "(" << nbok << "/" << nb << ") ll_copied=" << ll_ocopy << std::endl;
+    }
+
+  trace.endBlock();
+
   return ( nb == nbok ) ? 0 : 1;
 }
 /** @ingroup Tests **/


### PR DESCRIPTION
There was several issues with copy constructor and copy operator of LabelledMap. The test file has been updated to check this issues.

The documentation has been corrected (typo in the first block capacity).