### PR TITLE
Fixing ball radius and resolution when used to represent a 3D point 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -82,8 +82,7 @@
  [#948](https://github.com/DGtal-team/DGtal/pull/948))
  - Fix issues with SphereFitting and TensorVoting local estimators on
    digital surfaces (Jérémy Levallois, David Coeurjolly
-   [#970](https://github.com/DGtal-team/DGtal/pull/970))
-   
+   [#970](https://github.com/DGtal-team/DGtal/pull/970))   
 
 - *IO Package*
  - Performance improvement of color managment in Display3D, Board3D

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -90,7 +90,10 @@
    and Viewer3D: no more "createNew...List" when setting a new
    color. (David Coeurjolly,
    [#958](https://github.com/DGtal-team/DGtal/pull/958))
-
+ - Radius and resolution of balls have been fixed when used to
+   represent a 3D point in grid mode (David Coeurjolly,
+   [#978](https://github.com/DGtal-team/DGtal/pull/978))
+ 
 
 # DGtal 0.8
 

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -225,7 +225,7 @@ namespace DGtal
       RealPoint center;
       bool isSigned;
       bool signPos;
-      double size;
+      double radius;
       unsigned int resolution;
     };
 
@@ -622,12 +622,12 @@ namespace DGtal
     /**
      * Method to add a point to the current display.
      * @param center ball center x
-     * @param size the ball radius (default 1)
+     * @param radius the ball radius (default 0.5)
      * @param resolution ball resolution (default 30)
      *
      */
     void addBall(const RealPoint &center ,
-                 const double size=1.0,
+                 const double radius=0.5,
                  const unsigned int resolution = 30);
 
 

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -286,7 +286,7 @@ template < typename Space ,typename KSpace >
 inline
 void
 DGtal::Display3D< Space ,KSpace >::addBall(const RealPoint &center,
-                                           const double size,
+                                           const double radius,
                                            const unsigned int resolution)
 {
   updateBoundingBox(center);
@@ -295,7 +295,7 @@ DGtal::Display3D< Space ,KSpace >::addBall(const RealPoint &center,
   p.color    = getFillColor();
   p.isSigned = false;
   p.signPos  = false;
-  p.size     = size;
+  p.radius     = radius;
   p.resolution = resolution;
   p.name     = name3d();
   if (myBallSetList.size()== 0)

--- a/src/DGtal/io/Display3DFactory.h
+++ b/src/DGtal/io/Display3DFactory.h
@@ -83,6 +83,11 @@ namespace DGtal
   struct Display3DFactory
   {
 
+    ///The size of the ball radius when used to display a 3D point.
+    constexpr BOOST_STATIC_CONSTANT(double, POINT_AS_BALL_RADIUS = 0.1);
+    ///The ball resolution when used to display a point
+    constexpr BOOST_STATIC_CONSTANT(unsigned int, POINT_AS_BALL_RES = 10);
+    
     typedef TSpace Space;
     typedef TKSpace KSpace;
     typedef Display3DFactory<Space, KSpace> Self;
@@ -624,7 +629,7 @@ namespace DGtal
      */
     static void 
     draw( Display & display, const DGtal::SetSelectCallback3D& aFct );
-
+    
   }; // end of struct Display3DFactory
 
 } // namespace DGtal

--- a/src/DGtal/io/Display3DFactory.h
+++ b/src/DGtal/io/Display3DFactory.h
@@ -84,9 +84,9 @@ namespace DGtal
   {
 
     ///The size of the ball radius when used to display a 3D point.
-    constexpr BOOST_STATIC_CONSTANT(double, POINT_AS_BALL_RADIUS = 0.1);
+    constexpr BOOST_STATIC_CONSTANT(double, POINT_AS_BALL_RADIUS = 0.2);
     ///The ball resolution when used to display a point
-    constexpr BOOST_STATIC_CONSTANT(unsigned int, POINT_AS_BALL_RES = 10);
+    constexpr BOOST_STATIC_CONSTANT(unsigned int, POINT_AS_BALL_RES = 5);
     
     typedef TSpace Space;
     typedef TKSpace KSpace;

--- a/src/DGtal/io/Display3DFactory.ih
+++ b/src/DGtal/io/Display3DFactory.ih
@@ -498,7 +498,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsGrid( Display & display,
         ++it )
     {
       DGtal::Z3i::RealPoint rp = display.embed((*it) );
-      display.addBall(rp);
+      display.addBall(rp,POINT_AS_BALL_RADIUS, POINT_AS_BALL_RES);
     }
 }
 
@@ -587,7 +587,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsGrid( Display & display,
         ++it )
     {
       DGtal::Z3i::RealPoint rp = display.embed((*it) );
-      display.addBall(rp);
+      display.addBall(rp,POINT_AS_BALL_RADIUS, POINT_AS_BALL_RES);
     }
 }
 
@@ -833,7 +833,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsPavingBalls( Display & display
                 {
                   DGtal::Z3i::RealPoint rp = display.embed( DGtal::Z3i::Point(x, y, z) );
                   display.setFillColor(DGtal::Color(255, 0 ,0));
-                  display.addBall(rp);
+                  display.addBall(rp,POINT_AS_BALL_RADIUS, POINT_AS_BALL_RES);
                 }
             }
         }
@@ -981,7 +981,7 @@ void DGtal::Display3DFactory<Space,KSpace>::draw( Display & display,
         display.setFillColor(DGtal::Color(200, 200, 20, 255));
       }
 
-    display.addBall(rp, 0.05);
+    display.addBall(rp, POINT_AS_BALL_RADIUS, POINT_AS_BALL_RES);
     break;
   case 1:
     if(mode!=""&& mode!="Basic" && mode!="IllustrationCustomColor")
@@ -1121,7 +1121,7 @@ void DGtal::Display3DFactory<Space,KSpace>::draw( Display & display,
           else
             display.setFillColor(DGtal::Color(20, 20, 150, 255));
         }
-      display.addBall(rps, 0.05);
+      display.addBall(rps, POINT_AS_BALL_RADIUS, POINT_AS_BALL_RES);
       break;
     case 1:
       if(mode!="" && mode!="Basic" && mode!="IllustrationCustomColor")
@@ -1245,7 +1245,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsGrid( Display & display,
   ASSERT(dim == 3);
   DGtal::Z3i::RealPoint rp = display.embed( p );
   display.setFillColor(display.getLineColor());
-  display.addBall( rp);
+  display.addBall(rp,POINT_AS_BALL_RADIUS, POINT_AS_BALL_RES);
   display.setFillColor(fillColorSave);
 }
 

--- a/src/DGtal/io/boards/Board3D.ih
+++ b/src/DGtal/io/boards/Board3D.ih
@@ -220,7 +220,7 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
                 double phiResolution = s_it->resolution;
                 double phiStep= M_PI/phiResolution;
                 
-                double radius = s_it->size*scale;
+                double radius = s_it->radius*scale;
                 double xCenter = (s_it->center[0]-shift[0])*scale;
                 double yCenter = (s_it->center[1]-shift[0])*scale;
                 double zCenter = (s_it->center[2]-shift[0])*scale;

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -223,7 +223,7 @@ namespace DGtal
     }
 
 
-    /// the 3 possible axes for the image direction
+    /// the 3 possible axes for the imaball3Dge direction
     enum ImageDirection {xDirection, yDirection, zDirection, undefDirection };
     /// the modes of representation of an image
     enum TextureMode {RGBMode, GrayScaleMode };

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -698,7 +698,7 @@ DGtal::Viewer3D<Space, KSpace>::draw()
     {
       if ( Viewer3D<Space, KSpace>::myBallSetList.at ( j ).size() !=0 )
         {
-          glPointSize ( ( Viewer3D<Space, KSpace>::myBallSetList.at ( j ).at ( 0 ).size ) /distCam );
+          glPointSize ( ( Viewer3D<Space, KSpace>::myBallSetList.at ( j ).at ( 0 ).radius ) /distCam );
         }
       glCallList(myBallSetListId+j);
     }
@@ -1100,7 +1100,7 @@ DGtal::Viewer3D<Space, KSpace>::glDrawGLBall ( typename Viewer3D<Space, KSpace>:
   double phiResolution = aBall.resolution;
   double phiStep= M_PI/phiResolution;
   
-  double radius = aBall.size;
+  double radius = aBall.radius;
   double xCenter = aBall.center[0];
   double yCenter = aBall.center[1];
   double zCenter = aBall.center[2];


### PR DESCRIPTION
Static constant in Display3DFactory to specify the radius and resolution of a ball when used to display a 3D point. (see #965)
