### PR TITLE
Change export color mode in OFF Mesh 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -102,7 +102,7 @@
  - Radius and resolution of balls have been fixed when used to
    represent a 3D point in grid mode (David Coeurjolly,
    [#978](https://github.com/DGtal-team/DGtal/pull/978))
- - Change in the Mesh off export: now the export try by default to export colors (if stored).
+ - Change in the mesh export in OFF format: now it tries by default to export colors (if stored).
    (Bertrand Kerautret, [#985](https://github.com/DGtal-team/DGtal/pull/985))
 
 # DGtal 0.8

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -102,7 +102,8 @@
  - Radius and resolution of balls have been fixed when used to
    represent a 3D point in grid mode (David Coeurjolly,
    [#978](https://github.com/DGtal-team/DGtal/pull/978))
-
+ - Change in the Mesh off export: now the export try by default to export colors (if stored).
+   (Bertrand Kerautret, [#985](https://github.com/DGtal-team/DGtal/pull/985))
 
 # DGtal 0.8
 

--- a/src/DGtal/io/writers/MeshWriter.h
+++ b/src/DGtal/io/writers/MeshWriter.h
@@ -81,16 +81,17 @@ namespace DGtal
 
 
     /** 
-     * Export Mesh towards a OFF format.
+     * Export Mesh towards a OFF format. By default the face colors are
+     * exported (if they are stored in the Mesh object). 
      * 
      * @param out the output stream of the exported OFF object.
      * @param aMesh the Mesh object to be exported.
-     * @param exportColor true to export colors (default false). 
+     * @param exportColor true to try to export the face colors if they are stored in the Mesh object (default true). 
      * @return true if no errors occur.
      */
     
     static bool export2OFF(std::ostream &out, const  Mesh<TPoint>  &aMesh, 
-      bool exportColor=false) throw(DGtal::IOException);
+                           bool exportColor=true) throw(DGtal::IOException);
   
   
 

--- a/src/DGtal/io/writers/MeshWriter.ih
+++ b/src/DGtal/io/writers/MeshWriter.ih
@@ -65,12 +65,13 @@ DGtal::MeshWriter<TPoint>::export2OFF(std::ostream & out,
 	  out << indexVertex << " " ;	    
 	}
 	DGtal::Color col = aMesh.getFaceColor(i);
-	if(exportColor){
-	  out << " ";
- 	  out << ((double) col.red())/255.0 << " "
-	      << ((double) col.green())/255.0 << " "<< ((double) col.blue())/255.0 
-	      << " " << ((double) col.alpha())/255.0 ;
-	}  
+	if(exportColor && aMesh.isStoringFaceColors() )
+          {
+            out << " ";
+            out << ((double) col.red())/255.0 << " "
+                << ((double) col.green())/255.0 << " "<< ((double) col.blue())/255.0 
+                << " " << ((double) col.alpha())/255.0 ;
+          }  
 	out << std::endl;
       }
     }catch( ... )
@@ -131,11 +132,14 @@ DGtal::operator>> (   Mesh<TPoint> & aMesh, const std::string & aFilename ){
   std::string extension = aFilename.substr(aFilename.find_last_of(".") + 1);
   std::ofstream out;
   out.open(aFilename.c_str());
-  if(extension== "off") {
-    return DGtal::MeshWriter<TPoint>::export2OFF(out, aMesh, true);
-  }else if(extension== "obj") {
-    return DGtal::MeshWriter<TPoint>::export2OBJ(out, aMesh);
-  }
+  if(extension== "off") 
+    {
+      return DGtal::MeshWriter<TPoint>::export2OFF(out, aMesh, true);
+    }
+  else if(extension== "obj")
+    {
+      return DGtal::MeshWriter<TPoint>::export2OBJ(out, aMesh);
+    }
   out.close();
   return false;
 } 


### PR DESCRIPTION
It was not natural to have the default option set to false when dealing with Mesh storing colors.
Now, when exporting mesh it first tries to export colors if available. (you can always force to not do it by changing the default option).