### PR TITLE
Fix basic domain sub sampler

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -116,8 +116,9 @@
    (Bertrand Kerautret, [#985](https://github.com/DGtal-team/DGtal/pull/985))
 
 - *Kernel Package*
-  - New functor Fix bug when a DomainSubSampler is applied on a domain with non 0 origin.
-    (Bertrand Kerautret, [887](https://github.com/DGtal-team/DGtal/pull/987)).
+  - BasicDomainSubSampler can now handle non 0 origin point. This update also correct
+    the search of point which are outside the source domain (it is now checked in testBasicPointFunctors).
+    (Bertrand Kerautret, [987](https://github.com/DGtal-team/DGtal/pull/987)).
 
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -106,6 +106,11 @@
  - Change in the mesh export in OFF format: now it tries by default to export colors (if stored).
    (Bertrand Kerautret, [#985](https://github.com/DGtal-team/DGtal/pull/985))
 
+- *Kernel Package*
+  - New functor Fix bug when a DomainSubSampler is applied on a domain with non 0 origin.
+    (Bertrand Kerautret, [887](https://github.com/DGtal-team/DGtal/pull/987)).
+
+
 
 # DGtal 0.8
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -118,7 +118,7 @@
 - *Kernel Package*
   - BasicDomainSubSampler can now handle non 0 origin point. This update also correct
     the search of point which are outside the source domain (it is now checked in testBasicPointFunctors).
-    (Bertrand Kerautret, [987](https://github.com/DGtal-team/DGtal/pull/987)).
+    (Bertrand Kerautret, [989](https://github.com/DGtal-team/DGtal/pull/989)).
 
 
 

--- a/src/DGtal/kernel/BasicPointFunctors.h
+++ b/src/DGtal/kernel/BasicPointFunctors.h
@@ -612,14 +612,14 @@ namespace functors
                                                      myGridShift(aGridShift),
                                                      myGridSize(aGridSize)
     {
-      Point domainUpperBound;
+      Point domainUpperBound=aSourceDomain.upperBound();
+      Point domainLowerBound=aSourceDomain.lowerBound();
+
       for (Dimension dim=0; dim< Space::dimension; dim++){
-        Dimension sizeInDim = (aSourceDomain.upperBound()[dim] - 
-                               aSourceDomain.lowerBound()[dim]+1)/aGridSize[dim]-1;
-        domainUpperBound[dim]=sizeInDim;
+        domainLowerBound[dim] /= aGridSize[dim];
+        domainUpperBound[dim] /= aGridSize[dim];
       }
-      domainUpperBound + aSourceDomain.lowerBound();
-      myNewDomain = TDomain(aSourceDomain.lowerBound(), 
+      myNewDomain = TDomain(domainLowerBound, 
                             domainUpperBound);
       Point upperGrid;
       for (Dimension dim=0; dim < Space::dimension; dim++)
@@ -636,8 +636,8 @@ namespace functors
      * returns a point belonging to the source domain. If such a point
      * does not exits it return the point with null coordinates.
      *
-     * @param aPoint a point which should  elong to the new domain.  
-     * @return the point to be taken in the * subsampled domain.
+     * @param aPoint a point which should  belong to the new domain.  
+     * @return the point to be taken in the subsampled domain.
      *
      */
     
@@ -660,8 +660,8 @@ namespace functors
         // we are looking for a point inside the domain
         for(typename TDomain::ConstIterator it = myGridSampleDomain.begin();
             it!= myGridSampleDomain.end(); it++){
-          if (mySourceDomain.isInside(*it))
-            return *it;
+          if (mySourceDomain.isInside(ptRes+(*it)))
+            return ptRes+(*it);
         }
       }
       return ptRes;

--- a/tests/kernel/testBasicPointFunctors.cpp
+++ b/tests/kernel/testBasicPointFunctors.cpp
@@ -212,11 +212,16 @@ bool testProjector()
     trace.info()<< "Subsampling functor on 3D domain " << domainSource3D <<" with grid size " 
                 << aGridSize3D[0] << " " << aGridSize3D[1]<< " " << aGridSize3D[2] << " and shift vector "<< shiftVector3D <<std::endl ;
     PointVector<3,int> pointTest3D(0,1,2);
+    PointVector<3,int> pointTest3D2(0,0,0);
     PointVector<3,int> pointInSourceDomain3D = subSampler3D(pointTest3D);
+    PointVector<3,int> pointInSourceDomain3D2 = subSampler3D(pointTest3D2);
     trace.info() << "Sampling point of coordinate "<< pointTest3D << ", => coordinates in source domain:" 
                  << pointInSourceDomain3D << " == " << PointVector<3,int>(0, 4, 1) << std::endl; 
+    trace.info() << "Sampling point of coordinate "<< pointTest3D2 << ", => coordinates in source domain:" 
+                 << pointInSourceDomain3D2 << " == " << PointVector<3,int>(0, 1, 0) << std::endl; 
     nb++;
-    nbok += (pointInSourceDomain3D== PointVector<3,int>(0, 4, 1));
+    nbok += (pointInSourceDomain3D== PointVector<3,int>(0, 4, 1)) && 
+            (pointInSourceDomain3D2== PointVector<3,int>(0, 1, 0));
 
   // FlipDomainAxis
     std::vector<unsigned int> vectFlip; 


### PR DESCRIPTION
BasicDomainSubSampler can now handle non 0 origin point. This update also correct the search of point which are outside the source domain.
It also fix the issue #210 of DGTalTools.