### PR TITLE
Adding of a little more genericity in ImageHelper.h

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,10 @@
    Levall1ois [#935](https://github.com/DGtal-team/DGtal/pull/935),
    backport from imagene)
 
+- *Image Package*
+ - Adding copy between images of different types. (Roland Denis [#1001]
+   (https://github.com/DGtal-team/DGtal/pull/1001))
+
 - *IO Package*
  - Limited interaction added to QGLViewer Viewer3D class. The user
    may assign integer identifiers (OpenGL names) to surfels and

--- a/src/DGtal/images/ImageHelper.h
+++ b/src/DGtal/images/ImageHelper.h
@@ -311,7 +311,7 @@ namespace DGtal
    * @return 'true' if a new point is found and the value read 
    * but 'false' otherwise
    *
-   * @tparam I any model of CImage
+   * @tparam I any model of CConstImage
    * @tparam S any model of CDigitalSet
    *
    * The general behavior is like: 

--- a/src/DGtal/images/ImageHelper.h
+++ b/src/DGtal/images/ImageHelper.h
@@ -198,10 +198,11 @@ namespace DGtal
    * @param aImg1 the image to fill
    * @param aImg2 the image to copy
    *
-   * @tparam I any model of CImage
+   * @tparam I1 any model of CImage
+   * @tparam I2 any model of CConstImage
    */
-  template<typename I>
-  void imageFromImage(I& aImg1, const I& aImg2); 
+  template<typename I1, typename I2>
+  void imageFromImage(I1& aImg1, const I2& aImg2); 
 
   /**
    * Insert @a aPoint in @a aSet and if (and only if)

--- a/src/DGtal/images/ImageHelper.h
+++ b/src/DGtal/images/ImageHelper.h
@@ -351,7 +351,7 @@ namespace DGtal
     typedef typename Image::Point Point;
     typedef TValue Value;
     
-    BOOST_CONCEPT_ASSERT(( concepts::CImage<Image> ));
+    BOOST_CONCEPT_ASSERT(( concepts::CConstImage<Image> ));
     BOOST_CONCEPT_ASSERT(( concepts::CPointPredicate<PointPredicate> ));
     BOOST_CONCEPT_ASSERT(( CQuantity<Value> ));
     
@@ -386,7 +386,7 @@ namespace DGtal
      * 
      * @return val between _ZERO_ or aVal
      */
-    Value operator()( const Point &aPoint )
+    Value operator()( const Point &aPoint ) const
     {
       if ((myImage->domain().isInside(aPoint)))
       {

--- a/src/DGtal/images/ImageHelper.ih
+++ b/src/DGtal/images/ImageHelper.ih
@@ -150,14 +150,15 @@ DGtal::imageFromFunctor(I& aImg, const F& aFun)
 }
 
 //------------------------------------------------------------------------------
-template<typename I>
+template<typename I1, typename I2>
 inline
 void 
-DGtal::imageFromImage(I& aImg1, const I& aImg2)
+DGtal::imageFromImage(I1& aImg1, const I2& aImg2)
 {
-  BOOST_CONCEPT_ASSERT(( concepts::CImage<I> )); 
+  BOOST_CONCEPT_ASSERT(( concepts::CImage<I1> )); 
+  BOOST_CONCEPT_ASSERT(( concepts::CConstImage<I2> )); 
 
-  typename I::ConstRange r = aImg2.constRange(); 
+  typename I2::ConstRange r = aImg2.constRange(); 
   std::copy( r.begin(), r.end(), aImg1.range().outputIterator() ); 
 }
 

--- a/src/DGtal/images/ImageHelper.ih
+++ b/src/DGtal/images/ImageHelper.ih
@@ -342,7 +342,7 @@ DGtal::findAndGetValue(const I& aImg, const S& aSet,
 		       typename I::Value& aValue ) 
 {
   
-  BOOST_CONCEPT_ASSERT(( concepts::CImage<I> )); 
+  BOOST_CONCEPT_ASSERT(( concepts::CConstImage<I> )); 
   BOOST_CONCEPT_ASSERT(( concepts::CDigitalSet<S> )); 
   BOOST_STATIC_ASSERT(( boost::is_same< typename I::Point, typename S::Point >::value ));
 

--- a/tests/kernel/testImagesSetsUtilities.cpp
+++ b/tests/kernel/testImagesSetsUtilities.cpp
@@ -114,7 +114,7 @@ bool testImageFromSet()
 
   Image image3 = image;
   //fill image3 from image2
-  imageFromImage(image3, image2);
+  imageFromImage(image3, const_cast<Image const&>(image2));
   //image2 and image3 should be equal,
   //but both different from image
   Image::ConstRange rimg = image.constRange();


### PR DESCRIPTION
Changes are:
- enabling `imageFromImage` for two different images type with `CConstImage` concept check on source image,
- `CConstImage` concept check and const-correctness in `ImageToConstantFunctor`,
- checking `CConstImage` instead of `CImage` in `findAndGetValue`.
