### PR TITLE
Linearizer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -130,6 +130,8 @@
 - *Kernel Package*
   - HyperRectDomain can now be empty (lowerBound == upperBound + diagonal(1)). Warning about the use 
     of lexicographical order in comparison operators of PointVector. (Roland Denis, [#996](https://github.com/DGtal-team/DGtal/pull/996))
+  - Adds generic linearization (point to index) and reverse process (index to point), specialized for HyperRectDomain.
+    (Roland Denis, [#1039](https://github.com/DGtal-team/DGtal/pull/1039))
 
 - *Shapes Package*
  - Adds a vertex Iterator in the Mesh class in addition to the

--- a/src/DGtal/images/ImageContainerBySTLVector.ih
+++ b/src/DGtal/images/ImageContainerBySTLVector.ih
@@ -38,6 +38,7 @@
 
 //////////////////////////////////////////////////////////////////////////////
 #include <cstdlib>
+#include <DGtal/kernel/domains/Linearizer.h>
 //////////////////////////////////////////////////////////////////////////////
 
 //------------------------------------------------------------------------------
@@ -179,112 +180,6 @@ DGtal::ImageContainerBySTLVector<D, V>::className() const
   return "ImageContainerBySTLVector";
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Helper classes defined in the compilation unit (anonymous namespace)
-
-namespace
-{
-
-  /**
-   * Class template for linearization of the coordinates of a Point.
-   * This class template is to be specialized for efficiency for dimensions 1,
-   * 2 and 3 to prevent the use of a loop in these cases.
-   *
-   * @tparam Domain an instance of HyperRectDomain
-   * @tparam dimension domain dimension
-   */
-  template < typename Domain, int dimension>
-  struct linearizer
-  {
-
-    typedef typename Domain::Point Point;
-    typedef typename Domain::Size Size;
-
-    /**
-     * Compute the linearized offset of a point in a vector container.
-     *
-     * @param aPoint a point
-     * @param lowerBound lower bound of the image domain.
-     * @param extent extension of the image domain.
-     *
-     * @return the index
-     */
-    static Size apply( const Point & aPoint, const Point & lowerBound,
-        const Point & extent )
-    {
-      Size pos = aPoint[ 0 ] - lowerBound[ 0 ] ;
-      Size multiplier = 1;
-      for (typename Domain::Dimension k = 1 ; k < dimension ; ++k)
-      {
-        multiplier *= extent[ k-1  ];
-        pos += multiplier * ( aPoint[ k ] - lowerBound[ k ] );
-      }
-      return pos;
-    }
-  };
-
-  /**
-   * Specialization of the linearizer class for dimension 1.
-   *
-   */
-  template < typename Domain >
-  struct linearizer< Domain, 1 >
-  {
-    typedef typename Domain::Point Point;
-    typedef typename Domain::Size Size;
-
-    static Size apply( const Point & aPoint,
-        const Point & lowerBound,
-        const Point & /*extent*/ )
-    {
-      return aPoint[ 0 ] - lowerBound[ 0 ];
-    }
-  };
-
-  /**
-   * Specialization of the linearizer class for dimension 2.
-   *
-   */
-  template < typename Domain >
-  struct linearizer< Domain, 2 >
-  {
-    typedef typename Domain::Point Point;
-    typedef typename Domain::Size Size;
-
-    static Size apply( const Point & aPoint,
-        const Point & lowerBound,
-        const Point & extent )
-    {
-      return ( aPoint[ 0 ] - lowerBound[ 0 ] ) + extent[ 0 ] *
-	(aPoint[ 1 ] - lowerBound[ 1 ] );
-    }
-  };
-
-  /**
-   * Specialization of the linearizer class for dimension 3.
-   *
-   */
-  template < typename Domain >
-  struct linearizer< Domain, 3 >
-  {
-    typedef typename Domain::Point Point;
-    typedef typename Domain::Size Size;
-
-    static Size apply( const Point & aPoint,
-        const Point & lowerBound,
-        const Point & extent )
-    {
-      Size res = aPoint[ 0 ] - lowerBound[ 0 ];
-      Size multiplier = extent[ 0 ];
-      res += multiplier * ( aPoint[ 1 ] - lowerBound[ 1 ] );
-      multiplier *= extent[ 1 ];
-      res += multiplier * ( aPoint[ 2 ] - lowerBound[ 2 ] );
-      return res;
-    }
-  };
-}
-
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Internals - private :
@@ -293,9 +188,7 @@ inline
 typename DGtal::ImageContainerBySTLVector<Domain, T>::Size
 DGtal::ImageContainerBySTLVector<Domain, T>::linearized(const Point &aPoint) const
 {
-  return linearizer<Domain, Domain::dimension >::apply( aPoint,
-							myDomain.lowerBound(),
-							myExtent );
+  return DGtal::Linearizer<Domain, ColMajorStorage>::getIndex( aPoint, myDomain.lowerBound(), myExtent );
 }
 
 

--- a/src/DGtal/kernel/domains/HyperRectDomain_Iterator.h
+++ b/src/DGtal/kernel/domains/HyperRectDomain_Iterator.h
@@ -236,7 +236,7 @@ namespace DGtal
                 if ( current_pos < TPoint::dimension )
                   ++myPoint[current_pos];
               }
-            while (( current_pos < TPoint::dimension - 1 ) &&
+            while (( current_pos + 1 < TPoint::dimension ) &&
                 ( myPoint[ current_pos ]  >  myupper[ current_pos ] ) );
           }
       }
@@ -279,7 +279,7 @@ namespace DGtal
                 if ( current_pos < TPoint::dimension )
                   --myPoint[ current_pos ];
               }
-            while (( current_pos < TPoint::dimension - 1 ) &&
+            while (( current_pos + 1 < TPoint::dimension ) &&
                 ( myPoint[ current_pos ]  <  mylower[ current_pos ] ) );
           }
       }
@@ -464,7 +464,7 @@ namespace DGtal
                 if ( current_pos < mySubDomain.size() )
                   ++myPoint[ mySubDomain[current_pos] ];
               }
-            while (( current_pos < mySubDomain.size() - 1  ) &&
+            while (( current_pos + 1 < mySubDomain.size() ) &&
                 ( myPoint[ mySubDomain[current_pos] ]  >
                   myupper[ mySubDomain[current_pos] ] ) );
           }
@@ -512,7 +512,7 @@ namespace DGtal
                 if ( current_pos < mySubDomain.size() )
                   --myPoint[ mySubDomain[current_pos] ];
               }
-            while (( current_pos < mySubDomain.size() - 1 ) &&
+            while (( current_pos + 1 < mySubDomain.size() ) &&
                 ( myPoint[ mySubDomain[current_pos] ]  <
                   mylower[ mySubDomain[current_pos] ] ) );
           }

--- a/src/DGtal/kernel/domains/Linearizer.h
+++ b/src/DGtal/kernel/domains/Linearizer.h
@@ -1,0 +1,193 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+#pragma once
+
+/**
+ * @file Linearizer.h
+ * @author Roland Denis (\c roland.denis@univ-smb.fr )
+ * LAboratory of MAthematics - LAMA (CNRS, UMR 5127), University of Savoie, France
+ *
+ * @date 2015/06/18
+ *
+ * This file is part of the DGtal library.
+ */
+
+#if defined(Linearizer_RECURSES)
+#error Recursive header files inclusion detected in Linearizer.h
+#else // defined(Linearizer_RECURSES)
+/** Prevents recursive inclusion of headers. */
+#define Linearizer_RECURSES
+
+#if !defined Linearizer_h
+/** Prevents repeated inclusion of headers. */
+#define Linearizer_h
+
+//////////////////////////////////////////////////////////////////////////////
+// Inclusions
+#include <DGtal/kernel/domains/HyperRectDomain.h> // Only for specialization purpose.
+//////////////////////////////////////////////////////////////////////////////
+
+namespace DGtal
+{
+
+  /////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @brief Tag (empty structure) specifying a row-major storage order.
+   *
+   * @see Linearizer
+   */
+  struct RowMajorStorage {};
+
+  /**
+   * @brief Tag (empty structure) specifying a col-major storage order.
+   *
+   * @see Linearizer
+   */
+  struct ColMajorStorage {};
+
+  /////////////////////////////////////////////////////////////////////////////
+  /**
+   * @brief Aim: Linearization and de-linearization interface for domains.
+   *
+   * Description of class 'Linearizer' <p>
+   * This class is empty but there is a specialization for HyperRectDomain.
+   *
+   * @tparam  TDomain       Type of the domain.
+   * @tparam  TStorageOrder Storage Order (RowMajorStorage of ColMajorStorage).
+   *
+   */
+  template <
+      typename TDomain,
+      typename TStorageOrder = ColMajorStorage
+    >
+  struct Linearizer;
+
+  /**
+   * @brief Aim: Linearization and de-linearization interface for HyperRectDomain.
+   *
+   * This is a static class that provides point linearization (point to index) and de-linearization (index to point) for storages working on HyperRectDomain.
+   *
+   * The storage order can be specified by template (default is colum-major ordered).
+   *
+   * Example:
+   * @code
+   * typedef SpaceND<2>             Space;
+   * tydedef HyperRectDomain<Space> Domain;
+   * typedef typename Space::Point  Point;
+   *
+   * const Domain domain( Point(0, 1), Point(4, 3) );
+   *
+   * size_t id = Linearizer<Domain>::getIndex( Point(2, 2), domain ); // returns 7.
+   *
+   * Point pt = Linearizer<Domain>::getPoint( 7, domain); // returns Point(2,2).
+   * @endcode
+   *
+   * @tparam  TSpace       Type of the space of the HyperRectDomain (auto-deduced from TDomain template, see Linearizer).
+   * @tparam  TStorageOrder Storage Order (RowMajorStorage of ColMajorStorage).
+   */
+  template <
+      typename TSpace,
+      typename TStorageOrder
+    >
+  struct Linearizer< HyperRectDomain<TSpace>, TStorageOrder >
+    {
+      // Usefull typedefs
+      typedef HyperRectDomain<TSpace> Domain; ///< The domain type.
+      typedef typename TSpace::Point Point;   ///< The point type.
+      typedef Point Extent;                   ///< The domain's extent type.
+      typedef typename TSpace::Size  Size;    ///< The space's size type.
+
+      /** Linearized index of a point, given the domain lower-bound and extent.
+       *
+       * @param[in] aPoint      The point to be linearized.
+       * @param[in] aLowerBound The lower-bound of the domain.
+       * @param[in] anExtent    The extent of the domain.
+       * @return the linearized index of the point.
+       */
+      static inline
+      Size getIndex( Point aPoint, Point const& aLowerBound, Extent const& anExtent );
+
+      /** Linearized index of a point, given the domain extent.
+       *
+       * The lower-bound of the domain is defined to the origin.
+       *
+       * @param[in] aPoint    The Point to be linearized.
+       * @param[in] anExtent  The extent of the domain.
+       * @return the linearized index of the point.
+       */
+      static inline
+      Size getIndex( Point aPoint, Extent const& anExtent );
+
+      /** Linearized index of a point, given a domain.
+       *
+       * @param[in] aPoint    The Point to be linearized.
+       * @param[in] aDomain   The domain.
+       * @return the linearized index of the point.
+       */
+      static inline
+      Size getIndex( Point aPoint, Domain const& aDomain );
+
+      /** De-linearization of an index, given the domain lower-bound and extent.
+       *
+       * @param[in] anIndex     The linearized index.
+       * @param[in] aLowerBound The lower-bound of the domain.
+       * @param[in] anExtent    The domain extent.
+       * @return  the point whose linearized index is anIndex.
+       */
+      static inline
+      Point getPoint( Size anIndex, Point const& aLowerBound, Extent const& anExtent );
+
+      /** De-linearization of an index, given the domain extent.
+       *
+       * The lower-bound of the domain is set to the origin.
+       *
+       * @param[in] anIndex   The linearized index.
+       * @param[in] anExtent  The domain extent.
+       * @return  the point whose linearized index is anIndex.
+       */
+      static inline
+      Point getPoint( Size anIndex, Extent const& anExtent );
+
+      /** De-linearization of an index, given a domain.
+       *
+       * @param[in] anIndex   The linearized index.
+       * @param[in] aDomain   The domain.
+       * @return  the point whose linearized index is anIndex.
+       */
+      static inline
+      Point getPoint( Size anIndex, Domain const& aDomain );
+
+  }; // end of class Linearizer
+
+} // namespace DGtal
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Includes inline functions.
+#include "DGtal/kernel/domains/Linearizer.ih"
+
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#endif // !defined Linearizer_h
+
+#undef Linearizer_RECURSES
+#endif // else defined(Linearizer_RECURSES)
+
+/* GNU coding style */
+/* vim: set ts=2 sw=2 expandtab cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 : */

--- a/src/DGtal/kernel/domains/Linearizer.h
+++ b/src/DGtal/kernel/domains/Linearizer.h
@@ -92,7 +92,7 @@ namespace DGtal
    *
    * const Domain domain( Point(0, 1), Point(4, 3) );
    *
-   * size_t id = Linearizer<Domain>::getIndex( Point(2, 2), domain ); // returns 7.
+   * typename Linearizer<Domain>::Size id = Linearizer<Domain>::getIndex( Point(2, 2), domain ); // returns 7.
    *
    * Point pt = Linearizer<Domain>::getPoint( 7, domain); // returns Point(2,2).
    * @endcode
@@ -189,5 +189,3 @@ namespace DGtal
 #undef Linearizer_RECURSES
 #endif // else defined(Linearizer_RECURSES)
 
-/* GNU coding style */
-/* vim: set ts=2 sw=2 expandtab cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 : */

--- a/src/DGtal/kernel/domains/Linearizer.ih
+++ b/src/DGtal/kernel/domains/Linearizer.ih
@@ -133,7 +133,7 @@ namespace DGtal
         static inline
         void apply( TPoint& aPoint, TExtent const& anExtent, TSize anIndex )
           {
-            const auto dim_extent = anExtent[ linearizer_helper<TStorageOrder, N, I>::dim ];
+            typename TExtent::Scalar const dim_extent = anExtent[ linearizer_helper<TStorageOrder, N, I>::dim ];
             aPoint[ linearizer_helper<TStorageOrder, N, I>::dim ] = anIndex % dim_extent;
             delinearizer_impl< TStorageOrder, N, I-1 >::apply( aPoint, anExtent, anIndex / dim_extent );
           }
@@ -191,7 +191,7 @@ namespace DGtal
   Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::
       getPoint( Size anIndex, Point const& aLowerBound, Extent const& anExtent )
     {
-      Point point{};
+      Point point;
       delinearizer_impl<TStorageOrder, Domain::dimension>::apply(point, anExtent, anIndex);
       return point + aLowerBound;
     }
@@ -202,7 +202,7 @@ namespace DGtal
   Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::
       getPoint( Size anIndex, Extent const& anExtent )
     {
-      Point point{};
+      Point point;
       delinearizer_impl<TStorageOrder, Domain::dimension>::apply(point, anExtent, anIndex);
       return point;
     }
@@ -213,7 +213,7 @@ namespace DGtal
   Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::
       getPoint( Size anIndex, Domain const& aDomain )
     {
-      Point point{};
+      Point point;
       linearizer_impl<Size, TStorageOrder, Domain::dimension>::apply(point, aDomain.upperBound()-aDomain.lowerBound()+Point::diagonal(1), anIndex);
       return point + aDomain.lowerBound();
     }

--- a/src/DGtal/kernel/domains/Linearizer.ih
+++ b/src/DGtal/kernel/domains/Linearizer.ih
@@ -220,5 +220,3 @@ namespace DGtal
 
 } // namespace DGtal
 
-/* GNU coding style */
-/* vim: set ts=2 sw=2 expandtab cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 : */

--- a/src/DGtal/kernel/domains/Linearizer.ih
+++ b/src/DGtal/kernel/domains/Linearizer.ih
@@ -214,7 +214,7 @@ namespace DGtal
       getPoint( Size anIndex, Domain const& aDomain )
     {
       Point point;
-      linearizer_impl<Size, TStorageOrder, Domain::dimension>::apply(point, aDomain.upperBound()-aDomain.lowerBound()+Point::diagonal(1), anIndex);
+      delinearizer_impl<TStorageOrder, Domain::dimension>::apply(point, aDomain.upperBound()-aDomain.lowerBound()+Point::diagonal(1), anIndex);
       return point + aDomain.lowerBound();
     }
 

--- a/src/DGtal/kernel/domains/Linearizer.ih
+++ b/src/DGtal/kernel/domains/Linearizer.ih
@@ -1,0 +1,224 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file Linearizer.ih
+ * @author Roland Denis (\c roland.denis@univ-smb.fr )
+ * LAboratory of MAthematics - LAMA (CNRS, UMR 5127), University of Savoie, France
+ *
+ * @date 2015/06/18
+ *
+ * This file is part of the DGtal library.
+ */
+
+
+//////////////////////////////////////////////////////////////////////////////
+#include <cstddef>
+//////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// IMPLEMENTATION of inline methods.
+///////////////////////////////////////////////////////////////////////////////
+
+namespace DGtal
+{
+
+  /// Tools
+  namespace
+  {
+
+    /** Helper that calculates the dimension index given the current linearization step.
+     *
+     * The step I is always decrementing from N-1 to 0.
+     *
+     * @tparam TStorageOrder  Storage order (RowMajorStorage of ColMajorStorage).
+     * @tparam N              Dimension of the space.
+     * @tparam I              Current step.
+     */
+    template < typename TStorageOrder, std::size_t N, std::size_t I >
+    struct linearizer_helper;
+
+    template < std::size_t N, std::size_t I >
+    struct linearizer_helper< RowMajorStorage, N, I >
+      {
+        enum { dim = I }; ///< Dimension index related to the step I.
+      };
+
+    template < std::size_t N, std::size_t I >
+    struct linearizer_helper< ColMajorStorage, N, I >
+      {
+        enum { dim = N-1 - I }; ///< Dimension index related to the step I.
+      };
+
+    /** Templated static structure for linearization of the coordinates of a point.
+     *
+     * @tparam TSize  Type of the linearizared index.
+     * @tparam TStorageOrder  Storage order (RowMajorStorage of ColMajorStorage).
+     * @tparam N      Dimension of the space.
+     * @tparam I      Current step.
+     */
+    template < typename TSize, typename TStorageOrder, std::size_t N, std::size_t I = N-1  >
+    struct linearizer_impl
+      {
+
+        /**
+         * Return the linearized index from the coordinates of a point.
+         *
+         * @tparam    TPoint    Type of the point.
+         * @tparam    TExtent   Type of the domain's extent.
+         * @param[in] aPoint    The point to linearize.
+         * @param[in] anExtent  The extent of the domain.
+         * @return    the linearized index of the point.
+         */
+        template < typename TPoint, typename TExtent >
+        static inline
+        TSize apply( TPoint const& aPoint, TExtent const& anExtent )
+          {
+            return
+                aPoint[ linearizer_helper<TStorageOrder, N, I>::dim ]
+              + anExtent[ linearizer_helper<TStorageOrder, N, I>::dim ] * linearizer_impl< TSize, TStorageOrder, N, I-1 >::apply( aPoint, anExtent );
+          }
+      };
+
+    /**
+     * Specialization of the structure linearizer_impl for the last step.
+     *
+     * It is actually used as a terminate condition of the recursive process.
+     */
+    template < typename TSize, typename TStorageOrder, std::size_t N >
+    struct linearizer_impl< TSize, TStorageOrder, N, 0 >
+      {
+        template < typename TPoint, typename TExtent >
+        static inline
+        TSize apply( TPoint const& aPoint, TExtent const& /* anExtent */ )
+          {
+            return aPoint[ linearizer_helper<TStorageOrder, N, 0>::dim ];
+          }
+      };
+
+    /** Templated static structure for de-linearization of a point index.
+     *
+     * @tparam TStorageOrder  Storage order (RowMajorStorage of ColMajorStorage).
+     * @tparam N      Dimension of the space.
+     * @tparam I      Current step.
+     */
+    template < typename TStorageOrder, std::size_t N, std::size_t I = N-1  >
+    struct delinearizer_impl
+      {
+
+        /**
+         * Return the de-linearized point from the linearized index of the point.
+         *
+         * @tparam    TPoint    Type of the point.
+         * @tparam    TExtent   Type of the domain's extent.
+         * @tparam    TSize     Type of the linearized index.
+         * @param[out]  aPoint    The point after de-linearization.
+         * @param[in]   anExtent  The extent of the domain.
+         * @param[in]   anIndex   The linearized index of the point.
+         */
+        template < typename TPoint, typename TExtent, typename TSize >
+        static inline
+        void apply( TPoint& aPoint, TExtent const& anExtent, TSize anIndex )
+          {
+            const auto dim_extent = anExtent[ linearizer_helper<TStorageOrder, N, I>::dim ];
+            aPoint[ linearizer_helper<TStorageOrder, N, I>::dim ] = anIndex % dim_extent;
+            delinearizer_impl< TStorageOrder, N, I-1 >::apply( aPoint, anExtent, anIndex / dim_extent );
+          }
+      };
+
+    /**
+     * Specialization of the structure delinearizer_impl for the last step.
+     *
+     * It is actually used as a terminate condition of the recursive process.
+     */
+    template < typename TStorageOrder, std::size_t N >
+    struct delinearizer_impl< TStorageOrder, N, 0 >
+      {
+        template < typename TPoint, typename TExtent, typename TSize >
+        static inline
+        void apply( TPoint& aPoint, TExtent const& /* anExtent */, TSize anIndex )
+          {
+            aPoint[ linearizer_helper<TStorageOrder, N, 0>::dim ] = anIndex;
+          }
+      };
+
+  } // anonymous namespace
+
+  /// Linearized index of a point, given the domain lower-bound and extent.
+  template <typename TSpace, typename TStorageOrder>
+  typename Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::Size
+  Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::
+      getIndex( Point aPoint, Point const& aLowerBound, Extent const& anExtent )
+    {
+      aPoint -= aLowerBound;
+      return linearizer_impl<Size, TStorageOrder, Domain::dimension>::apply(aPoint, anExtent);
+    }
+
+  /// Linearized index of a point, given the domain extent.
+  template <typename TSpace, typename TStorageOrder>
+  typename Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::Size
+  Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::
+      getIndex( Point aPoint, Extent const& anExtent )
+    {
+      return linearizer_impl<Size, TStorageOrder, Domain::dimension>::apply(aPoint, anExtent);
+    }
+
+  /// Linearized index of a point, given a domain.
+  template <typename TSpace, typename TStorageOrder>
+  typename Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::Size
+  Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::
+      getIndex( Point aPoint, Domain const& aDomain )
+    {
+      return linearizer_impl<Size, TStorageOrder, Domain::dimension>::apply(aPoint - aDomain.lowerBound(), aDomain.upperBound()-aDomain.lowerBound()+Point::diagonal(1));
+    }
+
+  /// De-linearization of an index, given the domain lower-bound and extent.
+  template <typename TSpace, typename TStorageOrder>
+  typename Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::Point
+  Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::
+      getPoint( Size anIndex, Point const& aLowerBound, Extent const& anExtent )
+    {
+      Point point{};
+      delinearizer_impl<TStorageOrder, Domain::dimension>::apply(point, anExtent, anIndex);
+      return point + aLowerBound;
+    }
+
+  /// De-linearization of an index, given the domain extent.
+  template <typename TSpace, typename TStorageOrder>
+  typename Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::Point
+  Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::
+      getPoint( Size anIndex, Extent const& anExtent )
+    {
+      Point point{};
+      delinearizer_impl<TStorageOrder, Domain::dimension>::apply(point, anExtent, anIndex);
+      return point;
+    }
+
+  /// De-linearization of an index, given a domain.
+  template <typename TSpace, typename TStorageOrder>
+  typename Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::Point
+  Linearizer< HyperRectDomain<TSpace>, TStorageOrder >::
+      getPoint( Size anIndex, Domain const& aDomain )
+    {
+      Point point{};
+      linearizer_impl<Size, TStorageOrder, Domain::dimension>::apply(point, aDomain.upperBound()-aDomain.lowerBound()+Point::diagonal(1), anIndex);
+      return point + aDomain.lowerBound();
+    }
+
+} // namespace DGtal
+
+/* GNU coding style */
+/* vim: set ts=2 sw=2 expandtab cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 : */

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -12,6 +12,7 @@ SET(DGTAL_TESTS_SRC_KERNEL
    testBasicPointFunctors
    testEmbedder
    testPointPredicateConcepts
+   testLinearizer
    )
 
 

--- a/tests/kernel/testLinearizer.cpp
+++ b/tests/kernel/testLinearizer.cpp
@@ -144,103 +144,6 @@ namespace
   };
 }
 
-// Test for Linearizer with dimension parameter
-template < DGtal::Dimension N >
-class LinearizerTester
-{
-public:
-  typedef SpaceND<N>              Space;
-  typedef HyperRectDomain<Space>  Domain;
-  typedef typename Space::Point   Point;
-
-  typedef linearizer<Domain, N>   RefLinearizer;
-  typedef Linearizer<Domain, ColMajorStorage>   NewLinearizer;
-
-private:
-  Domain myDomain;
-
-public:
-  /// Construct a test domain whose size is near the given size.
-  LinearizerTester( std::size_t size = 1e5 )
-    {
-      Point lowerBound;
-      for ( std::size_t i = 0 ; i < N ; ++i )
-        lowerBound[i] = 1 + 7*i;
-
-      std::size_t dim_size = std::size_t( std::pow( double(size), 1./N ) + 0.5 );
-      Point upperBound;
-      for ( std::size_t i = 0; i < N ; ++i )
-        upperBound[i] = lowerBound[i] + dim_size + i;
-
-      myDomain = Domain( lowerBound, upperBound );
-    }
-
-  /// Test getIndex( Point, Point, Extent ) syntax
-  bool testGetIndexFromPPE()
-    {
-      const Point lowerBound = myDomain.lowerBound();
-      const Point extent = myDomain.upperBound() - lowerBound + Point::diagonal(1);
-
-      bool success = true;
-      for ( typename Domain::ConstIterator it = myDomain.begin(), it_end = myDomain.end(); it != it_end && success ; ++it )
-        {
-          if ( RefLinearizer::apply( *it, lowerBound, extent ) != NewLinearizer::getIndex( *it, lowerBound, extent ) )
-            {
-              FAIL( "Index is different for " << *it );
-              success = false;
-            }
-        }
-
-      return success;
-    }
-
-  /// Test getIndex( Point, Extent ) syntax
-  bool testGetIndexFromPE()
-    {
-      const Point lowerBound = myDomain.lowerBound();
-      const Point extent = myDomain.upperBound() - lowerBound + Point::diagonal(1);
-
-      bool success = true;
-      for ( typename Domain::ConstIterator it = myDomain.begin(), it_end = myDomain.end(); it != it_end && success ; ++it )
-        {
-          if ( RefLinearizer::apply( *it, lowerBound, extent ) != NewLinearizer::getIndex( *it - lowerBound, extent ) )
-            {
-              FAIL( "Index is different for " << *it );
-              success = false;
-            }
-        }
-
-      return success;
-    }
-
-  /// Test getIndex( Point, Domain ) syntax
-  bool testGetIndexFromPD()
-    {
-      const Point lowerBound = myDomain.lowerBound();
-      const Point extent = myDomain.upperBound() - lowerBound + Point::diagonal(1);
-
-      bool success = true;
-      for ( typename Domain::ConstIterator it = myDomain.begin(), it_end = myDomain.end(); it != it_end && success ; ++it )
-        {
-          if ( RefLinearizer::apply( *it, lowerBound, extent ) != NewLinearizer::getIndex( *it, myDomain ) )
-            {
-              FAIL( "Index is different for " << *it );
-              success = false;
-            }
-        }
-
-      return success;
-    }
-
-  /// Test getPoint( Size, Point, Extent ) syntax
-  bool testGetPointFromSPE()
-    {
-      const Point lowerBound = myDomain.lowerBound();
-      const Point extent = myDomain.upperBound() - lowerBound + Point::diagonal(1);
-      return true;
-
-    }
-};
 
 /// Converter between col-major and row-major storage order.
 template < typename StorageOrder >
@@ -278,7 +181,7 @@ TEST_CASE( "Testing Linearizer in dimension " #N " with " #ORDER, "[test][dim" #
 \
   typedef SpaceND<N>              Space;\
   typedef HyperRectDomain<Space>  Domain;\
-  typedef typename Space::Point   Point;\
+  typedef Space::Point   Point;\
 \
   typedef linearizer<Domain, N>   RefLinearizer;\
   typedef Linearizer<Domain, ORDER>   NewLinearizer;\
@@ -304,19 +207,19 @@ TEST_CASE( "Testing Linearizer in dimension " #N " with " #ORDER, "[test][dim" #
 \
   SECTION( "Testing getIndex(Point, Point, Extent) syntax" )\
     {\
-      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
-          REQUIRE( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, lowerBound, extent ) );\
+      for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+          REQUIRE(( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, lowerBound, extent ) ));\
     }\
 \
   SECTION( "Testing getIndex(Point, Extent) syntax" )\
     {\
-      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+      for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
           REQUIRE( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it - lowerBound, extent ) );\
     }\
 \
   SECTION( "Testing getIndex(Point, Domain) syntax" )\
     {\
-      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+      for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
           REQUIRE( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, domain ) );\
     }\
 \
@@ -345,7 +248,7 @@ TEST_CASE( "Benchmarking Linearizer in dimension " #N " with " #ORDER, "[.bench]
 \
   typedef SpaceND<N>              Space;\
   typedef HyperRectDomain<Space>  Domain;\
-  typedef typename Space::Point   Point;\
+  typedef Space::Point   Point;\
 \
   typedef linearizer<Domain, N>   RefLinearizer;\
   typedef Linearizer<Domain, ORDER>   NewLinearizer;\
@@ -371,32 +274,32 @@ TEST_CASE( "Benchmarking Linearizer in dimension " #N " with " #ORDER, "[.bench]
 \
   std::size_t sum = 0;\
 \
-  for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+  for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
       sum += RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent );\
   REQUIRE( sum > 0 );\
   sum = 0;\
 \
   SECTION( "Benchmarking reference linearizer" )\
     {\
-      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+      for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
           sum += RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent );\
     }\
 \
   SECTION( "Benchmarking getIndex(Point, Point, Extent) syntax" )\
     {\
-      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+      for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
           sum += NewLinearizer::getIndex( *it, lowerBound, extent );\
     }\
 \
   SECTION( "Benchmarking getIndex(Point, Extent) syntax" )\
     {\
-      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+      for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
           sum += NewLinearizer::getIndex( *it, extent );\
     }\
 \
   SECTION( "Benchmarking getIndex(Point, Domain) syntax" )\
     {\
-      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+      for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
           sum += NewLinearizer::getIndex( *it, domain );\
     }\
 \

--- a/tests/kernel/testLinearizer.cpp
+++ b/tests/kernel/testLinearizer.cpp
@@ -214,31 +214,31 @@ TEST_CASE( "Testing Linearizer in dimension " #N " with " #ORDER, "[test][dim" #
   SECTION( "Testing getIndex(Point, Extent) syntax" )\
     {\
       for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
-          REQUIRE( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it - lowerBound, extent ) );\
+          REQUIRE(( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it - lowerBound, extent ) ));\
     }\
 \
   SECTION( "Testing getIndex(Point, Domain) syntax" )\
     {\
       for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
-          REQUIRE( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, domain ) );\
+          REQUIRE(( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, domain ) ));\
     }\
 \
   SECTION( "Testing getPoint(Index, Point, Extent) syntax" )\
     {\
       for ( std::size_t i = 0; i < domain.size(); ++i )\
-          REQUIRE( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, lowerBound, extent ) ), refLowerBound, refExtent ) == i );\
+          REQUIRE(( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, lowerBound, extent ) ), refLowerBound, refExtent ) == i ));\
     }\
 \
   SECTION( "Testing getPoint(Index, Extent) syntax" )\
     {\
       for ( std::size_t i = 0; i < domain.size(); ++i )\
-          REQUIRE( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, extent ) + lowerBound ), refLowerBound, refExtent ) == i );\
+          REQUIRE(( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, extent ) + lowerBound ), refLowerBound, refExtent ) == i ));\
     }\
 \
   SECTION( "Testing getPoint(Index, Domain) syntax" )\
     {\
       for ( std::size_t i = 0; i < domain.size(); ++i )\
-          REQUIRE( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, domain ) ), refLowerBound, refExtent ) == i );\
+          REQUIRE(( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, domain ) ), refLowerBound, refExtent ) == i ));\
     }\
 }
 

--- a/tests/kernel/testLinearizer.cpp
+++ b/tests/kernel/testLinearizer.cpp
@@ -1,0 +1,446 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file testLinearizer.cpp
+ * @ingroup Tests
+ * @author Roland Denis (\c roland.denis@univ-smb.fr )
+ *
+ *
+ * @date 2015/09/10
+ *
+ * This file is part of the DGtal library
+ */
+
+/**
+ * Description of testLinearizer.cpp <p>
+ * Aim: Tests of linearization (point to index) et reverse process (index to point) for HyperRectDomain.
+ */
+
+#include <cstddef>
+#include <cmath>
+
+#include "DGtalCatch.h"
+
+#include <DGtal/kernel/SpaceND.h>
+#include <DGtal/kernel/domains/HyperRectDomain.h>
+#include <DGtal/kernel/domains/Linearizer.h>
+
+using namespace DGtal;
+
+// Previous version of the linearizer, used here for reference results.
+namespace
+{
+
+  /**
+   * Class template for linearization of the coordinates of a Point.
+   * This class template is to be specialized for efficiency for dimensions 1,
+   * 2 and 3 to prevent the use of a loop in these cases.
+   *
+   * @tparam Domain an instance of HyperRectDomain
+   * @tparam dimension domain dimension
+   */
+  template < typename Domain, int dimension>
+  struct linearizer
+  {
+
+    typedef typename Domain::Point Point;
+    typedef typename Domain::Size Size;
+
+    /**
+     * Compute the linearized offset of a point in a vector container.
+     *
+     * @param aPoint a point
+     * @param lowerBound lower bound of the image domain.
+     * @param extent extension of the image domain.
+     *
+     * @return the index
+     */
+    static Size apply( const Point & aPoint, const Point & lowerBound,
+        const Point & extent )
+    {
+      Size pos = aPoint[ 0 ] - lowerBound[ 0 ] ;
+      Size multiplier = 1;
+      for (typename Domain::Dimension k = 1 ; k < dimension ; ++k)
+      {
+        multiplier *= extent[ k-1  ];
+        pos += multiplier * ( aPoint[ k ] - lowerBound[ k ] );
+      }
+      return pos;
+    }
+  };
+
+  /**
+   * Specialization of the linearizer class for dimension 1.
+   *
+   */
+  template < typename Domain >
+  struct linearizer< Domain, 1 >
+  {
+    typedef typename Domain::Point Point;
+    typedef typename Domain::Size Size;
+
+    static Size apply( const Point & aPoint,
+        const Point & lowerBound,
+        const Point & /*extent*/ )
+    {
+      return aPoint[ 0 ] - lowerBound[ 0 ];
+    }
+  };
+
+  /**
+   * Specialization of the linearizer class for dimension 2.
+   *
+   */
+  template < typename Domain >
+  struct linearizer< Domain, 2 >
+  {
+    typedef typename Domain::Point Point;
+    typedef typename Domain::Size Size;
+
+    static Size apply( const Point & aPoint,
+        const Point & lowerBound,
+        const Point & extent )
+    {
+      return ( aPoint[ 0 ] - lowerBound[ 0 ] ) + extent[ 0 ] *
+	(aPoint[ 1 ] - lowerBound[ 1 ] );
+    }
+  };
+
+  /**
+   * Specialization of the linearizer class for dimension 3.
+   *
+   */
+  template < typename Domain >
+  struct linearizer< Domain, 3 >
+  {
+    typedef typename Domain::Point Point;
+    typedef typename Domain::Size Size;
+
+    static Size apply( const Point & aPoint,
+        const Point & lowerBound,
+        const Point & extent )
+    {
+      Size res = aPoint[ 0 ] - lowerBound[ 0 ];
+      Size multiplier = extent[ 0 ];
+      res += multiplier * ( aPoint[ 1 ] - lowerBound[ 1 ] );
+      multiplier *= extent[ 1 ];
+      res += multiplier * ( aPoint[ 2 ] - lowerBound[ 2 ] );
+      return res;
+    }
+  };
+}
+
+// Test for Linearizer with dimension parameter
+template < DGtal::Dimension N >
+class LinearizerTester
+{
+public:
+  typedef SpaceND<N>              Space;
+  typedef HyperRectDomain<Space>  Domain;
+  typedef typename Space::Point   Point;
+
+  typedef linearizer<Domain, N>   RefLinearizer;
+  typedef Linearizer<Domain, ColMajorStorage>   NewLinearizer;
+
+private:
+  Domain myDomain;
+
+public:
+  /// Construct a test domain whose size is near the given size.
+  LinearizerTester( std::size_t size = 1e5 )
+    {
+      Point lowerBound;
+      for ( std::size_t i = 0 ; i < N ; ++i )
+        lowerBound[i] = 1 + 7*i;
+
+      std::size_t dim_size = std::size_t( std::pow( double(size), 1./N ) + 0.5 );
+      Point upperBound;
+      for ( std::size_t i = 0; i < N ; ++i )
+        upperBound[i] = lowerBound[i] + dim_size + i;
+
+      myDomain = Domain( lowerBound, upperBound );
+    }
+
+  /// Test getIndex( Point, Point, Extent ) syntax
+  bool testGetIndexFromPPE()
+    {
+      const Point lowerBound = myDomain.lowerBound();
+      const Point extent = myDomain.upperBound() - lowerBound + Point::diagonal(1);
+
+      bool success = true;
+      for ( typename Domain::ConstIterator it = myDomain.begin(), it_end = myDomain.end(); it != it_end && success ; ++it )
+        {
+          if ( RefLinearizer::apply( *it, lowerBound, extent ) != NewLinearizer::getIndex( *it, lowerBound, extent ) )
+            {
+              FAIL( "Index is different for " << *it );
+              success = false;
+            }
+        }
+
+      return success;
+    }
+
+  /// Test getIndex( Point, Extent ) syntax
+  bool testGetIndexFromPE()
+    {
+      const Point lowerBound = myDomain.lowerBound();
+      const Point extent = myDomain.upperBound() - lowerBound + Point::diagonal(1);
+
+      bool success = true;
+      for ( typename Domain::ConstIterator it = myDomain.begin(), it_end = myDomain.end(); it != it_end && success ; ++it )
+        {
+          if ( RefLinearizer::apply( *it, lowerBound, extent ) != NewLinearizer::getIndex( *it - lowerBound, extent ) )
+            {
+              FAIL( "Index is different for " << *it );
+              success = false;
+            }
+        }
+
+      return success;
+    }
+
+  /// Test getIndex( Point, Domain ) syntax
+  bool testGetIndexFromPD()
+    {
+      const Point lowerBound = myDomain.lowerBound();
+      const Point extent = myDomain.upperBound() - lowerBound + Point::diagonal(1);
+
+      bool success = true;
+      for ( typename Domain::ConstIterator it = myDomain.begin(), it_end = myDomain.end(); it != it_end && success ; ++it )
+        {
+          if ( RefLinearizer::apply( *it, lowerBound, extent ) != NewLinearizer::getIndex( *it, myDomain ) )
+            {
+              FAIL( "Index is different for " << *it );
+              success = false;
+            }
+        }
+
+      return success;
+    }
+
+  /// Test getPoint( Size, Point, Extent ) syntax
+  bool testGetPointFromSPE()
+    {
+      const Point lowerBound = myDomain.lowerBound();
+      const Point extent = myDomain.upperBound() - lowerBound + Point::diagonal(1);
+      return true;
+
+    }
+};
+
+/// Converter between col-major and row-major storage order.
+template < typename StorageOrder >
+struct PointConverter;
+
+template <>
+struct PointConverter<ColMajorStorage>
+{
+  template < typename TPoint >
+  static inline
+  TPoint apply( TPoint const& aPoint )
+    {
+      return aPoint;
+    }
+};
+
+template <>
+struct PointConverter<RowMajorStorage>
+{
+  template < typename TPoint >
+  static inline
+  TPoint apply( TPoint const& aPoint )
+    {
+      TPoint result;
+      for ( std::size_t i = 0 ; i < TPoint::dimension ; ++i )
+        result[i] = aPoint[ TPoint::dimension - i - 1 ];
+
+      return result;
+    }
+};
+
+#define TEST_LINEARIZER( N , ORDER ) \
+TEST_CASE( "Testing Linearizer in dimension " #N " with " #ORDER, "[test][dim" #N "][" #ORDER "]" )\
+{\
+\
+  typedef SpaceND<N>              Space;\
+  typedef HyperRectDomain<Space>  Domain;\
+  typedef typename Space::Point   Point;\
+\
+  typedef linearizer<Domain, N>   RefLinearizer;\
+  typedef Linearizer<Domain, ORDER>   NewLinearizer;\
+\
+  typedef PointConverter<ORDER>   RefConverter;\
+\
+  std::size_t size = 1e3;\
+\
+  Point lowerBound;\
+  for ( std::size_t i = 0 ; i < N ; ++i )\
+    lowerBound[i] = 1 + 7*i;\
+\
+  std::size_t dim_size = std::size_t( std::pow( double(size), 1./N ) + 0.5 );\
+  Point upperBound;\
+  for ( std::size_t i = 0; i < N ; ++i )\
+    upperBound[i] = lowerBound[i] + dim_size + i;\
+\
+  Domain domain( lowerBound, upperBound );\
+  Point extent = upperBound - lowerBound + Point::diagonal(1);\
+\
+  Point refLowerBound = RefConverter::apply(lowerBound);\
+  Point refExtent     = RefConverter::apply(extent);\
+\
+  SECTION( "Testing getIndex(Point, Point, Extent) syntax" )\
+    {\
+      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+          REQUIRE( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, lowerBound, extent ) );\
+    }\
+\
+  SECTION( "Testing getIndex(Point, Extent) syntax" )\
+    {\
+      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+          REQUIRE( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it - lowerBound, extent ) );\
+    }\
+\
+  SECTION( "Testing getIndex(Point, Domain) syntax" )\
+    {\
+      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+          REQUIRE( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, domain ) );\
+    }\
+\
+  SECTION( "Testing getPoint(Index, Point, Extent) syntax" )\
+    {\
+      for ( std::size_t i = 0; i < domain.size(); ++i )\
+          REQUIRE( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, lowerBound, extent ) ), refLowerBound, refExtent ) == i );\
+    }\
+\
+  SECTION( "Testing getPoint(Index, Extent) syntax" )\
+    {\
+      for ( std::size_t i = 0; i < domain.size(); ++i )\
+          REQUIRE( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, extent ) + lowerBound ), refLowerBound, refExtent ) == i );\
+    }\
+\
+  SECTION( "Testing getPoint(Index, Domain) syntax" )\
+    {\
+      for ( std::size_t i = 0; i < domain.size(); ++i )\
+          REQUIRE( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, domain ) ), refLowerBound, refExtent ) == i );\
+    }\
+}
+
+#define BENCH_LINEARIZER( N , ORDER ) \
+TEST_CASE( "Benchmarking Linearizer in dimension " #N " with " #ORDER, "[.bench][dim" #N "][" #ORDER "]" )\
+{\
+\
+  typedef SpaceND<N>              Space;\
+  typedef HyperRectDomain<Space>  Domain;\
+  typedef typename Space::Point   Point;\
+\
+  typedef linearizer<Domain, N>   RefLinearizer;\
+  typedef Linearizer<Domain, ORDER>   NewLinearizer;\
+\
+  typedef PointConverter<ORDER>   RefConverter;\
+\
+  std::size_t size = 1e8;\
+\
+  Point lowerBound;\
+  for ( std::size_t i = 0 ; i < N ; ++i )\
+    lowerBound[i] = 1 + 7*i;\
+\
+  std::size_t dim_size = std::size_t( std::pow( double(size), 1./N ) + 0.5 );\
+  Point upperBound;\
+  for ( std::size_t i = 0; i < N ; ++i )\
+    upperBound[i] = lowerBound[i] + dim_size + i;\
+\
+  Domain domain( lowerBound, upperBound );\
+  Point extent = upperBound - lowerBound + Point::diagonal(1);\
+\
+  Point refLowerBound = RefConverter::apply(lowerBound);\
+  Point refExtent     = RefConverter::apply(extent);\
+\
+  std::size_t sum = 0;\
+\
+  for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+      sum += RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent );\
+  REQUIRE( sum > 0 );\
+  sum = 0;\
+\
+  SECTION( "Benchmarking reference linearizer" )\
+    {\
+      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+          sum += RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent );\
+    }\
+\
+  SECTION( "Benchmarking getIndex(Point, Point, Extent) syntax" )\
+    {\
+      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+          sum += NewLinearizer::getIndex( *it, lowerBound, extent );\
+    }\
+\
+  SECTION( "Benchmarking getIndex(Point, Extent) syntax" )\
+    {\
+      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+          sum += NewLinearizer::getIndex( *it, extent );\
+    }\
+\
+  SECTION( "Benchmarking getIndex(Point, Domain) syntax" )\
+    {\
+      for ( typename Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
+          sum += NewLinearizer::getIndex( *it, domain );\
+    }\
+\
+  SECTION( "Benchmarking getPoint(Index, Point, Extent) syntax" )\
+    {\
+      for ( std::size_t i = 0; i < domain.size(); ++i )\
+          sum += NewLinearizer::getPoint( i, lowerBound, extent )[N-1];\
+    }\
+\
+  SECTION( "Benchmarking getPoint(Index, Extent) syntax" )\
+    {\
+      for ( std::size_t i = 0; i < domain.size(); ++i )\
+          sum += NewLinearizer::getPoint( i, extent )[N-1];\
+    }\
+\
+  SECTION( "Benchmarking getPoint(Index, Domain) syntax" )\
+    {\
+      for ( std::size_t i = 0; i < domain.size(); ++i )\
+          sum += NewLinearizer::getPoint( i, domain )[N-1];\
+    }\
+\
+  REQUIRE( sum > 0 );\
+}
+
+TEST_LINEARIZER( 1, ColMajorStorage )
+TEST_LINEARIZER( 2, ColMajorStorage )
+TEST_LINEARIZER( 3, ColMajorStorage )
+TEST_LINEARIZER( 4, ColMajorStorage )
+TEST_LINEARIZER( 5, ColMajorStorage )
+
+TEST_LINEARIZER( 1, RowMajorStorage )
+TEST_LINEARIZER( 2, RowMajorStorage )
+TEST_LINEARIZER( 3, RowMajorStorage )
+TEST_LINEARIZER( 4, RowMajorStorage )
+TEST_LINEARIZER( 5, RowMajorStorage )
+
+BENCH_LINEARIZER( 1, ColMajorStorage )
+BENCH_LINEARIZER( 2, ColMajorStorage )
+BENCH_LINEARIZER( 3, ColMajorStorage )
+BENCH_LINEARIZER( 4, ColMajorStorage )
+BENCH_LINEARIZER( 5, ColMajorStorage )
+
+BENCH_LINEARIZER( 1, RowMajorStorage )
+BENCH_LINEARIZER( 2, RowMajorStorage )
+BENCH_LINEARIZER( 3, RowMajorStorage )
+BENCH_LINEARIZER( 4, RowMajorStorage )
+BENCH_LINEARIZER( 5, RowMajorStorage )


### PR DESCRIPTION
It provides linearization of point inside a given ```HyperRectDomain``` (with storage order specifier) and the reverse process (index to point). It replaces the linearizer used by ```ImageContainerBySTLVector``` and provides additional features:
- row-major and col-major storage order compatible (maybe not very useful ...);
- no loops, whatever the dimension ("meta-programming");
- possibility to be specialized for other domain types (if needed ?).