### PR TITLE
Viewer3d order display primitives

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,9 +29,10 @@
    (Pierre Gueth [#977](https://github.com/DGtal-team/DGtal/pull/977))
  - New antiderivative<order, duality>() operator.
    (Pierre Gueth [#977](https://github.com/DGtal-team/DGtal/pull/977))
- - New flatDirectional<duality, direction>() and sharpDirectional<duality, direction>()
-   operators defined as flat(vector_field_along_direction) and sharp(1-form).extractZeroForm(direction).
-   (Pierre Gueth [#977](https://github.com/DGtal-team/DGtal/pull/977))
+ - New flatDirectional<duality, direction>() and sharpDirectional<duality,
+   direction>() operators defined as flat(vector_field_along_direction) and
+   sharp(1-form).extractZeroForm(direction). (Pierre Gueth
+   [#977](https://github.com/DGtal-team/DGtal/pull/977))
  - DiscreteExteriorCalculus<dim_embedded, dim_ambient, Backend>
    takes 2 dimension template parameters for embedding
    manifold in ambient euclidean space.
@@ -113,26 +114,32 @@
    Assignable (David Coeurjolly
    [#940](https://github.com/DGtal-team/DGtal/pull/940))
  - Improvement of memory footprint of DGtal::Color (David Coeurjolly,
- [#961](https://github.com/DGtal-team/DGtal/pull/961))
+   [#961](https://github.com/DGtal-team/DGtal/pull/961))
  - New colormap adapter to add ticks/iso-contours (regularly spaced or
- specified by the user) to a given colormap. (David Coeurjolly,
- [#987](https://github.com/DGtal-team/DGtal/pull/987))
+   specified by the user) to a given colormap. (David Coeurjolly,
+   [#987](https://github.com/DGtal-team/DGtal/pull/987))
  - New flag (-DWITH_QT5) enables QT5 support in libqglviewer. (Nicolas
- Aubry, [#983](https://github.com/DGtal-team/DGtal/pull/983))
+   Aubry, [#983](https://github.com/DGtal-team/DGtal/pull/983))
  - Board2D now supports quadratic Bezier curve drawing. (Tristan Roussillon,
-  [#1002](https://github.com/DGtal-team/DGtal/pull/1002))
- - MeshWriter class can now export OBJ file including colors. (Bertrand Kerautret,
-  [#1016](https://github.com/DGtal-team/DGtal/pull/1016))
- - Viewer3D: Shift-L / L key binding added to save and restore camera settings. (Bertrand Kerautret,
-  [#1024](https://github.com/DGtal-team/DGtal/pull/1024))
- - Viewer3D:  change the chronological order to diplay primitives (in the draw function) in order to see see textured image primitives trough the transparency of other 3D primitives. (Bertrand Kerautret,  [#1041](https://github.com/DGtal-team/DGtal/pull/1041))
+   [#1002](https://github.com/DGtal-team/DGtal/pull/1002))
+ - MeshWriter class can now export OBJ file including colors.
+   (Bertrand Kerautret, [#1016](https://github.com/DGtal-team/DGtal/pull/1016))
+ - Viewer3D: Shift-L / L key binding added to save and restore camera settings.
+   (Bertrand Kerautret, [#1024](https://github.com/DGtal-team/DGtal/pull/1024))
+ - Viewer3D:  change the chronological order to diplay primitives (in the draw
+   function) in order to see see textured image primitives through the
+   transparency of other 3D primitives. (Bertrand Kerautret,
+   [#1041](https://github.com/DGtal-team/DGtal/pull/1041))
 
 
 - *Kernel Package*
-  - HyperRectDomain can now be empty (lowerBound == upperBound + diagonal(1)). Warning about the use 
-    of lexicographical order in comparison operators of PointVector. (Roland Denis, [#996](https://github.com/DGtal-team/DGtal/pull/996))
-  - Adds generic linearization (point to index) and reverse process (index to point), specialized for HyperRectDomain.
-    (Roland Denis, [#1039](https://github.com/DGtal-team/DGtal/pull/1039))
+  - HyperRectDomain can now be empty (lowerBound == upperBound + diagonal(1)).
+    Warning about the use of lexicographical order in comparison operators of
+    PointVector. (Roland Denis,
+    [#996](https://github.com/DGtal-team/DGtal/pull/996))
+  - Adds generic linearization (point to index) and reverse process (index to
+    point), specialized for HyperRectDomain. (Roland Denis,
+    [#1039](https://github.com/DGtal-team/DGtal/pull/1039))
 
 - *Shapes Package*
  - Adds a vertex Iterator in the Mesh class in addition to the
@@ -152,19 +159,24 @@
    instead. (Jérémy Levallois
    [#962](https://github.com/DGtal-team/DGtal/pull/962))
  - Add various methods in the Mesh class to get the bounding box, to change the
-   mesh scale or to subdivide triangular faces. (Bertrand Kerautret, [#990](https://github.com/DGtal-team/DGtal/pull/990) and  [#992](https://github.com/DGtal-team/DGtal/pull/992))
- - New copy constructor and copy operator on Mesh object (and documentation added about vertex ordering for obj format).
-   (Bertrand Kerautret, [#976](https://github.com/DGtal-team/DGtal/pull/976))
+   mesh scale or to subdivide triangular faces. (Bertrand Kerautret,
+   [#990](https://github.com/DGtal-team/DGtal/pull/990) and
+   [#992](https://github.com/DGtal-team/DGtal/pull/992))
+ - New copy constructor and copy operator on Mesh object (and documentation
+   added about vertex ordering for obj format). (Bertrand Kerautret,
+   [#976](https://github.com/DGtal-team/DGtal/pull/976))
 
 - *Arithmetic Package*
  - Algorithm to compute the fraction of smallest denominator in between
-	two irreducible fractions (Isabelle Sivignon [#949](https://github.com/DGtal-team/DGtal/pull/949))
+   two irreducible fractions (Isabelle Sivignon
+   [#949](https://github.com/DGtal-team/DGtal/pull/949))
 
 ## Bug Fixes
 
 - *Configuration*
   - Forces Eigen 3.2.1 minimum (for a bug fix).
-    (Jacques-Olivier Lachaud, [1032](https://github.com/DGtal-team/DGtal/pull/1032)).
+    (Jacques-Olivier Lachaud,
+    [1032](https://github.com/DGtal-team/DGtal/pull/1032)).
   - Fix issue #925, detection of Eigen3 (3.1 minimum) and also issue
     #924, DGtal configuration file when using Eigen3.  (Jacques-Olivier
     Lachaud, [#926](https://github.com/DGtal-team/DGtal/pull/926))
@@ -176,8 +188,8 @@
  - Various fixes of compiler warnings due to unused paramters (David
    Coeurjolly, Roland Denis,
    [#1034](https://github.com/DGtal-team/DGtal/pull/1030))
-   
-   
+
+
 - *Base Package*
  - Fix bug with LabelledMap copy constructor and copy iterator. (Roland
    Denis, [#973](https://github.com/DGtal-team/DGtal/pull/973))
@@ -187,7 +199,7 @@
  [#938](https://github.com/DGtal-team/DGtal/pull/938))
  - Cleanup of DGtal namespaces (David Coeurjolly,
  [#993](https://github.com/DGtal-team/DGtal/pull/993))
- 
+
 
 - *Geometry Package*
  - Fix bug occuring in the computation of the Faithful Polygon (class FP)
@@ -202,7 +214,7 @@
 	ArithmeticalDSSConvexHull::smartCH and
 	ArithmeticalDSSConvexHull::smartCHNextVertex to enable negative
 	positions as input arguments. (Isabelle Sivignon,
-	[#950](https://github.com/DGtal-team/DGtal/pull/950)) 	 
+	[#950](https://github.com/DGtal-team/DGtal/pull/950))
  - Fix Bezout Vector computation (Isabelle Sivignon,
  [#948](https://github.com/DGtal-team/DGtal/pull/948))
  - Fix issues with SphereFitting and TensorVoting local estimators on
@@ -217,8 +229,9 @@
  - Radius and resolution of balls have been fixed when used to
    represent a 3D point in grid mode (David Coeurjolly,
    [#978](https://github.com/DGtal-team/DGtal/pull/978))
- - Change in the mesh export in OFF format: now it tries by default to export colors (if stored).
-   (Bertrand Kerautret, [#985](https://github.com/DGtal-team/DGtal/pull/985))
+ - Change in the mesh export in OFF format: now it tries by default to export
+   colors (if stored). (Bertrand Kerautret,
+   [#985](https://github.com/DGtal-team/DGtal/pull/985))
  - Bugfix in quad visualization in BoardD3D and Viewer3D (David
    Coeurjolly, [#980](https://github.com/DGtal-team/DGtal/pull/980))
  - Fix warnings message of std::abs in Display3D.    (Bertrand Kerautret,
@@ -227,15 +240,17 @@
    [#995](https://github.com/DGtal-team/DGtal/pull/995))
  - Fix issues in OBJ color export when exporting voxels. (David
    Coeurjolly, [#1022](https://github.com/DGtal-team/DGtal/pull/1022))
- - Fix compilation issue on gentoo system related to MeshWriter (gcc version 4.9.2-r2). (Van Tho Nguyen,
-	[#1035](https://github.com/DGtal-team/DGtal/pull/1035))
+ - Fix compilation issue on gentoo system related to MeshWriter
+   (gcc version 4.9.2-r2). (Van Tho Nguyen,
+   [#1035](https://github.com/DGtal-team/DGtal/pull/1035))
  - Fix deprecated usage of setMouseBindingDescription with QGLViewer >= 2.5.0.
    (Roland Denis, [#1036](https://github.com/DGtal-team/DGtal/pull/1036))
 
 - *Kernel Package*
-  - BasicDomainSubSampler can now handle non 0 origin point. This update also correct
-    the search of point which are outside the source domain (it is now checked in testBasicPointFunctors).
-    (Bertrand Kerautret, [989](https://github.com/DGtal-team/DGtal/pull/989)).
+  - BasicDomainSubSampler can now handle non 0 origin point. This update also
+    correct the search of point which are outside the source domain (it is now
+    checked in testBasicPointFunctors). (Bertrand Kerautret,
+    [989](https://github.com/DGtal-team/DGtal/pull/989)).
 
 - *Topology  Package*
   - Fix loop bug in extractAllConnectedSCell of Surfaces from helpers.
@@ -243,7 +258,8 @@
 
 - *DEC  Package*
   - Fix missing include in testEigenSolver.
-    (Jacques-Olivier Lachaud, [1032](https://github.com/DGtal-team/DGtal/pull/1032)).
+    (Jacques-Olivier Lachaud,
+    [1032](https://github.com/DGtal-team/DGtal/pull/1032)).
 
 
 # DGtal 0.8
@@ -421,7 +437,8 @@
   Coeurjolly, [#871](https://github.com/DGtal-team/DGtal/pull/871))
 
 - *Topology Package*
-  - Surfaces::findABell accepts now arbitrary pair of points (Jacques-Olivier Lachaud, David Coeurjolly,
+  - Surfaces::findABell accepts now arbitrary pair of points (Jacques-Olivier
+    Lachaud, David Coeurjolly,
     [#851](https://github.com/DGtal-team/DGtal/pull/851))
 
 
@@ -450,14 +467,17 @@
 - *Topology Package*
   - small fix in ImplicitDigitalSurface. (Jacques-Olivier Lachaud,
     [#803](https://github.com/DGtal-team/DGtal/pull/803))
-  - fix examples volTrackBoundary and volScanBoundary for DEBUG mode (Jacques-Olivier Lachaud, David Coeurjolly,
+  - fix examples volTrackBoundary and volScanBoundary for DEBUG mode
+    (Jacques-Olivier Lachaud, David Coeurjolly,
     [#851](https://github.com/DGtal-team/DGtal/pull/851))
-  - New methods to fill the interior/exterior of digital contours (in the Surface class of topology/helpers).  (Bertrand Kerautret   [#827](https://github.com/DGtal-team/DGtal/pull/827))
+  - New methods to fill the interior/exterior of digital contours
+    (in the Surface class of topology/helpers).  (Bertrand Kerautret
+    [#827](https://github.com/DGtal-team/DGtal/pull/827))
 
 
 - *Graph Package*
-  - fix examples volDistanceTraversal for DEBUG mode (Jacques-Olivier Lachaud, David Coeurjolly,
-    [#851](https://github.com/DGtal-team/DGtal/pull/851))
+  - fix examples volDistanceTraversal for DEBUG mode (Jacques-Olivier Lachaud,
+    David Coeurjolly, [#851](https://github.com/DGtal-team/DGtal/pull/851))
 
 - *Image Package*
   - Fixing template types in ImageAdapter (David Coeurjolly,
@@ -472,7 +492,8 @@
    [#853](https://github.com/DGtal-team/DGtal/pull/853))
   - Renaming BasicColorToScalarFunctors namespace to functors:: (David
     Coeurjolly,  [#857](https://github.com/DGtal-team/DGtal/pull/857))
-  - Fix OpenGL warnings by redefining openGL primitive (glSphere) (Bertrand Kerautret [#981](https://github.com/DGtal-team/DGtal/pull/891))
+  - Fix OpenGL warnings by redefining openGL primitive (glSphere) (Bertrand
+    Kerautret [#981](https://github.com/DGtal-team/DGtal/pull/891))
 
 === DGtal 0.7 ===
 
@@ -505,9 +526,11 @@
 
     - New basic functors:
 	- SliceRotator2D: to rotate 2D Slice images from 3D volume.
-	- Point2DEmbedderIn3D: a simple functor to embed in 3d a 2d points (useful to extract 2D image from 3D volume).
+	- Point2DEmbedderIn3D: a simple functor to embed in 3d a 2d points
+	  (useful to extract 2D image from 3D volume).
 
-    - Sets have been updated to own their domain with a copy-on-write pointer, in order to avoid some inconsistencies.
+    - Sets have been updated to own their domain with a copy-on-write pointer,
+      in order to avoid some inconsistencies.
 
 *Topology Package*
 
@@ -522,12 +545,13 @@
 
     - New classes to deal with arithmetical digital straight segments.
       Now the representation of the primitives and their recognition
-      along a discrete structure are separated. The unique class ArithmeticalDSS,
-      which was a segment computer, has been replaced by mainly three classes:
-      ArithmeticalDSL, ArithmeticalDSS and ArithmeticalDSSComputer.
-      This is described in a doc page of the geometry package.
-      Note that Backward/Forward suffixes have been renamed into Back/Front.
-      Moreover, get prefixes for data members accessors have been removed.
+      along a discrete structure are separated. The unique class
+      ArithmeticalDSS,  which was a segment computer, has been replaced by
+      mainly three classes: ArithmeticalDSL, ArithmeticalDSS and
+      ArithmeticalDSSComputer. This is described in a doc page of the geometry
+      package. Note that Backward/Forward suffixes have been renamed into
+      Back/Front. Moreover, get prefixes for data members accessors have been
+      removed.
 
     - Generic adapter to transform a metric (model of CMetric) with
       monotonic (see doc) properties to a separable metric (model of
@@ -537,8 +561,8 @@
     - New possibility to access the 3 2D ArithmeticDSS object within an
       ArithmeticDSS3d.
 
-    - New local estimator adapter to make easy implementation of locally defined differential
-      estimator on digital surfaces.
+    - New local estimator adapter to make easy implementation of locally defined
+      differential estimator on digital surfaces.
 
     - New documentation on local estimators from digital surface
       patches and surfel functors. New normal vector estimator from
@@ -551,7 +575,8 @@
 
     - Minor improvements in the spherical accumulator.
 
-    - Improvement of integral invariant estimators (better memory footprint, ...).
+    - Improvement of integral invariant estimators (better memory footprint,
+	...).
       They also allow to estimate principal curvatures using Covariance matrix.
       Covariance matrix is also "masks" based, so the computation is efficient.
 
@@ -563,17 +588,21 @@
     - Chord algorithm for (naive) plane recognition and width computation.
 
     - New organization for computing primitives. Introduction of the concept
-      of PrimitiveComputer and specialization. COBA algorithm and Chord algorithm
-      are now models of AdditivePrimitiveComputer.
+      of PrimitiveComputer and specialization. COBA algorithm and Chord
+      algorithm are now models of AdditivePrimitiveComputer.
 
-    - Introduction of the primitive ParallelStrip, computed by COBA and Chord algorithms
+    - Introduction of the primitive ParallelStrip, computed by COBA and Chord
+      algorithms
 
-    - New documentation for planarity decision, plane recognition and width computation.
+    - New documentation for planarity decision, plane recognition and width
+      computation.
       Quantitative and qualitative evaluation of COBA and Chord algorithm.
 
-    - Bug fix in COBA algorithm when extending an empty computer with a group of points.
+    - Bug fix in COBA algorithm when extending an empty computer with a group of
+      points.
 
-    - add standard plane recognition with adapter classes both for COBA and Chord algorithm.
+    - add standard plane recognition with adapter classes both for COBA and
+      Chord algorithm.
 
 *Shape Package*
 
@@ -583,21 +612,25 @@
 
 *Topology Package*
 
-    - The class SCellToMidPoint is now deprecated. Use CanonicSCellEmbedder instead
-      to map a signed cell to its corresponding point in the Euclidean space
+    - The class SCellToMidPoint is now deprecated. Use CanonicSCellEmbedder
+      instead to map a signed cell to its corresponding point in the Euclidean
+      space
 
 *IO Package*
 
     - Complete refactoring of 3D viewers and boards (Viewer3D, Board3DTo2D).
     - New Board3D to export 3D displays to OBJ 3D vector format.
     - A new display of 2D and 3D image in Viewer3D.
-    - New reader: HDF5 file with 2D image dataset(s) (8-bit with palette and 24-bit truecolor with INTERLACE_PIXEL).
+    - New reader: HDF5 file with 2D image dataset(s) (8-bit with palette and
+      24-bit truecolor with INTERLACE_PIXEL).
     - New GenericReader and Generic Writer for both 2D, 3D and ND images.
-    - Adding a Table Reader to extract objets given in a specific column from a text file.
+    - Adding a Table Reader to extract objets given in a specific column from a
+      text file.
     - Adding missing PPM Reader.
     - Adding missing DICOM reader (with ITK library)
     - Adding ITK reader and ITK writer
-    - OpenInventor (SOQT/Coin3D) based viewer has been removed (please consider release <=0.6 if interested).
+    - OpenInventor (SOQT/Coin3D) based viewer has been removed (please consider
+      release <=0.6 if interested).
 
 *Image Package*
 
@@ -664,8 +697,8 @@
  *Image Package*
     - Update on image writers (no colormap required for scalar only writers).
       Documentation updated.
-    - New image adapters to adapt both domains and values of an image (ImageAdapter
-      and ConstImageAdapter).
+    - New image adapters to adapt both domains and values of an image
+      (ImageAdapter and ConstImageAdapter).
     - several enhancements of the main image concept and its image
       container models
 
@@ -899,17 +932,20 @@ Posted on April 4, 2011 by David Coeurjolly
 === DGtal 0.3.0 ===
 Posted on April 1, 2011 by David Coeurjolly
 
-Beside the DGtal presentation at DGCI 2011, we are pleased to announce a new DGtal release 0.3.0.
+Beside the DGtal presentation at DGCI 2011, we are pleased to announce a new
+DGtal release 0.3.0.
 
 New features:
 
     User-guide added (based on doxygen system)
-    Kernel: new concepts and controls to enhance the Interger type management, new iterators (Range/SubRange) on HyperRectDomains.
+    Kernel: new concepts and controls to enhance the Interger type management,
+            new iterators (Range/SubRange) on HyperRectDomains.
     Topology: interpixel model added (cells, boundary tracking mechanisms,…)
-    Geometry 2D: 2D curve primitive decomposition, tangential cover, convexity/concavity decomposition.
+    Geometry 2D: 2D curve primitive decomposition, tangential cover,
+                 convexity/concavity decomposition.
     Geometry nD: reverse Euclidean distance transformation
-    Visualisation: stream mechanism to visualize 3D DGtal objects with libQGLViewer (optional)
-    Shape generator factory added in nD
+    Visualisation: stream mechanism to visualize 3D DGtal objects with
+	           libQGLViewer (optional) Shape generator factory added in nD
 
 BugFixes, enhancements:
 
@@ -918,8 +954,9 @@ BugFixes, enhancements:
 
 Known problems:
 
-    For technical reasons, we haven’t be able to verify that this release also compile on Windows Visual Studio systems (see ticket #87). A new release will fix this problem as soon as possible.
-    All open tickets
+    For technical reasons, we haven’t be able to verify that this release also
+    compile on Windows Visual Studio systems (see ticket #87). A new release
+    will fix this problem as soon as possible. 
 
 
 
@@ -966,12 +1003,14 @@ Known problems:
   * Many bug fixes for VS compatibility
 
 2010-05-15 dcoeurjo
-  * Assert.h: added macro ASSERT() added based on the boost/assert.hpp (TODO: implement a nice callback)
+  * Assert.h: added macro ASSERT() added based on the boost/assert.hpp (TODO:
+	      implement a nice callback)
   * Point and Vector templated classes added
   * Space.*: skeleton of a DGtal::Space added
 
 2010-03-03 dcoeurjo
-	* math/MeasureOfStraightLines: new class to compute the measure of a set of Straight lines defined as a polygon in the (a,b) parameter space.
+	* math/MeasureOfStraightLines: new class to compute the measure of a set
+	of Straight lines defined as a polygon in the (a,b) parameter space.
 	* test_measure: added
 
 2010-02-17 dcoeurjo
@@ -983,15 +1022,21 @@ Known problems:
   * Trace/Clock: minor edit and bug report
 
 2010-01-05 dcoeurjo
-  * Trace can be initialized on diffrent output stream (e.g. std::cerr or a file stream)
+  * Trace can be initialized on diffrent output stream (e.g. std::cerr or a file
+	  stream)
   * test_trace: update to test the new API
 
 2010-01-04 dcoeurjo
-  * Clock: no more static variables and methods (in order to have several running clocks)
-  * Trace: new interface and the endBlock displays and returns the ellapsed time within the block
+  * Clock: no more static variables and methods (in order to have several
+	   running clocks)
+  * Trace: new interface and the endBlock displays and returns the
+	   ellapsed time within the block
 
 2009-12-28 dcoeurjo
-  * Trace: a new class to trace out messages to the standard output. Four type of messages are possible: info, debug, error and "emphased". On color linux terminal, messages appears with an appropriate color foreground.
+  * Trace: a new class to trace out messages to the standard output. Four type
+	   of messages are possible: info, debug, error and "emphased". On
+	   color linux terminal, messages appears with an appropriate color
+	   foreground.
   * test_trace: an illustration of the Trace interface
 
 2009-12-14 dcoeurjo

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -125,6 +125,7 @@
   [#1016](https://github.com/DGtal-team/DGtal/pull/1016))
  - Viewer3D: Shift-L / L key binding added to save and restore camera settings. (Bertrand Kerautret,
   [#1024](https://github.com/DGtal-team/DGtal/pull/1024))
+ - Viewer3D:  change the chronological order to diplay primitives (in the draw function) in order to see see textured image primitives trough the transparency of other 3D primitives. (Bertrand Kerautret,  [#1041](https://github.com/DGtal-team/DGtal/pull/1041))
 
 
 - *Kernel Package*

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -702,6 +702,14 @@ DGtal::Viewer3D<Space, KSpace>::draw()
         }
       glCallList(myBallSetListId+j);
     }
+ for ( typename vector<vector< typename Viewer3D<Space, KSpace>::BallD3D> >::const_iterator itb= Viewer3D<Space, KSpace>::myBallSetList.begin();
+	itb != Viewer3D<Space, KSpace>::myBallSetList.end(); itb++ )
+    {
+      for ( typename vector< typename Viewer3D<Space, KSpace>::BallD3D>::const_iterator it_s = itb->begin(); it_s !=itb->end() ; it_s ++)
+        {
+          glDrawGLBall ( *it_s );
+        }
+    }
 
   for ( unsigned int j=0; j< Viewer3D<Space, KSpace>::myLineSetList.size(); j++ )
     {
@@ -743,15 +751,7 @@ DGtal::Viewer3D<Space, KSpace>::draw()
       glCallList(myPolygonSetListWiredId);
     }
 
-  for ( typename vector<vector< typename Viewer3D<Space, KSpace>::BallD3D> >::const_iterator itb= Viewer3D<Space, KSpace>::myBallSetList.begin();
-	itb != Viewer3D<Space, KSpace>::myBallSetList.end(); itb++ )
-    {
-      for ( typename vector< typename Viewer3D<Space, KSpace>::BallD3D>::const_iterator it_s = itb->begin(); it_s !=itb->end() ; it_s ++)
-        {
-          glDrawGLBall ( *it_s );
-        }
-    }
-
+ 
   for(unsigned int j=0; j< myVectTextureImage.size(); j++)
     {
       GLTextureImage &textureImg = myVectTextureImage.at(j);

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -693,6 +693,30 @@ DGtal::Viewer3D<Space, KSpace>::draw()
   double distCam =sqrt ( ( posCam.x-centerS.x ) * ( posCam.x-centerS.x ) +
                          ( posCam.y-centerS.y ) * ( posCam.y-centerS.y ) +
                          ( posCam.z-centerS.z ) * ( posCam.z-centerS.z ) );
+  for(unsigned int j=0; j< myVectTextureImage.size(); j++)
+    {
+      GLTextureImage &textureImg = myVectTextureImage.at(j);
+      glPushName ( textureImg.myTextureName );
+      glEnable(GL_LIGHTING);
+      glEnable(GL_TEXTURE_2D);
+      glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+      glBindTexture(GL_TEXTURE_2D, textureImg.myTextureName);
+      glBegin(GL_QUADS);
+      glColor4ub ( 255.0, 255.0, 255.0, 255.0 );
+      glNormal3d(textureImg.vectNormal[0], textureImg.vectNormal[1], textureImg.vectNormal[2]);
+
+      glTexCoord2f(0, 0);
+      glVertex3f(textureImg.point1[0], textureImg.point1[1], textureImg.point1[2]);
+      glTexCoord2f(textureImg.myTextureFitX, 0.0);
+      glVertex3f(textureImg.point2[0], textureImg.point2[1], textureImg.point2[2]);
+      glTexCoord2f(textureImg.myTextureFitX, textureImg.myTextureFitY);
+      glVertex3f(textureImg.point3[0], textureImg.point3[1], textureImg.point3[2]);
+      glTexCoord2f(0.0, textureImg.myTextureFitY);
+      glVertex3f(textureImg.point4[0], textureImg.point4[1], textureImg.point4[2]);
+      glEnd();
+      glDisable(GL_TEXTURE_2D);
+
+    }
 
   for ( unsigned int j=0; j< Viewer3D<Space, KSpace>::myBallSetList.size(); j++ )
     {
@@ -752,30 +776,6 @@ DGtal::Viewer3D<Space, KSpace>::draw()
     }
 
  
-  for(unsigned int j=0; j< myVectTextureImage.size(); j++)
-    {
-      GLTextureImage &textureImg = myVectTextureImage.at(j);
-      glPushName ( textureImg.myTextureName );
-      glEnable(GL_LIGHTING);
-      glEnable(GL_TEXTURE_2D);
-      glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
-      glBindTexture(GL_TEXTURE_2D, textureImg.myTextureName);
-      glBegin(GL_QUADS);
-      glColor4ub ( 255.0, 255.0, 255.0, 255.0 );
-      glNormal3d(textureImg.vectNormal[0], textureImg.vectNormal[1], textureImg.vectNormal[2]);
-
-      glTexCoord2f(0, 0);
-      glVertex3f(textureImg.point1[0], textureImg.point1[1], textureImg.point1[2]);
-      glTexCoord2f(textureImg.myTextureFitX, 0.0);
-      glVertex3f(textureImg.point2[0], textureImg.point2[1], textureImg.point2[2]);
-      glTexCoord2f(textureImg.myTextureFitX, textureImg.myTextureFitY);
-      glVertex3f(textureImg.point3[0], textureImg.point3[1], textureImg.point3[2]);
-      glTexCoord2f(0.0, textureImg.myTextureFitY);
-      glVertex3f(textureImg.point4[0], textureImg.point4[1], textureImg.point4[2]);
-      glEnd();
-      glDisable(GL_TEXTURE_2D);
-
-    }
    glPopMatrix();
    glPopMatrix();
    drawLight(GL_LIGHT1);


### PR DESCRIPTION
Small PR just to change the chronological order to diplay primitives (in the draw function) in order to see see textured image primitives trough the transparency of other 3D primitives.
It fix some a display bug when for instance we display a mesh with transparency in front a slice image.