### PR TITLE
Fix for: CConstSinglePassRange.h:100:21: error: variable ‘it’ set but…

### DIFF
--- a/src/DGtal/base/CBidirectionalRange.h
+++ b/src/DGtal/base/CBidirectionalRange.h
@@ -40,8 +40,9 @@
 
 //////////////////////////////////////////////////////////////////////////////
 // Inclusions
-#include <iostream>
 #include "DGtal/base/Common.h"
+#include "boost/concept_check.hpp"
+#include "DGtal/base/ConceptUtils.h"
 #include "DGtal/base/CConstBidirectionalRange.h"
 //////////////////////////////////////////////////////////////////////////////
 
@@ -81,26 +82,27 @@ PointVector
 
 @tparam T the type that is checked. T should be a model of CBidirectionalRange.
 
-   */
+*/
   template <typename T>
   struct CBidirectionalRange : public CConstBidirectionalRange<T>
   {
     // ----------------------- Concept checks ------------------------------
   public:
     typedef typename T::ReverseIterator ReverseIterator;
-
+    
     BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ReverseIterator> ));
-
+    
     BOOST_CONCEPT_USAGE(CBidirectionalRange)
     {
- ReverseIterator it2=i.rbegin();
- it2=i.rend();
+      concepts::ConceptUtils::sameType( it, i.rbegin() );
+      concepts::ConceptUtils::sameType( it, i.rend() );
     };
-
+    
   private:
     T i;
+    ReverseIterator it;
   }; // end of concept CBidirectionalRange
-
+  
 } // namespace DGtal
 
 

--- a/src/DGtal/base/CConstBidirectionalRange.h
+++ b/src/DGtal/base/CConstBidirectionalRange.h
@@ -40,7 +40,9 @@
 
 //////////////////////////////////////////////////////////////////////////////
 // Inclusions
-#include <iostream>
+#include "DGtal/base/Common.h"
+#include "boost/concept_check.hpp"
+#include "DGtal/base/ConceptUtils.h"
 #include "DGtal/base/CConstSinglePassRange.h"
 //////////////////////////////////////////////////////////////////////////////
 
@@ -82,20 +84,25 @@ Description of \b concept '\b CConstBidirectionalRange'
 template <typename T>
 struct CConstBidirectionalRange: CConstSinglePassRange<T>
 {
- // ----------------------- Concept checks ------------------------------
+  // ----------------------- Concept checks ------------------------------
 public:
- typedef typename T::ConstReverseIterator ConstReverseIterator;
-
- BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ConstReverseIterator> ));
-
- BOOST_CONCEPT_USAGE(CConstBidirectionalRange)
- {
-  ConstReverseIterator it=i.rbegin();
-  it=i.rend();
- };
-
+  typedef typename T::ConstReverseIterator ConstReverseIterator;
+  
+  BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ConstReverseIterator> ));
+  
+  BOOST_CONCEPT_USAGE(CConstBidirectionalRange)
+  {
+    checkConstConstraints();
+  }
+  void checkConstConstraints() const
+  {
+    concepts::ConceptUtils::sameType( it, i.rbegin() );
+    concepts::ConceptUtils::sameType( it, i.rend() );
+  }
+  
 private:
- T i;
+  T i;
+  ConstReverseIterator it;
 }; // end of concept CConstBidirectionalRange
 
 } // namespace DGtal

--- a/src/DGtal/base/CConstSinglePassRange.h
+++ b/src/DGtal/base/CConstSinglePassRange.h
@@ -40,8 +40,8 @@
 
 //////////////////////////////////////////////////////////////////////////////
 // Inclusions
-#include <iostream>
 #include "DGtal/base/Common.h"
+#include "boost/concept_check.hpp"
 #include "DGtal/base/ConceptUtils.h"
 //////////////////////////////////////////////////////////////////////////////
 
@@ -94,15 +94,20 @@ namespace DGtal
     typedef typename T::ConstIterator ConstIterator;
     
     BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ConstIterator> ));
-
+    
     BOOST_CONCEPT_USAGE(CConstSinglePassRange)
     {
-      ConstIterator it=i.begin();
-      it=i.end();
-    };
-
+      checkConstConstraints();
+    }
+    void checkConstConstraints() const
+    {
+      concepts::ConceptUtils::sameType( it, i.begin() );
+      concepts::ConceptUtils::sameType( it, i.end() );
+    }
+    
   private:
     T i;
+    ConstIterator it;
   }; // end of concept CConstSinglePassRange
   
 } // namespace DGtal


### PR DESCRIPTION
… not used [-Werror=unused-but-set-variable]

One Travis test for my branch LambdaMST failed because of this error. I could not reproduce it here but I believe that this should fix the problem.