### PR TITLE
Fix nullptr_t issue in catch with gcc 5.2.0

### DIFF
--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -130,7 +130,7 @@
 // GCC
 #ifdef __GNUC__
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6 && defined(__GXX_EXPERIMENTAL_CXX0X__) )
+#if __GNUC__ == 4 && __GNUC_MINOR__ >= 6 && defined(__GXX_EXPERIMENTAL_CXX0X__)
 #   define CATCH_INTERNAL_CONFIG_CPP11_NULLPTR
 #endif
 


### PR DESCRIPTION
DGtal currently failed to compile with `gcc 5.2.0` when `C++11` support is not activated. It seems to be related to an issue in Catch when detecting `nullptr_t` typedef support (it is a `C++11` feature).

This fix comes from a commit in the develop branch of catch.
See https://github.com/philsquared/Catch/pull/471 and https://github.com/philsquared/Catch/commit/f3308ed7c48c7989464817d5b1f07c66122c1d85 .

Two remarks:
- we could also update our `catch.hpp` file from the Catch develop branch,
- there is a `CATCH_CONFIG_NO_CPP11` flag that we could set when DGtal is compiled without `C++11` support.