### PR TITLE
Fix parentheses warning with Catch

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,9 +12,10 @@
 ## Bug Fixes
 
 - *Configuration/General*
- - catch unit test framework upgraded to the develop version. (David
- Coeurjolly, [#10XX](https://github.com/DGtal-team/DGtal/pull/1052))
-
+ - catch unit test framework upgraded to the develop version.
+   (David Coeurjolly, [#1055](https://github.com/DGtal-team/DGtal/pull/1055))
+ - fixing parenthese warnings in Catch. Waiting for an official fix.
+   (Roland Denis, [#1067](https://github.com/DGtal-team/DGtal/pull/1067))
 
 
 # DGtal 0.9

--- a/tests/base/testCatch.cpp
+++ b/tests/base/testCatch.cpp
@@ -41,14 +41,14 @@ TEST_CASE( "Point Vector Unit tests" )
   
   SECTION("Comparisons")
     {
-      REQUIRE( (a == b) );
+      REQUIRE( a == b );
       a=6;
-      REQUIRE( (a == c) );
+      REQUIRE( a == c );
     }
   
   SECTION("No side-effects on global variables in section scopes")
     {
-      REQUIRE( (a == 5) );
+      REQUIRE( a == 5 );
     }
 
 }

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -1242,10 +1242,6 @@ namespace Catch {
         ExpressionLhs<bool> operator >> ( bool value );
 
         template<typename T>
-        ExpressionLhs<T const&> operator <= ( T const& operand );
-        ExpressionLhs<bool> operator <= ( bool value );
-        
-        template<typename T>
         ResultBuilder& operator << ( T const& value ) {
             m_stream.oss << value;
             return *this;
@@ -1895,15 +1891,6 @@ private:
 
 namespace Catch {
 
-    template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::operator <= ( T const& operand ) {
-        return ExpressionLhs<T const&>( *this, operand );
-    }
-
-    inline ExpressionLhs<bool> ResultBuilder::operator <= ( bool value ) {
-        return ExpressionLhs<bool>( *this, value );
-    }
-    
     template<typename T>
     inline ExpressionLhs<T const&> ResultBuilder::operator >> ( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -2079,12 +2079,15 @@ namespace Catch {
     resultBuilder.react();
 
 ///////////////////////////////////////////////////////////////////////////////
-#ifdef __GCC__
+#ifdef __clang__
 #    define INTERNAL_CATCH_TEST( expr, resultDisposition, macroName ) \
        do { \
            Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
            try { \
+               _Pragma("clang diagnostic push") \
+               _Pragma("clang diagnostic ignored \"-Woverloaded-shift-op-parentheses\"") \
                ( __catchResult >> expr ).endExpression(); \
+               _Pragma("clang diagnostic pop") \
            } \
            catch( ... ) { \
                __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \
@@ -2096,7 +2099,7 @@ namespace Catch {
        do { \
            Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
            try { \
-               ( __catchResult <= expr ).endExpression(); \
+               ( __catchResult >> expr ).endExpression(); \
            } \
            catch( ... ) { \
                __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -2066,17 +2066,50 @@ namespace Catch {
     resultBuilder.react();
 
 ///////////////////////////////////////////////////////////////////////////////
-#define INTERNAL_CATCH_TEST( expr, resultDisposition, macroName ) \
-    do { \
-        Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
-        try { \
-            ( __catchResult <= expr ).endExpression(); \
-        } \
-        catch( ... ) { \
-            __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \
-        } \
-        INTERNAL_CATCH_REACT( __catchResult ) \
-    } while( Catch::isTrue( false && (expr) ) ) // expr here is never evaluated at runtime but it forces the compiler to give it a look
+#ifdef __GNUC__
+#  include <features.h>
+#  if __GNUC_PREREQ(4, 8)
+#    define INTERNAL_CATCH_TEST( expr, resultDisposition, macroName ) \
+       do { \
+           Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
+           try { \
+               ( __catchResult <= expr ).endExpression(); \
+           } \
+           catch( ... ) { \
+               __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \
+           } \
+           INTERNAL_CATCH_REACT( __catchResult ) \
+       } while( Catch::isTrue( false && (expr) ) ) // expr here is never evaluated at runtime but it forces the compiler to give it a look
+#  else
+#    define INTERNAL_CATCH_TEST( expr, resultDisposition, macroName ) \
+       _Pragma("GCC diagnostic push") \
+       _Pragma("GCC diagnostic ignored \"-Wparentheses\"") \
+       do { \
+           Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
+           try { \
+               ( __catchResult <= expr ).endExpression(); \
+           } \
+           catch( ... ) { \
+               __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \
+           } \
+           INTERNAL_CATCH_REACT( __catchResult ) \
+       } while( Catch::isTrue( false && (expr) ) ) // expr here is never evaluated at runtime but it forces the compiler to give it a look \
+       _Pragma("GCC diagnostic pop")
+#  endif
+#else
+#  define INTERNAL_CATCH_TEST( expr, resultDisposition, macroName ) \
+     do { \
+         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
+         try { \
+             ( __catchResult <= expr ).endExpression(); \
+         } \
+         catch( ... ) { \
+             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \
+         } \
+         INTERNAL_CATCH_REACT( __catchResult ) \
+     } while( Catch::isTrue( false && (expr) ) ) // expr here is never evaluated at runtime but it forces the compiler to give it a look
+#endif  
+
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_IF( expr, resultDisposition, macroName ) \

--- a/tests/geometry/tools/testConvexHull2DThickness.cpp
+++ b/tests/geometry/tools/testConvexHull2DThickness.cpp
@@ -68,19 +68,19 @@ TEST_CASE( "Testing Rotating Caliper of ConvexHull2D (basic convex hull)" )
    
    SECTION("Testing computation of horizontal/vertical thickness of ConvexHull2D")
      {
-       REQUIRE( (thicknessHV == 1.0));
-       REQUIRE(  (pHV == Point(0,0)));
-       REQUIRE((qHV==Point(1,0)));
-       REQUIRE((sHV==Point(1,1)));
+       REQUIRE( thicknessHV == 1.0 );
+       REQUIRE( pHV == Point(0,0) );
+       REQUIRE( qHV==Point(1,0) );
+       REQUIRE( sHV==Point(1,1) );
      }
    
 
    SECTION("Testing computation of euclidean thickness of ConvexHull2D")
      {
-       REQUIRE( (thicknessEucl == Approx(std::sqrt(2.0)/2.0)) );
-       REQUIRE( (pE == Point(1,1)));
-       REQUIRE((qE==Point(0,0)) );
-       REQUIRE( (sE==Point(1,0)) );
+       REQUIRE( thicknessEucl == Approx(std::sqrt(2.0)/2.0) );
+       REQUIRE( pE == Point(1,1) );
+       REQUIRE( qE==Point(0,0) );
+       REQUIRE( sE==Point(1,0) );
      }
    
 }
@@ -118,15 +118,15 @@ TEST_CASE( "Testing Rotating Caliper of ConvexHull2D (convex hull with floating 
   
    SECTION("Testing antipodal points of ConvexHull2D")
      {
-       REQUIRE((pHV == Point(101.2, 48.2)));
-       REQUIRE((qHV==Point(104.2, 53.2)));
-       REQUIRE((sHV==Point(102.3, 52.3)));
+       REQUIRE( pHV == Point(101.2, 48.2) );
+       REQUIRE( qHV == Point(104.2, 53.2) );
+       REQUIRE( sHV == Point(102.3, 52.3) );
      }
    SECTION("Testing antipodal points of ConvexHull2D")
      {
-       REQUIRE((pE == Point(101.2, 48.2)));
-       REQUIRE((qE==Point(104.2, 53.2)));
-       REQUIRE((sE==Point(102.3, 52.3)));
+       REQUIRE( pE == Point(101.2, 48.2) );
+       REQUIRE( qE == Point(104.2, 53.2) );
+       REQUIRE( sE == Point(102.3, 52.3) );
      }
 }
 

--- a/tests/kernel/testLinearizer.cpp
+++ b/tests/kernel/testLinearizer.cpp
@@ -208,37 +208,37 @@ TEST_CASE( "Testing Linearizer in dimension " #N " with " #ORDER, "[test][dim" #
   SECTION( "Testing getIndex(Point, Point, Extent) syntax" )\
     {\
       for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, lowerBound, extent ) ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, lowerBound, extent )  );\
     }\
 \
   SECTION( "Testing getIndex(Point, Extent) syntax" )\
     {\
       for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it - lowerBound, extent ) ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it - lowerBound, extent )  );\
     }\
 \
   SECTION( "Testing getIndex(Point, Domain) syntax" )\
     {\
       for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, domain ) ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, domain )  );\
     }\
 \
   SECTION( "Testing getPoint(Index, Point, Extent) syntax" )\
     {\
       for ( std::size_t i = 0; i < domain.size(); ++i )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, lowerBound, extent ) ), refLowerBound, refExtent ) == i ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, lowerBound, extent ) ), refLowerBound, refExtent ) == i  );\
     }\
 \
   SECTION( "Testing getPoint(Index, Extent) syntax" )\
     {\
       for ( std::size_t i = 0; i < domain.size(); ++i )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, extent ) + lowerBound ), refLowerBound, refExtent ) == i ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, extent ) + lowerBound ), refLowerBound, refExtent ) == i  );\
     }\
 \
   SECTION( "Testing getPoint(Index, Domain) syntax" )\
     {\
       for ( std::size_t i = 0; i < domain.size(); ++i )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, domain ) ), refLowerBound, refExtent ) == i ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, domain ) ), refLowerBound, refExtent ) == i  );\
     }\
 }
 

--- a/tests/kernel/testPointHashFunctions.cpp
+++ b/tests/kernel/testPointHashFunctions.cpp
@@ -59,21 +59,21 @@ TEST_CASE("Hash functions on DGtal::Point")
   
   SECTION("Identity test")
     {
-      REQUIRE( (myhash(p) == myhash(p_copy)) );
+      REQUIRE( myhash(p) == myhash(p_copy) );
       CAPTURE( myhash(p) );
       
 #ifdef WITH_C11
-      REQUIRE( (myhashcpp11(p) == myhashcpp11(p_copy)) );
+      REQUIRE( myhashcpp11(p) == myhashcpp11(p_copy) );
 #endif      
     }
 
   
   SECTION("Difference test")
     {
-      REQUIRE( (myhash(p) != myhash(q)) );
+      REQUIRE( myhash(p) != myhash(q) );
       
 #ifdef WITH_C11
-      REQUIRE( (myhashcpp11(p) != myhashcpp11(q)) );
+      REQUIRE( myhashcpp11(p) != myhashcpp11(q) );
 #endif 
     }
     
@@ -90,15 +90,15 @@ TEST_CASE("Hash functions on DGtal::Point")
       std::hash<Point26> myhash26cpp11;
 #endif
  
-      REQUIRE( (myhash26(pp) == myhash26(qq)) );
+      REQUIRE( myhash26(pp) == myhash26(qq) );
       
 #ifdef WITH_C11
-      REQUIRE( (myhash26cpp11(pp) == myhash26cpp11(qq)) );
+      REQUIRE( myhash26cpp11(pp) == myhash26cpp11(qq) );
 #endif
-      REQUIRE( (myhash26(pp) != myhash26(rr)) );
+      REQUIRE( myhash26(pp) != myhash26(rr) );
       
 #ifdef WITH_C11
-      REQUIRE( (myhash26cpp11(pp) != myhash26cpp11(rr)) );
+      REQUIRE( myhash26cpp11(pp) != myhash26cpp11(rr) );
 #endif 
     }
 }

--- a/tests/kernel/testPointVector-catch.cpp
+++ b/tests/kernel/testPointVector-catch.cpp
@@ -60,7 +60,7 @@ TEST_CASE( "Point Vector Unit tests" )
 
   SECTION("Comparisons")
     {
-      REQUIRE( (p1 == p1bis) );
+      REQUIRE( p1 == p1bis );
       REQUIRE( p1 < p2 );
       
 #ifdef CPP11_INITIALIZER_LIST
@@ -71,10 +71,10 @@ TEST_CASE( "Point Vector Unit tests" )
   
   SECTION("Min/Max of vector components")
     {
-      REQUIRE( (p3.max() == 2.0) );
-      REQUIRE( (p3.min() == -2.0) );
-      REQUIRE( (*p3.maxElement() == 2.0) );
-      REQUIRE( (*p3.minElement() == -2.0) );
+      REQUIRE( p3.max() == 2.0 );
+      REQUIRE( p3.min() == -2.0 );
+      REQUIRE( *p3.maxElement() == 2.0 );
+      REQUIRE( *p3.minElement() == -2.0 );
     }
 
   Point  aPoint;
@@ -87,12 +87,12 @@ TEST_CASE( "Point Vector Unit tests" )
     {
       RealPoint normalized = aPoint.getNormalized();
       CAPTURE( normalized );
-      REQUIRE( (aPoint.norm ( Point::L_1 ) == 6) );
-      REQUIRE( (aPoint.norm ( Point::L_infty ) == 3) );
-      REQUIRE( (normalized[0] == Approx( 0.801784)) );
-      REQUIRE( (normalized[1] == Approx( -0.267261)) );
-      REQUIRE( (normalized[2] == Approx( 0.534522)) );
-      REQUIRE( (normalized[3] == Approx( 0.0)) );
+      REQUIRE( aPoint.norm ( Point::L_1 ) == 6 );
+      REQUIRE( aPoint.norm ( Point::L_infty ) == 3 );
+      REQUIRE( normalized[0] == Approx( 0.801784) );
+      REQUIRE( normalized[1] == Approx( -0.267261) );
+      REQUIRE( normalized[2] == Approx( 0.534522) );
+      REQUIRE( normalized[3] == Approx( 0.0) );
     }
 
   SECTION("PointVector Iterator")
@@ -107,19 +107,19 @@ TEST_CASE( "Point Vector Unit tests" )
       
       CAPTURE(aPoint25);
       CAPTURE(sum);
-      REQUIRE( (sum == 300) );
+      REQUIRE( sum == 300 );
     }
 
   SECTION("Arithmetical Operators")
     {
-      REQUIRE( ((p1 + p2) == Point(6,6,6,6)) );
-      REQUIRE( ((p1 - p2) == Point(-4,-2,0,2)) );
-      REQUIRE( ((p1*2) == Point(2,4,6,8)) );
-      REQUIRE( ((2*p1) == Point(2,4,6,8)) );
-      REQUIRE( ((-p1) == Point(-1,-2,-3,-4)) );
-      REQUIRE( (p1.inf(p2) == Point(1,2,3,2)) );
-      REQUIRE( (p1.sup(p2) == Point(5,4,3,4)) );
-      REQUIRE( (p1.dot(p2) == 30) );
+      REQUIRE( (p1 + p2) == Point(6,6,6,6) );
+      REQUIRE( (p1 - p2) == Point(-4,-2,0,2) );
+      REQUIRE( (p1*2) == Point(2,4,6,8) );
+      REQUIRE( (2*p1) == Point(2,4,6,8) );
+      REQUIRE( (-p1) == Point(-1,-2,-3,-4) );
+      REQUIRE( p1.inf(p2) == Point(1,2,3,2) );
+      REQUIRE( p1.sup(p2) == Point(5,4,3,4) );
+      REQUIRE( p1.dot(p2) == 30 );
     }
 
 }


### PR DESCRIPTION
Following the discussion in #1060, this PR proposes a solution to avoid warnings about missing parentheses in Catch assertions when using gcc (up to 4.7 but following versions may be concerned too).

Until now, the solution was to add extra parentheses around expression like this:
```
int a = 1, b = 2;
REQUIRE(( a == b ));
```
As the assertion failed, Catch outputs:
```
test.cpp:123: FAILED:
  REQUIRE( ( a == b ) );
with expansion:
  false
```
but one of the main argument of Catch is his ability to expand expressions. For example, without extra parentheses:
```
int a = 1, b = 2;
REQUIRE( a == b );
```
Catch outputs:
```
test.cpp:123: FAILED:
  REQUIRE( a == b );
with expansion:
  1 == 2
```

This issue has been addressed many times in Catch project ( see philsquared/Catch#528, philsquared/Catch#521 and philsquared/Catch#247 ) and the solutions proposed so far are:
1. to globally disable `-Wparentheses`, at least when using `gcc`,
2. to locally disable this warning in Catch,
3. to revert philsquared/Catch#247,
4. to replace `<=` operator of `ResultBuilder` by an operator with a slightly greater priority, like `<<` or `>>`.

The remarks about those solutions are:
1. it is quite ugly to globally disable warnings ... but, in fact, `-Wall` seems to be enable in DGtal only when `BUILD_TESTING` is set (see https://github.com/DGtal-team/DGtal/blob/master/cmake/CpackCtest.cmake ).
2. the problem comes from the line https://github.com/DGtal-team/DGtal/blob/master/tests/catch.hpp#L2073 . As we already are in a macro, we must use `_Pragma` to tell gcc to disable the warnings:
```
_Pragma("GCC diagnostic push") \
_Pragma("GCC diagnostic ignored \"-Wparentheses\"") \
 ( __catchResult <= expr ).endExpression(); \
_Pragma("GCC diagnostic pop") \
```
Unfortunately, there is many bugs with `_Pragam` and `gcc` that make it useless here.
3. Reverting philsquared/Catch#247 implies that expressions like `REQUIRE( 1+2 == 3 )` do not compile anymore (extra parentheses are then needed around `1+2`).
4. Using `>>` instead of `<=` removes warnings with gcc but clang wakes up with `-Woverloaded-shift-op-parentheses` warning ... 
Fortunately, `_Pragma` works fine with clang and it enables us to clean the warns.

This pull request is about that last solution. I don't know if other compilers (clang on Mac, icc, visual studio, ...) are ok with that PR.