### PR TITLE
Fix parentheses warning with Catch (again)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,8 +24,8 @@
  - Fixing boost include path issue when building tools using DGtal and
    its cmake DGtalConfig.cmake. (David Coeurjolly,
    [#1059](https://github.com/DGtal-team/DGtal/pull/1059))
- 
-
+ - Fixing parenthese warnings in Catch. Waiting for an official fix.
+   (Roland Denis, [#1069](https://github.com/DGtal-team/DGtal/pull/1069))
 
 - *Base Package*
  - Fix wrong initialization of reverse iterators in SimpleRandomAccess(Const)RangeFromPoint.

--- a/tests/base/testCatch.cpp
+++ b/tests/base/testCatch.cpp
@@ -41,14 +41,14 @@ TEST_CASE( "Point Vector Unit tests" )
   
   SECTION("Comparisons")
     {
-      REQUIRE( (a == b) );
+      REQUIRE( a == b );
       a=6;
-      REQUIRE( (a == c) );
+      REQUIRE( a == c );
     }
   
   SECTION("No side-effects on global variables in section scopes")
     {
-      REQUIRE( (a == 5) );
+      REQUIRE( a == 5 );
     }
 
 }

--- a/tests/base/testSimpleRandomAccessRangeFromPoint.cpp
+++ b/tests/base/testSimpleRandomAccessRangeFromPoint.cpp
@@ -66,29 +66,29 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
   SECTION( "Testing constant forward iterators" )
     {
       const Range range = image.range();
-      REQUIRE(( static_cast<Domain::Size>(range.end() - range.begin()) == domain.size() ));
+      REQUIRE( static_cast<Domain::Size>(range.end() - range.begin()) == domain.size() );
       REQUIRE( std::equal(range.begin(), range.end(), refImage.begin())  );
 
       ConstRange crange = image.constRange();
-      REQUIRE(( static_cast<Domain::Size>(crange.end() - crange.begin()) == domain.size() ));
+      REQUIRE( static_cast<Domain::Size>(crange.end() - crange.begin()) == domain.size() );
       REQUIRE( std::equal(crange.begin(), crange.end(), refImage.begin()) );
     }
 
   SECTION( "Testing constant forward iterators from a point" )
     {
       const Range range = image.range();
-      REQUIRE(( static_cast<Domain::Size>(range.end() - range.begin(aPoint)) == domain.size() - Linearizer::getIndex(aPoint, domain) ));
+      REQUIRE( static_cast<Domain::Size>(range.end() - range.begin(aPoint)) == domain.size() - Linearizer::getIndex(aPoint, domain) );
       REQUIRE( std::equal( range.begin(aPoint), range.end(), refImage.begin() + Linearizer::getIndex(aPoint, domain) ) );
 
       ConstRange crange = image.constRange();
-      REQUIRE(( static_cast<Domain::Size>(crange.end() - crange.begin(aPoint)) == domain.size() - Linearizer::getIndex(aPoint, domain) ));
+      REQUIRE( static_cast<Domain::Size>(crange.end() - crange.begin(aPoint)) == domain.size() - Linearizer::getIndex(aPoint, domain) );
       REQUIRE( std::equal( crange.begin(aPoint), crange.end(), refImage.begin() + Linearizer::getIndex(aPoint, domain) ) );
     }
 
   SECTION( "Testing mutable forward iterators" )
     {
       Range range = image.range();
-      REQUIRE(( static_cast<Domain::Size>(range.end() - range.begin()) == domain.size() ));
+      REQUIRE( static_cast<Domain::Size>(range.end() - range.begin()) == domain.size() );
 
       cnt = 1;
       for ( Range::Iterator it = range.begin(), it_end = range.end(); it != it_end; ++it )
@@ -109,7 +109,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
   SECTION( "Testing mutable forward iterators from a point" )
     {
       Range range = image.range();
-      REQUIRE(( static_cast<Domain::Size>(range.end() - range.begin(aPoint)) == domain.size() - Linearizer::getIndex(aPoint, domain) ));
+      REQUIRE( static_cast<Domain::Size>(range.end() - range.begin(aPoint)) == domain.size() - Linearizer::getIndex(aPoint, domain) );
 
       cnt = 1;
       for ( Range::Iterator it = range.begin(aPoint), it_end = range.end(); it != it_end; ++it )
@@ -130,29 +130,29 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
   SECTION( "Testing constant reverse iterators" )
     {
       const Range range = image.range();
-      REQUIRE(( static_cast<Domain::Size>(range.rend() - range.rbegin()) == domain.size() ));
+      REQUIRE( static_cast<Domain::Size>(range.rend() - range.rbegin()) == domain.size() );
       REQUIRE( std::equal(range.rbegin(), range.rend(), refImage.rbegin()) );
 
       ConstRange crange = image.constRange();
-      REQUIRE(( static_cast<Domain::Size>(crange.rend() - crange.rbegin()) == domain.size() ));
+      REQUIRE( static_cast<Domain::Size>(crange.rend() - crange.rbegin()) == domain.size() );
       REQUIRE( std::equal(crange.rbegin(), crange.rend(), refImage.rbegin()) );
     }
 
   SECTION( "Testing constant reverse iterators from a point" )
     {
       const Range range = image.range();
-      REQUIRE(( static_cast<Domain::Size>(range.rend() - range.rbegin(aPoint)) == Linearizer::getIndex(aPoint, domain) + 1 ));
+      REQUIRE( static_cast<Domain::Size>(range.rend() - range.rbegin(aPoint)) == Linearizer::getIndex(aPoint, domain) + 1 );
       REQUIRE( std::equal( range.rbegin(aPoint), range.rend(), refImage.rbegin() + (domain.size() - Linearizer::getIndex(aPoint, domain) - 1) ) );
 
       ConstRange crange = image.constRange();
-      REQUIRE(( static_cast<Domain::Size>(crange.rend() - crange.rbegin(aPoint)) == Linearizer::getIndex(aPoint, domain) + 1 ));
+      REQUIRE( static_cast<Domain::Size>(crange.rend() - crange.rbegin(aPoint)) == Linearizer::getIndex(aPoint, domain) + 1 );
       REQUIRE( std::equal( crange.rbegin(aPoint), crange.rend(), refImage.rbegin() + (domain.size() - Linearizer::getIndex(aPoint, domain) - 1) ) );
     }
 
   SECTION( "Testing mutable reverse iterators" )
     {
       Range range = image.range();
-      REQUIRE(( static_cast<Domain::Size>(range.rend() - range.rbegin()) == domain.size() ));
+      REQUIRE( static_cast<Domain::Size>(range.rend() - range.rbegin()) == domain.size() );
 
       cnt = 1;
       for ( Range::ReverseIterator it = range.rbegin(), it_end = range.rend(); it != it_end; ++it )
@@ -173,7 +173,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
   SECTION( "Testing mutable reverse iterators from a point" )
     {
       Range range = image.range();
-      REQUIRE(( static_cast<Domain::Size>(range.rend() - range.rbegin(aPoint)) == Linearizer::getIndex(aPoint, domain) + 1 ));
+      REQUIRE( static_cast<Domain::Size>(range.rend() - range.rbegin(aPoint)) == Linearizer::getIndex(aPoint, domain) + 1 );
 
       cnt = 1;
       for ( Range::ReverseIterator it = range.rbegin(aPoint), it_end = range.rend(); it != it_end; ++it )
@@ -274,7 +274,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
           sum += *it;
           ++cnt;
         }
-      REQUIRE(( sum == Approx(refSum) ));
+      REQUIRE( sum == Approx(refSum) );
       REQUIRE( std::equal( refImage.begin(), refImage.end(), range.c() ) );
 
       // Sum in backward way
@@ -285,7 +285,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
           sum += *it;
           ++cnt;
         }
-      REQUIRE(( sum == Approx(refSum) ));
+      REQUIRE( sum == Approx(refSum) );
 
       // Sum in forward way
       ConstRange crange = image.constRange();
@@ -296,7 +296,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
           sum += *it;
           ++cnt;
         }
-      REQUIRE(( sum == Approx(refSum) ));
+      REQUIRE( sum == Approx(refSum) );
       REQUIRE( std::equal( refImage.begin(), refImage.end(), crange.c() ) );
 
       // Sum in backward way
@@ -307,7 +307,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
           sum += *it;
           ++cnt;
         }
-      REQUIRE(( sum == Approx(refSum) ));
+      REQUIRE( sum == Approx(refSum) );
     }
 
   SECTION( "Testing constant reverse circulators" )
@@ -328,7 +328,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
           sum += *it;
           ++cnt;
         }
-      REQUIRE(( sum == Approx(refSum) ));
+      REQUIRE( sum == Approx(refSum) );
       REQUIRE( std::equal( refImage.rbegin(), refImage.rend(), range.rc() ) );
 
       // Sum in backward way
@@ -339,7 +339,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
           sum += *it;
           ++cnt;
         }
-      REQUIRE(( sum == Approx(refSum) ));
+      REQUIRE( sum == Approx(refSum) );
 
       // Sum in forward way
       ConstRange crange = image.constRange();
@@ -350,7 +350,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
           sum += *it;
           ++cnt;
         }
-      REQUIRE(( sum == Approx(refSum) ));
+      REQUIRE( sum == Approx(refSum) );
       REQUIRE( std::equal( refImage.rbegin(), refImage.rend(), crange.rc() ) );
 
       // Sum in backward way
@@ -361,7 +361,7 @@ TEST_CASE( "Testing SimpleRandomAccess(Const)RangeFromPoint from ImageContainerB
           sum += *it;
           ++cnt;
         }
-      REQUIRE(( sum == Approx(refSum) ));
+      REQUIRE( sum == Approx(refSum) );
     }
 
   SECTION( "Testing mutable circulators in forward way" )

--- a/tests/geometry/tools/testConvexHull2DThickness.cpp
+++ b/tests/geometry/tools/testConvexHull2DThickness.cpp
@@ -68,19 +68,19 @@ TEST_CASE( "Testing Rotating Caliper of ConvexHull2D (basic convex hull)" )
    
    SECTION("Testing computation of horizontal/vertical thickness of ConvexHull2D")
      {
-       REQUIRE( (thicknessHV == 1.0));
-       REQUIRE(  (pHV == Point(0,0)));
-       REQUIRE((qHV==Point(1,0)));
-       REQUIRE((sHV==Point(1,1)));
+       REQUIRE( thicknessHV == 1.0 );
+       REQUIRE( pHV == Point(0,0) );
+       REQUIRE( qHV==Point(1,0) );
+       REQUIRE( sHV==Point(1,1) );
      }
    
 
    SECTION("Testing computation of euclidean thickness of ConvexHull2D")
      {
-       REQUIRE( (thicknessEucl == Approx(std::sqrt(2.0)/2.0)) );
-       REQUIRE( (pE == Point(1,1)));
-       REQUIRE((qE==Point(0,0)) );
-       REQUIRE( (sE==Point(1,0)) );
+       REQUIRE( thicknessEucl == Approx(std::sqrt(2.0)/2.0) );
+       REQUIRE( pE == Point(1,1) );
+       REQUIRE( qE==Point(0,0) );
+       REQUIRE( sE==Point(1,0) );
      }
    
 }
@@ -118,15 +118,15 @@ TEST_CASE( "Testing Rotating Caliper of ConvexHull2D (convex hull with floating 
   
    SECTION("Testing antipodal points of ConvexHull2D")
      {
-       REQUIRE((pHV == Point(101.2, 48.2)));
-       REQUIRE((qHV==Point(104.2, 53.2)));
-       REQUIRE((sHV==Point(102.3, 52.3)));
+       REQUIRE( pHV == Point(101.2, 48.2) );
+       REQUIRE( qHV == Point(104.2, 53.2) );
+       REQUIRE( sHV == Point(102.3, 52.3) );
      }
    SECTION("Testing antipodal points of ConvexHull2D")
      {
-       REQUIRE((pE == Point(101.2, 48.2)));
-       REQUIRE((qE==Point(104.2, 53.2)));
-       REQUIRE((sE==Point(102.3, 52.3)));
+       REQUIRE( pE == Point(101.2, 48.2) );
+       REQUIRE( qE == Point(104.2, 53.2) );
+       REQUIRE( sE == Point(102.3, 52.3) );
      }
 }
 

--- a/tests/kernel/testLinearizer.cpp
+++ b/tests/kernel/testLinearizer.cpp
@@ -208,37 +208,37 @@ TEST_CASE( "Testing Linearizer in dimension " #N " with " #ORDER, "[test][dim" #
   SECTION( "Testing getIndex(Point, Point, Extent) syntax" )\
     {\
       for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, lowerBound, extent ) ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, lowerBound, extent )  );\
     }\
 \
   SECTION( "Testing getIndex(Point, Extent) syntax" )\
     {\
       for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it - lowerBound, extent ) ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it - lowerBound, extent )  );\
     }\
 \
   SECTION( "Testing getIndex(Point, Domain) syntax" )\
     {\
       for ( Domain::ConstIterator it = domain.begin(), it_end = domain.end(); it != it_end ; ++it )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, domain ) ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply(*it), refLowerBound, refExtent ) == NewLinearizer::getIndex( *it, domain )  );\
     }\
 \
   SECTION( "Testing getPoint(Index, Point, Extent) syntax" )\
     {\
       for ( std::size_t i = 0; i < domain.size(); ++i )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, lowerBound, extent ) ), refLowerBound, refExtent ) == i ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, lowerBound, extent ) ), refLowerBound, refExtent ) == i  );\
     }\
 \
   SECTION( "Testing getPoint(Index, Extent) syntax" )\
     {\
       for ( std::size_t i = 0; i < domain.size(); ++i )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, extent ) + lowerBound ), refLowerBound, refExtent ) == i ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, extent ) + lowerBound ), refLowerBound, refExtent ) == i  );\
     }\
 \
   SECTION( "Testing getPoint(Index, Domain) syntax" )\
     {\
       for ( std::size_t i = 0; i < domain.size(); ++i )\
-          REQUIRE(( RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, domain ) ), refLowerBound, refExtent ) == i ));\
+          REQUIRE(  RefLinearizer::apply( RefConverter::apply( NewLinearizer::getPoint( i, domain ) ), refLowerBound, refExtent ) == i  );\
     }\
 }
 

--- a/tests/kernel/testPointHashFunctions.cpp
+++ b/tests/kernel/testPointHashFunctions.cpp
@@ -59,21 +59,21 @@ TEST_CASE("Hash functions on DGtal::Point")
   
   SECTION("Identity test")
     {
-      REQUIRE( (myhash(p) == myhash(p_copy)) );
+      REQUIRE( myhash(p) == myhash(p_copy) );
       CAPTURE( myhash(p) );
       
 #ifdef WITH_C11
-      REQUIRE( (myhashcpp11(p) == myhashcpp11(p_copy)) );
+      REQUIRE( myhashcpp11(p) == myhashcpp11(p_copy) );
 #endif      
     }
 
   
   SECTION("Difference test")
     {
-      REQUIRE( (myhash(p) != myhash(q)) );
+      REQUIRE( myhash(p) != myhash(q) );
       
 #ifdef WITH_C11
-      REQUIRE( (myhashcpp11(p) != myhashcpp11(q)) );
+      REQUIRE( myhashcpp11(p) != myhashcpp11(q) );
 #endif 
     }
     
@@ -90,15 +90,15 @@ TEST_CASE("Hash functions on DGtal::Point")
       std::hash<Point26> myhash26cpp11;
 #endif
  
-      REQUIRE( (myhash26(pp) == myhash26(qq)) );
+      REQUIRE( myhash26(pp) == myhash26(qq) );
       
 #ifdef WITH_C11
-      REQUIRE( (myhash26cpp11(pp) == myhash26cpp11(qq)) );
+      REQUIRE( myhash26cpp11(pp) == myhash26cpp11(qq) );
 #endif
-      REQUIRE( (myhash26(pp) != myhash26(rr)) );
+      REQUIRE( myhash26(pp) != myhash26(rr) );
       
 #ifdef WITH_C11
-      REQUIRE( (myhash26cpp11(pp) != myhash26cpp11(rr)) );
+      REQUIRE( myhash26cpp11(pp) != myhash26cpp11(rr) );
 #endif 
     }
 }

--- a/tests/kernel/testPointVector-catch.cpp
+++ b/tests/kernel/testPointVector-catch.cpp
@@ -60,7 +60,7 @@ TEST_CASE( "Point Vector Unit tests" )
 
   SECTION("Comparisons")
     {
-      REQUIRE( (p1 == p1bis) );
+      REQUIRE( p1 == p1bis );
       REQUIRE( p1 < p2 );
       
 #ifdef CPP11_INITIALIZER_LIST
@@ -71,10 +71,10 @@ TEST_CASE( "Point Vector Unit tests" )
   
   SECTION("Min/Max of vector components")
     {
-      REQUIRE( (p3.max() == 2.0) );
-      REQUIRE( (p3.min() == -2.0) );
-      REQUIRE( (*p3.maxElement() == 2.0) );
-      REQUIRE( (*p3.minElement() == -2.0) );
+      REQUIRE( p3.max() == 2.0 );
+      REQUIRE( p3.min() == -2.0 );
+      REQUIRE( *p3.maxElement() == 2.0 );
+      REQUIRE( *p3.minElement() == -2.0 );
     }
 
   Point  aPoint;
@@ -87,12 +87,12 @@ TEST_CASE( "Point Vector Unit tests" )
     {
       RealPoint normalized = aPoint.getNormalized();
       CAPTURE( normalized );
-      REQUIRE( (aPoint.norm ( Point::L_1 ) == 6) );
-      REQUIRE( (aPoint.norm ( Point::L_infty ) == 3) );
-      REQUIRE( (normalized[0] == Approx( 0.801784)) );
-      REQUIRE( (normalized[1] == Approx( -0.267261)) );
-      REQUIRE( (normalized[2] == Approx( 0.534522)) );
-      REQUIRE( (normalized[3] == Approx( 0.0)) );
+      REQUIRE( aPoint.norm ( Point::L_1 ) == 6 );
+      REQUIRE( aPoint.norm ( Point::L_infty ) == 3 );
+      REQUIRE( normalized[0] == Approx( 0.801784) );
+      REQUIRE( normalized[1] == Approx( -0.267261) );
+      REQUIRE( normalized[2] == Approx( 0.534522) );
+      REQUIRE( normalized[3] == Approx( 0.0) );
     }
 
   SECTION("PointVector Iterator")
@@ -107,19 +107,19 @@ TEST_CASE( "Point Vector Unit tests" )
       
       CAPTURE(aPoint25);
       CAPTURE(sum);
-      REQUIRE( (sum == 300) );
+      REQUIRE( sum == 300 );
     }
 
   SECTION("Arithmetical Operators")
     {
-      REQUIRE( ((p1 + p2) == Point(6,6,6,6)) );
-      REQUIRE( ((p1 - p2) == Point(-4,-2,0,2)) );
-      REQUIRE( ((p1*2) == Point(2,4,6,8)) );
-      REQUIRE( ((2*p1) == Point(2,4,6,8)) );
-      REQUIRE( ((-p1) == Point(-1,-2,-3,-4)) );
-      REQUIRE( (p1.inf(p2) == Point(1,2,3,2)) );
-      REQUIRE( (p1.sup(p2) == Point(5,4,3,4)) );
-      REQUIRE( (p1.dot(p2) == 30) );
+      REQUIRE( (p1 + p2) == Point(6,6,6,6) );
+      REQUIRE( (p1 - p2) == Point(-4,-2,0,2) );
+      REQUIRE( (p1*2) == Point(2,4,6,8) );
+      REQUIRE( (2*p1) == Point(2,4,6,8) );
+      REQUIRE( (-p1) == Point(-1,-2,-3,-4) );
+      REQUIRE( p1.inf(p2) == Point(1,2,3,2) );
+      REQUIRE( p1.sup(p2) == Point(5,4,3,4) );
+      REQUIRE( p1.dot(p2) == 30 );
     }
 
 }


### PR DESCRIPTION
Second chance for the PR #1067.

The problem is now with expression like
```
REQUIRE( 1+2 == 3 );
```
that emits warning on adding parentheses around ```1+2```. 

It still allows Catch to expand each side of the comparison in case of assertion failure but it forces us to add extra-parentheses when left term contains `+` or `-`. It's more or less the same as when Catch was using `->` operator (but compilation was failing without the extra-parentheses). 

We can also keep this PR as is and wait for an official fix.

