### PR TITLE
Shadow boost warnings at build.

### DIFF
--- a/cmake/CheckDGtalDependencies.cmake
+++ b/cmake/CheckDGtalDependencies.cmake
@@ -14,7 +14,8 @@ set(Boost_USE_STATIC_RUNTIME OFF)
 set(Boost_FOUND FALSE)
 FIND_PACKAGE(Boost 1.46.0 REQUIRED)
 if ( Boost_FOUND )
-  include_directories( ${Boost_INCLUDE_DIRS} )
+  # SYSTEM to avoid warnings from boost.
+  include_directories(SYSTEM ${Boost_INCLUDE_DIRS} )
   SET(DGtalLibInc ${DGtalLibInc} ${Boost_INCLUDE_DIRS})
 
   ## Checking boost/random ( <1.47)


### PR DESCRIPTION
Setting include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

This shadows boost warnings when using/building DGtal. 
https://cmake.org/cmake/help/v3.0/command/include_directories.html