### PR TITLE
Small improvements in FMM and PGM writer.

### DIFF
--- a/src/DGtal/geometry/volumes/distance/FMM.h
+++ b/src/DGtal/geometry/volumes/distance/FMM.h
@@ -164,7 +164,6 @@ namespace DGtal
     typedef TPointPredicate PointPredicate; 
 
     //points
-    typedef typename Image::Point Vector;
     typedef typename Image::Point Point;
     BOOST_STATIC_ASSERT(( boost::is_same< Point, typename AcceptedPointSet::Point >::value ));
     BOOST_STATIC_ASSERT(( boost::is_same< Point, typename PointPredicate::Point >::value ));

--- a/src/DGtal/io/writers/PGMWriter.ih
+++ b/src/DGtal/io/writers/PGMWriter.ih
@@ -62,7 +62,7 @@ PGMWriter<I,C>::exportPGM(const std::string & filename, const I & aImage,
     out << "P5"<<std::endl;
   }
 
-  out << "#DGtal PNM Writer"<<std::endl<<std::endl;
+  out << "#DGtal PNM Writer"<<std::endl;
   out << size[0]<<" "<< size[1]<<std::endl;
   out << "255" <<std::endl;
   
@@ -136,7 +136,7 @@ PGMWriter<I,C>::exportPGM3D(const std::string & filename, const I & aImage,
   }else{
     out << ( (extension=="pgm")? "P5" : "P5-3D")<<std::endl;
   }
-  out << "#DGtal PNM Writer"<<std::endl<<std::endl;
+  out << "#DGtal PNM Writer"<<std::endl;
   out << size[0]<<" "<< size[1]<<" "<< size[2]<<std::endl;
   out << "255" <<std::endl;
 


### PR DESCRIPTION
In FMM:
    - delete an unused typedef, probably due to a copy-paste

In PGMWriter:
    - remove empty line between comment and dimensions in order to be compliant to the PGM specification