### PR TITLE
Add BoostGraphInterface to Object.

### DIFF
--- a/src/DGtal/graph/ObjectBoostGraphInterface.h
+++ b/src/DGtal/graph/ObjectBoostGraphInterface.h
@@ -1,0 +1,527 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+#pragma once
+
+/**
+ * @file ObjectBoostGraphInterface.h
+ * @author Pablo Hernandez-Cerdan. Institute of Fundamental Sciences.
+ * Massey University. Palmerston North, New Zealand
+ *
+ * @date 2016/02/01
+ *
+ * Header file for module ObjectBoostGraphInterface.cpp
+ *
+ * This file is part of the DGtal library.
+ */
+
+#if defined(ObjectBoostGraphInterface_RECURSES)
+#error Recursive header files inclusion detected in ObjectBoostGraphInterface.h
+#else // defined(ObjectBoostGraphInterface_RECURSES)
+/** Prevents recursive inclusion of headers. */
+#define ObjectBoostGraphInterface_RECURSES
+
+#if !defined ObjectBoostGraphInterface_h
+/** Prevents repeated inclusion of headers. */
+#define ObjectBoostGraphInterface_h
+
+//////////////////////////////////////////////////////////////////////////////
+// Inclusions
+#include <iostream>
+#include <vector>
+#include <boost/iterator/iterator_facade.hpp>
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/properties.hpp>
+#include <boost/property_map/property_map.hpp>
+#include "DGtal/base/Common.h"
+#include "DGtal/base/CountedPtr.h"
+#include "DGtal/topology/Object.h"
+//////////////////////////////////////////////////////////////////////////////
+
+
+// The interface to the Boost Graph should be defined in namespace boost.
+namespace boost
+{
+
+  /**
+     Defines the boost graph traits for any kind of object
+     (see DGtal::Object). With these definitions, a DGtal::Object is
+     a model of VertexListGraphConcept, AdjacencyGraphConcept,
+     IncidenceGraphConcept, EdgeListGraphConcept. You may use
+     DGtal::Object as is in BOOST graph algorithms (see
+     http://www.boost.org/doc/libs/1_60_0/libs/graph/doc/table_of_contents.html).
+
+     The difficult part is that models of
+     DGtal::CUndirectedSimpleGraph (like DGtal::Object) are
+     only required to provide vertex iterators that are models of
+     SinglePassIterator. Furthermore, no edge iterators are required,
+     only the list of adjacent vertices. Therefore, most of the work
+     is to create iterators over edges that are "persistent",
+     i.e. models of MultiPassInputIterator (very similar to
+     ForwardIterator).
+
+     @remark Note that, for now, vertex iterators are taken as is from
+     the DGtal::Object container. Hence, they must be models of
+     MultiPassInputIterator.
+
+     @tparam TDigitalTopology Topology of the set.
+
+     @tparam TDigitalSet the container chosen for the
+     digital set.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  struct graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >
+  {
+    /// the adapted DGtal graph class.
+    typedef DGtal::Object< TDigitalTopology, TDigitalSet > Adapted;
+    /// the graph is undirected.
+    typedef undirected_tag directed_category;
+    /// the graph satisfies AdjacencyListGraph and VertexListGraph concepts.
+    typedef Object_graph_traversal_category traversal_category;
+    /// the graph does not allow parallel edges.
+    typedef disallow_parallel_edge_tag edge_parallel_category;
+
+    /// the type for counting vertices
+    typedef typename Adapted::Size vertices_size_type;
+    /// the type for counting edges
+    typedef typename Adapted::Size edges_size_type;
+    /// the type for counting out or in edges
+    typedef typename Adapted::Size degree_size_type;
+
+    /// Vertex type
+    typedef typename Adapted::Vertex Vertex;
+    /// Vertex type
+    typedef Vertex vertex_descriptor;
+    /// (oriented) edge type
+    typedef typename Adapted::Edge Edge;
+    /// (oriented) edge type
+    typedef Edge edge_descriptor;
+    /// Iterator for visiting vertices. It must be a model of
+    /// MultiPassInputIterator, i.e. a kind of ForwardIterator.
+    typedef typename Adapted::ConstIterator vertex_iterator;
+
+    /// This is the intermediate data structure that is used for visiting adjacent vertices.
+    typedef std::vector< vertex_descriptor > AdjacentVertexContainer;
+    /// This is the intermediate data structure that is used for storing out edges.
+    typedef typename Adapted::EdgeRange OutEdgeContainer;
+
+
+    /**
+     *  @return the invalid vertex for that kind of graph (default Vertex( 0 )).
+     */
+    static
+    inline
+    vertex_descriptor null_vertex()
+    {
+      return vertex_descriptor( 0 );
+    }
+
+    /**
+       Iterator for visiting adjacent vertices.  We use an iterator
+       facade to create a STL-compliant iterator with as little effort
+       as possible.
+
+       \note The difficulty is that DGtal graphs do not provide
+       iterators for visiting edges or adjacent vertices, but merely
+       provide a method that outputs them. Therefore, this iterator \b
+       shares the container of adjacent vertices (a std::vector) with
+       other (potentially) iterators, through a DGtal::CountedPtr. When the
+       last iterator pointing in this structure is desallocated, the
+       container is automatically desallocated. This is for instance
+       used by function \ref adjacent_vertices, which returns a pair
+       of adjacency_iterator, both points on the same
+       container. Another problem is that the user may have called
+       twice \ref adjacent_vertices on the same vertex, and may wish
+       to compare iterators obtained by two different calls.
+
+       @code
+       typedef typename Object<...> G;
+       typedef typename graph_traits<G>::adjacency_iterator adjacency_iterator;
+       G g(...);
+       std::pair<adjacency_iterator,adjacency_iterator> vp1 = boost::adjacent_vertices( vertex, g );
+       std::pair<adjacency_iterator,adjacency_iterator> vp2 = boost::adjacent_vertices( vertex, g );
+       @endcode
+
+       In this case, \a vp1 and \a vp2 are not pointing on the same
+       structure, hence the address pointed by \a vp1 is different
+       from the address pointed by \a vp2. They are then not
+       comparable a priori. The adjacency_iterator is written so that
+       vp1 (.first or .second) and vp2 (.first or .second) \b are
+       comparable, using value comparison and out-of-range check.
+    */
+    class adjacency_iterator
+      : public iterator_facade< adjacency_iterator,
+                                Vertex,
+                                bidirectional_traversal_tag,
+                                const Vertex & >
+    {
+    public:
+      inline
+      adjacency_iterator()
+        : myIterator(), myVertices( 0 ) {}
+      inline
+      adjacency_iterator( typename AdjacentVertexContainer::const_iterator it,
+                          const DGtal::CountedPtr< AdjacentVertexContainer > & vertices )
+        : myIterator( it ), myVertices( vertices ) {}
+    private:
+      inline
+      const Vertex & dereference() const
+      {
+        ASSERT( myIterator != myVertices->end() );
+        return *myIterator;
+      }
+
+      inline
+      bool equal(const adjacency_iterator& other) const
+      {
+        bool thisAtEnd = ( myIterator == myVertices->end() );
+        bool otherAtEnd = ( other.myIterator == other.myVertices->end() );
+        if ( thisAtEnd || otherAtEnd ) return thisAtEnd && otherAtEnd;
+        else return *myIterator == *other.myIterator;
+      }
+
+      inline
+      void increment() { ++myIterator; }
+      inline
+      void decrement() { --myIterator; }
+
+      /// The iterator pointing in the container of adjacent vertices.
+      typename AdjacentVertexContainer::const_iterator myIterator;
+      /// A counted pointer to the dynamically allocated container of
+      /// vertices. Will be automatically deallocated when there is no
+      /// more iterators pointing on it.
+      DGtal::CountedPtr< AdjacentVertexContainer > myVertices;
+
+      friend class iterator_core_access;
+    }; // end class adjacency_iterator
+
+    /**
+       Iterator for visiting out edges.  We use an iterator
+       facade to create a STL-compliant iterator with as little effort
+       as possible.
+
+       \note The difficulty is that DGtal graphs do not provide
+       iterators for visiting edges or adjacent vertices, but merely
+       provide a method that outputs them. Therefore, this iterator \b
+       shares the container of out edges (a std::vector) with other
+       (potentially) iterators, through a DGtal::CountedPtr. When the last
+       iterator pointing in this structure is desallocated, the
+       container is automatically desallocated. This is for instance
+       used by function \ref out_edges, which returns a pair of
+       out_edge_iterator, both points on the same container. Another
+       problem is that the user may have called twice \ref out_edges
+       on the same vertex, and may wish to compare iterators obtained
+       by two different calls..
+
+       @code
+       typedef typename Object<...> G;
+       typedef typename graph_traits<G>::out_edge_iterator out_edge_iterator;
+       G g(...);
+       std::pair<out_edge_iterator,out_edge_iterator> vp1 = boost::out_edges( vertex, g );
+       std::pair<out_edge_iterator,out_edge_iterator> vp2 = boost::out_edges( vertex, g );
+       @endcode
+
+       In this case, \a vp1 and \a vp2 are not pointing on the same
+       structure, hence the address pointed by \a vp1 is different
+       from the address pointed by \a vp2. They are then not
+       comparable a priori. The out_edge_iterator is written so that
+       vp1 (.first or .second) and vp2 (.first or .second) \b are
+       comparable, using value comparison and out-of-range check.
+    */
+    class out_edge_iterator
+      : public iterator_facade< out_edge_iterator,
+                                Edge,
+                                bidirectional_traversal_tag,
+                                const Edge & >
+    {
+    public:
+      inline
+      out_edge_iterator()
+        : myIterator(), myOutEdges( 0 ) {}
+      inline
+      out_edge_iterator( typename OutEdgeContainer::const_iterator it,
+                         const DGtal::CountedPtr< OutEdgeContainer > & out_edges )
+        : myIterator( it ), myOutEdges( out_edges ) {}
+    private:
+      inline
+      const Edge & dereference() const
+      {
+        ASSERT( myIterator != myOutEdges->end() );
+        return *myIterator;
+      }
+
+      inline
+      bool equal(const out_edge_iterator & other) const
+      {
+        bool thisAtEnd = ( myIterator == myOutEdges->end() );
+        bool otherAtEnd = ( other.myIterator == other.myOutEdges->end() );
+        if ( thisAtEnd || otherAtEnd ) return thisAtEnd && otherAtEnd;
+        else return *myIterator == *other.myIterator;
+      }
+
+      inline
+      void increment() { ++myIterator; }
+      inline
+      void decrement() { --myIterator; }
+
+      /// The iterator pointing in the container of out edges.
+      typename OutEdgeContainer::const_iterator myIterator;
+      /// A counted pointer to the dynamically allocated container of
+      /// out edges. Will be automatically deallocated when there is no
+      /// more iterators pointing on it.
+      DGtal::CountedPtr< OutEdgeContainer > myOutEdges;
+
+      friend class iterator_core_access;
+    }; // end class out_edge_iterator
+
+    /**
+       Iterator for visiting all edges of the graph.  We use an iterator
+       facade to create a STL-compliant iterator with as little effort
+       as possible.
+
+       \note The difficulty is that DGtal graphs do not provide
+       iterators for visiting edges or adjacent vertices, but merely
+       provide a method that outputs them. Therefore, this iterator
+       mixes a vertex_iterator (to visit all vertices) and a local
+       out_edge_iterator (to visit all out edges of each vertex). This
+       is for instance used by function \ref edges, which returns a
+       pair of edge_iterator. A potential problem is that the user may
+       have called twice \ref edges, and may wish to compare iterators
+       obtained by two different calls. Here, edges are constructed on
+       the fly, hence iterators may not point on the same container
+       even if the values are the same.
+
+       @code
+       typedef typename Object<...> G;
+       typedef typename graph_traits<G>::edge_iterator edge_iterator;
+       G g(...);
+       std::pair<edge_iterator,edge_iterator> vp1 = boost::edges( g );
+       std::pair<edge_iterator,edge_iterator> vp2 = boost::edges( g );
+       @endcode
+
+       In this case, \a vp1 and \a vp2 are not pointing on the same
+       structure, hence the address pointed by \a vp1 is different
+       from the address pointed by \a vp2. They are then not
+       comparable a priori. The edge_iterator is written so that
+       vp1 (.first or .second) and vp2 (.first or .second) \b are
+       comparable, using value comparison and out-of-range check.
+    */
+    class edge_iterator
+      : public iterator_facade< edge_iterator,
+                                Edge,
+                                forward_traversal_tag,
+                                const Edge & >
+    {
+    public:
+      edge_iterator();
+      edge_iterator( const Adapted & graph,
+                     const vertex_iterator & itB, const vertex_iterator & itE );
+
+    private:
+      const Edge & dereference() const;
+      bool equal(const edge_iterator & other) const;
+      void increment();
+
+      const Adapted* myGraph;
+      std::pair< vertex_iterator, vertex_iterator > myVertexRange;
+      std::pair< out_edge_iterator, out_edge_iterator > myOutEdgeRange;
+
+      friend class iterator_core_access;
+    }; // end class out_edge_iterator
+
+
+    using in_edge_iterator = out_edge_iterator ;
+  }; // end struct graph_traits< >
+
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Functions for the boost graph interface to Object<TDigitalTopology, TDigitalSet>.
+
+  /**
+     @param edge an edge (s,t) on \a obj.
+     @param obj a valid object.
+     @return the vertex s.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  inline
+  typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertex_descriptor
+  source( typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_descriptor edge,
+          const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
+  {
+    return edge.vertices[0]; ;
+  }
+  /**
+     @param edge an arc (s,t) on \a obj.
+     @param obj a valid object.
+     @return the vertex t.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  inline
+  typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertex_descriptor
+  target( typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_descriptor edge,
+          const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
+  {
+    return edge.vertices[1];
+  }
+
+  /**
+     @param obj a valid object.
+     @return a pair< vertex_iterator, vertex_iterator > that
+     represents a range to visit all the vertices of \a obj.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  std::pair<
+    typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertex_iterator,
+    typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertex_iterator
+    >
+  vertices( const DGtal::Object< TDigitalTopology, TDigitalSet > & obj );
+
+  /**
+     @param obj a valid object.
+     @return the number of vertices of \a obj.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  inline
+  typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertices_size_type
+  num_vertices( const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
+  {
+    return obj.size();
+  }
+
+  /**
+     @param u a vertex belonging to \a obj.
+     @param obj a valid object.
+     @return a pair< adjacency_iterator, adjacency_iterator > that
+     represents a range to visit the adjacent vertices of vertex \a
+     u.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  inline
+  std::pair<
+    typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::adjacency_iterator,
+    typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::adjacency_iterator
+    >
+  adjacent_vertices( typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertex_descriptor u,
+                     const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
+  {
+    typedef typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >
+      ::adjacency_iterator Iterator;
+    typedef typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >
+      ::AdjacentVertexContainer Container;
+    DGtal::CountedPtr<Container> ptrAdjVertices( new Container );
+    std::back_insert_iterator< Container > outIt = std::back_inserter( *ptrAdjVertices );
+    obj.writeNeighbors( outIt, u );
+    return std::make_pair( Iterator( ptrAdjVertices->begin(), ptrAdjVertices ),
+                           Iterator( ptrAdjVertices->end(), ptrAdjVertices ) );
+  }
+
+
+  /**
+     @param u a vertex belonging to \a obj.
+     @param obj a valid object.
+
+     @return a pair< out_edge_iterator, out_edge_iterator > that
+     represents a range to visit the out edges of vertex \a u. Each
+     out edge is a tuple (u,t) of vertices, where t != u.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  inline
+  std::pair<
+    typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::out_edge_iterator,
+    typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::out_edge_iterator
+    >
+  out_edges( typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertex_descriptor u,
+             const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
+  {
+    typedef typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >
+      ::out_edge_iterator Iterator;
+    typedef typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >
+      ::OutEdgeContainer Container;
+    DGtal::CountedPtr<Container> ptrEdges( new Container( obj.outEdges( u ) ) );
+    return std::make_pair( Iterator( ptrEdges->begin(), ptrEdges ),
+                           Iterator( ptrEdges->end(), ptrEdges ) );
+  }
+
+
+  /**
+     @param u a vertex belonging to \a obj
+     @param obj a valid Object.
+
+     @return the number of out edges at vertex \a u.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  inline
+  typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::degree_size_type
+  out_degree( typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertex_descriptor u,
+              const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
+  {
+    return obj.degree( u );
+  }
+
+  /**
+     @param obj a valid Object.
+     @return a pair< edge_iterator, edge_iterator > that
+     represents a range to visit all the edges of \a obj . Each
+     edge is a tuple (u,t) of vertices, where t != u.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  inline
+  std::pair<
+    typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_iterator,
+    typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_iterator
+    >
+  edges( const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
+  {
+    typedef typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_iterator
+      edge_iterator;
+    return std::make_pair( edge_iterator( obj, obj.begin(), obj.end() ),
+                           edge_iterator( obj, obj.end(), obj.end() ) );
+  }
+
+  /**
+     @param obj a valid object.
+     @return the number of edges of \a obj.
+  */
+  template < class TDigitalTopology, class TDigitalSet >
+  inline
+  typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edges_size_type
+  num_edges( const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
+  {
+    typedef typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_iterator
+      edge_iterator;
+    typedef typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edges_size_type
+      edges_size_type;
+    edges_size_type nbEdges = 0;
+    for ( std::pair< edge_iterator, edge_iterator > ve = boost::edges( obj );
+          ve.first != ve.second; ++ve.first )
+      ++nbEdges;
+    return nbEdges;
+  }
+
+} // namespace Boost
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Includes inline functions.
+#include "DGtal/graph/ObjectBoostGraphInterface.ih"
+
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#endif // !defined ObjectBoostGraphInterface_h
+
+#undef ObjectBoostGraphInterface_RECURSES
+#endif // else defined(ObjectBoostGraphInterface_RECURSES)

--- a/src/DGtal/graph/ObjectBoostGraphInterface.h
+++ b/src/DGtal/graph/ObjectBoostGraphInterface.h
@@ -361,10 +361,10 @@ namespace boost
   source( typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_descriptor edge,
           const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
   {
-    return edge.vertices[0]; ;
+    return obj.tail( edge );
   }
   /**
-     @param edge an arc (s,t) on \a obj.
+     @param edge an edge (s,t) on \a obj.
      @param obj a valid object.
      @return the vertex t.
   */
@@ -374,7 +374,7 @@ namespace boost
   target( typename graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_descriptor edge,
           const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
   {
-    return edge.vertices[1];
+    return obj.head( edge );
   }
 
   /**

--- a/src/DGtal/graph/ObjectBoostGraphInterface.h
+++ b/src/DGtal/graph/ObjectBoostGraphInterface.h
@@ -120,13 +120,13 @@ namespace boost
 
 
     /**
-     *  @return the invalid vertex for that kind of graph (default Vertex( 0 )).
+     *  @return the invalid vertex for that kind of graph (default Vertex()).
      */
     static
     inline
     vertex_descriptor null_vertex()
     {
-      return vertex_descriptor( 0 );
+      return vertex_descriptor();
     }
 
     /**
@@ -139,8 +139,8 @@ namespace boost
        provide a method that outputs them. Therefore, this iterator \b
        shares the container of adjacent vertices (a std::vector) with
        other (potentially) iterators, through a DGtal::CountedPtr. When the
-       last iterator pointing in this structure is desallocated, the
-       container is automatically desallocated. This is for instance
+       last iterator pointing in this structure is deallocated, the
+       container is automatically deallocated. This is for instance
        used by function \ref adjacent_vertices, which returns a pair
        of adjacency_iterator, both points on the same
        container. Another problem is that the user may have called
@@ -169,14 +169,30 @@ namespace boost
                                 const Vertex & >
     {
     public:
+      /// Default, invalid, constructor.
       inline
       adjacency_iterator()
         : myIterator(), myVertices( 0 ) {}
+
+      /**
+       * Valid constructor from instance of AdjacentVertexContainer.
+       * The iterator shares the container of adjacent vertices
+       * (a std::vector) with other (potentially) iterators,
+       * through a DGtal::CountedPtr.
+       *
+       * @param it const_iterator of AdjacentVertexContainer.
+       * @param vertices CountedPtr of an AdjacentVertexContainer
+       */
       inline
       adjacency_iterator( typename AdjacentVertexContainer::const_iterator it,
                           const DGtal::CountedPtr< AdjacentVertexContainer > & vertices )
         : myIterator( it ), myVertices( vertices ) {}
+
     private:
+      /**
+       * @return const reference to the Vertex the iterator is pointing to.
+       * Required for Readable Iterator, Writable Iterator Concepts
+       */
       inline
       const Vertex & dereference() const
       {
@@ -184,6 +200,14 @@ namespace boost
         return *myIterator;
       }
 
+      /**
+       * Predicate to compare equal value of iterators.
+       * Required to implement Single Pass Iterator Concept.
+       *
+       * @param other adjacency_iterator to compare with.
+       *
+       * @return true iff other and this refer to the same Vertex.
+       */
       inline
       bool equal(const adjacency_iterator& other) const
       {
@@ -193,18 +217,32 @@ namespace boost
         else return *myIterator == *other.myIterator;
       }
 
+      /**
+       * Increment iterator.
+       * Required to implement Incrementable Iterator Concept.
+       */
       inline
       void increment() { ++myIterator; }
+
+      /**
+       * Decrement iterator.
+       * Required to implement Bidirectional Traversal Iterator Concept.
+       */
       inline
       void decrement() { --myIterator; }
 
+      // ///////////// Data Members ////////////////
+
       /// The iterator pointing in the container of adjacent vertices.
       typename AdjacentVertexContainer::const_iterator myIterator;
-      /// A counted pointer to the dynamically allocated container of
-      /// vertices. Will be automatically deallocated when there is no
-      /// more iterators pointing on it.
+      /**
+       * A counted pointer to the dynamically allocated container of
+       * vertices. Will be automatically deallocated when there is no
+       * more iterators pointing on it.
+       */
       DGtal::CountedPtr< AdjacentVertexContainer > myVertices;
 
+      /// Requirement for boost::iterator_facade
       friend class iterator_core_access;
     }; // end class adjacency_iterator
 
@@ -218,8 +256,8 @@ namespace boost
        provide a method that outputs them. Therefore, this iterator \b
        shares the container of out edges (a std::vector) with other
        (potentially) iterators, through a DGtal::CountedPtr. When the last
-       iterator pointing in this structure is desallocated, the
-       container is automatically desallocated. This is for instance
+       iterator pointing in this structure is deallocated, the
+       container is automatically deallocated. This is for instance
        used by function \ref out_edges, which returns a pair of
        out_edge_iterator, both points on the same container. Another
        problem is that the user may have called twice \ref out_edges
@@ -248,14 +286,28 @@ namespace boost
                                 const Edge & >
     {
     public:
+      /// Default, invalid, constructor.
       inline
       out_edge_iterator()
         : myIterator(), myOutEdges( 0 ) {}
+      /**
+       * Valid constructor from instance of OutEdgeContainer.
+       * The iterator shares the container of out edges
+       * (a std::vector) with other (potentially) iterators,
+       * through a DGtal::CountedPtr.
+       *
+       * @param it const_iterator of OutEdgeContainer.
+       * @param vertices CountedPtr of an OutEdgeContainer
+       */
       inline
       out_edge_iterator( typename OutEdgeContainer::const_iterator it,
                          const DGtal::CountedPtr< OutEdgeContainer > & out_edges )
         : myIterator( it ), myOutEdges( out_edges ) {}
     private:
+      /**
+       * @return const reference to the Edge the iterator is pointing to.
+       * Required for Readable Iterator, Writable Iterator Concepts
+       */
       inline
       const Edge & dereference() const
       {
@@ -263,6 +315,14 @@ namespace boost
         return *myIterator;
       }
 
+      /**
+       * Predicate to compare equal value of iterators.
+       * Required to implement Single Pass Iterator Concept.
+       *
+       * @param other out_edge_iterator to compare with.
+       *
+       * @return true iff other and this refer to the same Edge.
+       */
       inline
       bool equal(const out_edge_iterator & other) const
       {
@@ -272,20 +332,36 @@ namespace boost
         else return *myIterator == *other.myIterator;
       }
 
+      /**
+       * Increment iterator.
+       * Required to implement Incrementable Iterator Concept.
+       */
       inline
       void increment() { ++myIterator; }
+      /**
+       * Decrement iterator.
+       * Required to implement Bidirectional Traversal Iterator Concept.
+       */
       inline
       void decrement() { --myIterator; }
 
       /// The iterator pointing in the container of out edges.
       typename OutEdgeContainer::const_iterator myIterator;
-      /// A counted pointer to the dynamically allocated container of
-      /// out edges. Will be automatically deallocated when there is no
-      /// more iterators pointing on it.
+      /** A counted pointer to the dynamically allocated container of
+       *  out edges. Will be automatically deallocated when there is no
+       *  more iterators pointing on it.
+       */
       DGtal::CountedPtr< OutEdgeContainer > myOutEdges;
 
+      /// Requirement for boost::iterator_facade
       friend class iterator_core_access;
     }; // end class out_edge_iterator
+
+    /**
+     * Alias to use in_edge_iterator as out_edge_iterator.
+     * Required by filtered_graph algorithm.
+     */
+    using in_edge_iterator = out_edge_iterator ;
 
     /**
        Iterator for visiting all edges of the graph.  We use an iterator
@@ -326,24 +402,55 @@ namespace boost
                                 const Edge & >
     {
     public:
+      /// Default, invalid, constructor.
       edge_iterator();
+      /**
+       * Valid constructor from instance of an Object (Graph),
+       * and begin/end vertex_iterators.
+       * This iterator mixes a vertex_iterator (to visit all vertices)
+       * and a local out_edge_iterator (to visit all out edges
+       * of each vertex).
+       *
+       * @param graph valid Object.
+       * @param itB begin vertex_iterator of \b graph.
+       * @param itE end vertex_iterator of \b graph.
+       */
       edge_iterator( const Adapted & graph,
                      const vertex_iterator & itB, const vertex_iterator & itE );
 
     private:
+      /**
+       * @return const reference to the Edge the iterator is pointing to.
+       * Required for Readable Iterator, Writable Iterator Concepts
+       */
       const Edge & dereference() const;
+      /**
+       * Predicate to compare equal value of iterators.
+       * Required to implement Single Pass Iterator Concept.
+       *
+       * @param other edge_iterator to compare with.
+       *
+       * @return true iff other and this refer to the same Edge.
+       */
       bool equal(const edge_iterator & other) const;
+      /**
+       * Increment iterator.
+       * Required to implement Incrementable Iterator Concept.
+       */
       void increment();
 
+      // /////////// Data Members //////////////
+      /// Graph to iterate from.
       const Adapted* myGraph;
+      /// Vertex Range to iterator from. Set at constructor.
       std::pair< vertex_iterator, vertex_iterator > myVertexRange;
+      /// Local pair of out_edge_iterator. Created within this iterator.
       std::pair< out_edge_iterator, out_edge_iterator > myOutEdgeRange;
 
+      /// Requirement for boost::iterator_facade
       friend class iterator_core_access;
     }; // end class out_edge_iterator
 
-
-    using in_edge_iterator = out_edge_iterator ;
   }; // end struct graph_traits< >
 
 

--- a/src/DGtal/graph/ObjectBoostGraphInterface.h
+++ b/src/DGtal/graph/ObjectBoostGraphInterface.h
@@ -297,7 +297,7 @@ namespace boost
        * through a DGtal::CountedPtr.
        *
        * @param it const_iterator of OutEdgeContainer.
-       * @param vertices CountedPtr of an OutEdgeContainer
+       * @param out_edges CountedPtr of an OutEdgeContainer
        */
       inline
       out_edge_iterator( typename OutEdgeContainer::const_iterator it,

--- a/src/DGtal/graph/ObjectBoostGraphInterface.ih
+++ b/src/DGtal/graph/ObjectBoostGraphInterface.ih
@@ -1,0 +1,120 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file ObjectBoostGraphInterface.ih
+ * @author Pablo Hernandez-Cerdan. Institute of Fundamental Sciences.
+ * Massey University. Palmerston North, New Zealand
+ *
+ * @date 2016/02/01
+ *
+ * Implementation of inline methods defined in ObjectBoostGraphInterface.h
+ *
+ * This file is part of the DGtal library.
+ */
+
+
+//////////////////////////////////////////////////////////////////////////////
+#include <cstdlib>
+//////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// IMPLEMENTATION of inline methods.
+///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// ----------------------- Standard services ------------------------------
+
+template < class TDigitalTopology, class TDigitalSet >
+inline
+std::pair<
+  typename boost::graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertex_iterator,
+  typename boost::graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::vertex_iterator
+  >
+boost::vertices( const DGtal::Object< TDigitalTopology, TDigitalSet > & obj )
+{
+  return std::make_pair( obj.begin(), obj.end() );
+}
+//-----------------------------------------------------------------------------
+template < class TDigitalTopology, class TDigitalSet >
+inline
+boost::graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_iterator::
+edge_iterator()
+  : myGraph( 0 )
+{}
+//-----------------------------------------------------------------------------
+template < class TDigitalTopology, class TDigitalSet >
+inline
+boost::graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_iterator::
+edge_iterator( const Adapted & graph,
+               const vertex_iterator & itB, const vertex_iterator & itE )
+  : myGraph( &graph ),
+    myVertexRange( itB, itE ),
+    myOutEdgeRange()
+{
+  if ( myVertexRange.first != myVertexRange.second )
+    {
+      myOutEdgeRange = boost::out_edges( *myVertexRange.first, *myGraph );
+    }
+}
+//-----------------------------------------------------------------------------
+template < class TDigitalTopology, class TDigitalSet >
+inline
+const typename boost::graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::Edge &
+boost::graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_iterator::
+dereference() const
+{
+  ASSERT( myVertexRange.first != myVertexRange.second );
+  ASSERT( myOutEdgeRange.first != myOutEdgeRange.second );
+  return *( myOutEdgeRange.first );
+}
+//-----------------------------------------------------------------------------
+template < class TDigitalTopology, class TDigitalSet >
+inline
+bool
+boost::graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_iterator::
+equal( const edge_iterator & other ) const
+{
+  bool thisAtEnd = ( myVertexRange.first == myVertexRange.second );
+  bool otherAtEnd = ( other.myVertexRange.first == other.myVertexRange.second );
+  if ( thisAtEnd || otherAtEnd ) return thisAtEnd && otherAtEnd;
+  else
+    {
+      ASSERT( myOutEdgeRange.first != myOutEdgeRange.second );
+      ASSERT( other.myOutEdgeRange.first != other.myOutEdgeRange.second );
+      return *myOutEdgeRange.first == *other.myOutEdgeRange.first;
+    }
+}
+//-----------------------------------------------------------------------------
+template < class TDigitalTopology, class TDigitalSet >
+inline
+void
+boost::graph_traits< DGtal::Object< TDigitalTopology, TDigitalSet > >::edge_iterator::
+increment()
+{
+  ++myOutEdgeRange.first;
+  if ( myOutEdgeRange.first == myOutEdgeRange.second )
+    {
+      ++myVertexRange.first;
+      if ( myVertexRange.first != myVertexRange.second )
+        myOutEdgeRange = boost::out_edges( *myVertexRange.first, *myGraph );
+    }
+}
+
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+

--- a/src/DGtal/graph/doc/moduleBoostGraphWrapping.dox
+++ b/src/DGtal/graph/doc/moduleBoostGraphWrapping.dox
@@ -38,8 +38,10 @@ namespace DGtal {
    on-the-fly), because boost graphs require multipass iterators on
    vertices and edges. 
 
-   For now, only DigitalSurface instances are wrapped to satisfy boost
-   graph concepts.
+   For now, the only models that are wrapped to satisfy boost
+   graph concepts are:
+   - DigitalSurface.
+   - Object, since 0.9.2.
 
    @note A natural question is why DGtal graph concepts do not match
    exactly boost graph concepts. This is for mainly three reasons:
@@ -282,6 +284,21 @@ creating your property map, as follows.
 You may have a look at \ref
 graph/testDigitalSurfaceBoostGraphInterface.cpp to see a few more
 examples of using Boost Graph algorithms (max-flow and min-cut).
+
+  @subsection dgtal_graph_boost_3 Wrapping Object as a boost graph
+
+   The file \ref ObjectBoostGraphInterface.h defines the boost
+   graph traits for any kind of Object (see
+   Object). With those definitios, an Object is a model of
+   VertexListGraphConcept, AdjacencyGraphConcept,
+   IncidenceGraphConcept, EdgeListGraphConcept.
+   You may use an Object as a graph in any Boost Graph Library
+   algorithm that satisfies the mentioned concepts.
+
+   You may have a look at \ref
+   graph/testObjectBoostGraphInterface.cpp for examples
+   on how to use Object as a graph. Also see DigitalSurface section,
+   as the interfaces are similar.
 
 */
 

--- a/src/DGtal/topology/Object.h
+++ b/src/DGtal/topology/Object.h
@@ -27,7 +27,9 @@
  *
  * Header file for module Object.cpp
  *
+ * PHC just added Boost Graph Library Interface in 0.9.2
  * This file is part of the DGtal library.
+ *
  */
 
 #if defined(Object_RECURSES)
@@ -101,6 +103,8 @@ namespace DGtal
    * \b Object has a Boost Graph Interface to directly use an object
    * instance into boost graph library algorithms.
    *	@see ObjectBoostGraphInterface.h
+   *	@see moduleBoostGraphWrapping for documentation on the interface
+   *	with boost::graph library.
    *
    * @tparam TDigitalTopology any realization of DigitalTopology.
    * @tparam TDigitalSet any model of CDigitalSet.

--- a/src/DGtal/topology/Object.h
+++ b/src/DGtal/topology/Object.h
@@ -168,7 +168,6 @@ namespace DGtal
 	Constructor from vertices with no auto-order.
 	@param v1 the first vertex.
 	@param v2 the second vertex.
-	@param bool unused flag to select this constructor.
 	*/
       Edge( const Vertex & v1, const Vertex & v2, const bool )
       {

--- a/src/DGtal/topology/Object.h
+++ b/src/DGtal/topology/Object.h
@@ -173,6 +173,7 @@ namespace DGtal
       {
 	vertices[ 0 ] = v1;
 	vertices[ 1 ] = v2;
+	boost::ignore_unused_variable_warning(b);
       }
       /**
 	Constructor from vertices with auto-ordering.
@@ -523,6 +524,23 @@ objects[ 0 ].writeComponents( it ); // it points in same container as this.
      * @return opposite edge.
      */
     Edge opposite(const Edge & e) const;
+
+    /**
+     *
+     * @param e edge
+     *
+     * @return Head vertex of edge. Related to boost::target
+     * @note It doesn't check if output vertex belongs to Object.
+     */
+    Vertex head( const Edge & e) const;
+    /**
+     *
+     * @param e edge
+     *
+     * @return Tail vertex of edge. Related to boost::source
+     * @note It doesn't check if output vertex belongs to Object.
+     */
+    Vertex tail( const Edge & e) const;
 
     // ----------------------- Simple points -------------------------------
   public:

--- a/src/DGtal/topology/Object.h
+++ b/src/DGtal/topology/Object.h
@@ -20,8 +20,10 @@
  * @file Object.h
  * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr )
  * Laboratory of Mathematics (CNRS, UMR 5807), University of Savoie, France
+ * @author Pablo Hernandez-Cerdan. Institute of Fundamental Sciences.
+ * Massey University. Palmerston North, New Zealand
  *
- * @date 2010/07/07
+ * @date 2016/02/01
  *
  * Header file for module Object.cpp
  *
@@ -52,7 +54,21 @@
 #include "DGtal/kernel/sets/CDigitalSet.h"
 #include "DGtal/kernel/sets/DigitalSetSelector.h"
 #include "DGtal/topology/Topology.h"
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/properties.hpp>
 //////////////////////////////////////////////////////////////////////////////
+
+namespace boost
+{
+  /**
+     This is the kind of boost graph that an Object (@see DGtal::Object) can mimick.
+  */
+  struct Object_graph_traversal_category
+    : public virtual adjacency_graph_tag,
+      public virtual vertex_list_graph_tag,
+      public virtual incidence_graph_tag,
+      public virtual edge_list_graph_tag { };
+}
 
 namespace DGtal
 {
@@ -81,7 +97,7 @@ namespace DGtal
    * adjacency relations are displayed.
    *
    * \b Model of CUndirectedSimpleLocalGraph and CUndirectedSimpleGraph.
-   * 
+   *
    * @tparam TDigitalTopology any realization of DigitalTopology.
    * @tparam TDigitalSet any model of CDigitalSet.
    *
@@ -94,444 +110,499 @@ namespace DGtal
     // ----------------------- Standard services ------------------------------
   public:
     typedef TDigitalSet DigitalSet;
-    
+
     BOOST_CONCEPT_ASSERT(( concepts::CDigitalSet< TDigitalSet > ));
-    
-      typedef TDigitalTopology DigitalTopology;
-      typedef typename DigitalTopology::ReverseTopology ReverseTopology;
-      typedef typename DigitalSet::Size Size;
-      typedef typename DigitalSet::Point Point;
-      // should be the same as Point.
-      typedef typename DigitalTopology::Point DTPoint;
 
-      typedef typename DigitalSet::Domain Domain;
-      typedef typename Domain::Space Space;
-      typedef
+    // ----------------------- boost graph tags ------------------------------
+    // JOL (2013/02/01): required to define internal tags (boost/graph/copy.hpp, l. 251 error ?).
+    // PHC(2016/02/01): copied from digital surface to use connected_components
+  public:
+    /// the graph is undirected.
+    typedef boost::undirected_tag directed_category;
+    /// the graph satisfies AdjacencyListGraph and VertexListGraph concepts.
+    typedef boost::Object_graph_traversal_category traversal_category;
+    /// the graph does not allow parallel edges.
+    typedef boost::disallow_parallel_edge_tag edge_parallel_category;
+
+    typedef TDigitalTopology DigitalTopology;
+    typedef typename DigitalTopology::ReverseTopology ReverseTopology;
+    typedef typename DigitalSet::Size Size;
+    typedef typename DigitalSet::Point Point;
+    // should be the same as Point.
+    typedef typename DigitalTopology::Point DTPoint;
+
+    typedef typename DigitalSet::Domain Domain;
+    typedef typename Domain::Space Space;
+    typedef
       typename DigitalSetSelector < Domain,
-                                    SMALL_DS + HIGH_ITER_DS >::Type SmallSet;
-      typedef typename DigitalTopology::ForegroundAdjacency ForegroundAdjacency;
-      typedef typename DigitalTopology::BackgroundAdjacency BackgroundAdjacency;
-      typedef Object<ReverseTopology, DigitalSet> ComplementObject;
-      typedef Object<DigitalTopology, SmallSet> SmallObject;
-      typedef Object<ReverseTopology, SmallSet> SmallComplementObject;
+	       SMALL_DS + HIGH_ITER_DS >::Type SmallSet;
+    typedef typename DigitalTopology::ForegroundAdjacency ForegroundAdjacency;
+    typedef typename DigitalTopology::BackgroundAdjacency BackgroundAdjacency;
+    typedef Object<ReverseTopology, DigitalSet> ComplementObject;
+    typedef Object<DigitalTopology, SmallSet> SmallObject;
+    typedef Object<ReverseTopology, SmallSet> SmallComplementObject;
 
-      // Required by CUndirectedSimpleLocalGraph
-      typedef TDigitalSet VertexSet;
-      typedef typename DigitalSet::Point Vertex;
-      template <typename Value> struct VertexMap {
-        typedef typename std::map<Vertex, Value> Type;
-      };
-      typedef typename DigitalSet::ConstIterator ConstIterator;
-      
-      // Required by CUndirectedSimpleGraph
-      struct Edge
-      {
-	Vertex vertices [2];
-	
-	/** 
-          Constructor from vertices.
-          @param v1 the first vertex.
-          @param v2 the second vertex.
+    // Required by CUndirectedSimpleLocalGraph
+    typedef typename DigitalSet::Point Vertex;
+    typedef TDigitalSet VertexSet;
+    template <typename Value> struct VertexMap {
+      typedef typename std::map<Vertex, Value> Type;
+    };
+    typedef typename DigitalSet::ConstIterator ConstIterator;
+
+    // Required by CUndirectedSimpleGraph
+    struct Edge
+    {
+      Vertex vertices [2];
+
+      /**
+       * Invalid default constructor.
+       */
+      inline Edge(){}
+	// vertices{
+	//   std::numeric_limits<Vertex>::max(),
+	//   std::numeric_limits<Vertex>::max()}
+	// {}
+
+      /**
+	Constructor from vertices with no order.
+	@param v1 the first vertex.
+	@param v2 the second vertex.
 	*/
-	Edge( const Vertex & v1, const Vertex & v2 )
-	{
-	  if ( v1 <= v2 ) 
-	    {
-	      vertices[ 0 ] = v1;
-	      vertices[ 1 ] = v2;
-	    }
-	  else
-	    {
-	      vertices[ 0 ] = v2;
-	      vertices[ 1 ] = v1;
-	    }
-	}
-	bool operator==( const Edge & other ) const
-	{
-	  return ( vertices[ 0 ] == other.vertices[ 0 ] )
-	    && ( vertices[ 1 ] == other.vertices[ 1 ] );
-	}
-	bool operator<( const Edge & other ) const
-	{
-	  return ( vertices[ 0 ] < other.vertices[ 0 ] )
-	    || ( ( vertices[ 0 ] == other.vertices[ 0 ] )
-		&& ( vertices[ 1 ] < other.vertices[ 1 ] ) );
-	}
-      };
-      // ... End added
-
-
+      Edge( const Vertex & v1, const Vertex & v2, const bool b )
+      {
+	vertices[ 0 ] = v1;
+	vertices[ 1 ] = v2;
+      }
       /**
-       * Constructor. The object is not valid.
-       */
-      Object();
+	Constructor from vertices with auto-ordering.
+	@param v1 the first vertex.
+	@param v2 the second vertex.
+	*/
+      Edge( const Vertex & v1, const Vertex & v2 )
+      {
+	if ( v1 <= v2 )
+	{
+	  vertices[ 0 ] = v1;
+	  vertices[ 1 ] = v2;
+	}
+	else
+	{
+	  vertices[ 0 ] = v2;
+	  vertices[ 1 ] = v1;
+	}
+      }
+      bool operator==( const Edge & other ) const
+      {
+	return ( vertices[ 0 ] == other.vertices[ 0 ] )
+	  && ( vertices[ 1 ] == other.vertices[ 1 ] );
+      }
+      bool operator!=( const Edge & other ) const
+      {
+	return ( vertices[ 0 ] != other.vertices[ 0 ] )
+	  || ( vertices[ 1 ] != other.vertices[ 1 ] );
+      }
+      bool operator<( const Edge & other ) const
+      {
+	return ( vertices[ 0 ] < other.vertices[ 0 ] )
+	  || ( ( vertices[ 0 ] == other.vertices[ 0 ] )
+	      && ( vertices[ 1 ] < other.vertices[ 1 ] ) );
+      }
+    };
+    // ... End added
 
-      /**
-       * Constructor.
-       *
-       * @param aTopology the digital topology chosen for this set, a copy of
-       * which is stored in the object.
-       *
-       * @param aPointSet the set of points of the object. It is copied
-       * in the object.
-       *
-       * @param cxn the connectedness (default is UNKNOWN).
-       */
+    typedef std::vector<Edge> EdgeRange;
+
+    /**
+     * Constructor. The object is not valid.
+     */
+    Object();
+
+    /**
+     * Constructor.
+     *
+     * @param aTopology the digital topology chosen for this set, a copy of
+     * which is stored in the object.
+     *
+     * @param aPointSet the set of points of the object. It is copied
+     * in the object.
+     *
+     * @param cxn the connectedness (default is UNKNOWN).
+     */
     Object( Clone<DigitalTopology> aTopology,
-	    Clone<DigitalSet> aPointSet,
-	    Connectedness cxn = UNKNOWN );
+	Clone<DigitalSet> aPointSet,
+	Connectedness cxn = UNKNOWN );
 
 
-      /**
-       * Constructor of an empty object by providing a domain.
-       *
-       * @param aTopology the digital topology chosen for this set, a copy of
-       * which is stored in the object.
-       *
-       * @param domain any domain related to the given topology.
-       */
+    /**
+     * Constructor of an empty object by providing a domain.
+     *
+     * @param aTopology the digital topology chosen for this set, a copy of
+     * which is stored in the object.
+     *
+     * @param domain any domain related to the given topology.
+     */
     Object( Clone<DigitalTopology> aTopology,
-	    Clone<Domain> domain );
+	Clone<Domain> domain );
 
-      /**
-       * Copy constructor.
-       * @param other the object to clone.
-       *
-       * The copy is smart in the sense that the digital set is
-       * referenced, and will be copied only if the set is changed.
-       */
-      Object ( const Object & other );
+    /**
+     * Copy constructor.
+     * @param other the object to clone.
+     *
+     * The copy is smart in the sense that the digital set is
+     * referenced, and will be copied only if the set is changed.
+     */
+    Object ( const Object & other );
 
-      /**
-       * Destructor.
-       */
-      ~Object();
+    /**
+     * Destructor.
+     */
+    ~Object();
 
-      /**
-       * Assignment.
-       * @param other the object to copy.
-       * @return a reference on 'this'.
-       */
-      Object & operator= ( const Object & other );
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     */
+    Object & operator= ( const Object & other );
 
-      /**
-       * @return the number of elements in the set.
-       */
-      Size size() const;
+    /**
+     * @return the number of elements in the set.
+     */
+    Size size() const;
 
-      /**
-       * A const reference to the embedding domain.
-       */
-      const Domain & domain() const;
+    /**
+     * A const reference to the embedding domain.
+     */
+    const Domain & domain() const;
 
-      /**
-       * A counted pointer to the embedding domain.
-       */
-      CowPtr<Domain> domainPointer() const;
+    /**
+     * A counted pointer to the embedding domain.
+     */
+    CowPtr<Domain> domainPointer() const;
 
-      /**
-       * A const reference on the point set defining the points of the
-       * digital object.
-       */
-      const DigitalSet & pointSet() const;
+    /**
+     * A const reference on the point set defining the points of the
+     * digital object.
+     */
+    const DigitalSet & pointSet() const;
 
-      /**
-       * A reference on the point set defining the points of the
-       * digital object (may duplicate the set).
-       */
-      DigitalSet & pointSet();
+    /**
+     * A reference on the point set defining the points of the
+     * digital object (may duplicate the set).
+     */
+    DigitalSet & pointSet();
 
-      /**
-       * @return a const reference to the topology of this object.
-       */
-      const DigitalTopology & topology() const;
+    /**
+     * @return a const reference to the topology of this object.
+     */
+    const DigitalTopology & topology() const;
 
-      /**
-       * @return a const reference to the adjacency of this object.
-       */
-      const ForegroundAdjacency & adjacency() const;
+    /**
+     * @return a const reference to the adjacency of this object.
+     */
+    const ForegroundAdjacency & adjacency() const;
 
-      // ----------------------- Object services --------------------------------
-    public:
+    // ----------------------- Object services --------------------------------
+  public:
 
-      /**
-       * Let A be this object with foreground adjacency k and N_k(p) the
-       * k-neighborhood of p. Returns the set A intersected with N_k(p).
-       *
-       * @param p any point (in the domain of the digital object, not
-       * necessarily in the object).
-       *
-       * @return the kappa-neighborhood of [p] in this object.
-       *
-       * @see neighborhoodSize
-       *
-       * NB: if you need only the size of neighborhood, use neighborhoodSize.
-       */
-      SmallObject neighborhood( const Point & p ) const;
+    /**
+     * Let A be this object with foreground adjacency k and N_k(p) the
+     * k-neighborhood of p. Returns the set A intersected with N_k(p).
+     *
+     * @param p any point (in the domain of the digital object, not
+     * necessarily in the object).
+     *
+     * @return the kappa-neighborhood of [p] in this object.
+     *
+     * @see neighborhoodSize
+     *
+     * NB: if you need only the size of neighborhood, use neighborhoodSize.
+     */
+    SmallObject neighborhood( const Point & p ) const;
 
-      /**
-       * @param p any point (in the domain of the digital object, not
-       * necessarily in the object).
-       *
-       * @return the cardinal of the kappa-neighborhood of [p] in this object.
-       *
-       * @see neighborhood
-       *
-       * NB: faster than computing the neighborhood then computing its cardinal.
-       */
-      Size neighborhoodSize( const Point & p ) const;
+    /**
+     * @param p any point (in the domain of the digital object, not
+     * necessarily in the object).
+     *
+     * @return the cardinal of the kappa-neighborhood of [p] in this object.
+     *
+     * @see neighborhood
+     *
+     * NB: faster than computing the neighborhood then computing its cardinal.
+     */
+    Size neighborhoodSize( const Point & p ) const;
 
-      /**
-       * Let A be this object with foreground adjacency k and N*_k(p)
-       * the proper k-neighborhood of p. Returns the set A intersected
-       * with N*_k(p).
-       *
-       * @param p any point (in the domain of the digital object, not
-       * necessarily in the object).
-       *
-       * @return the kappa-neighborhood of [p] in this object, without p.
-       *
-       * @see properNeighborhoodSize
-       *
-       * NB: if you need only the size of the proper neighborhood, use
-       * properNeighborhoodSize.
-       */
-      SmallObject properNeighborhood( const Point & p ) const;
+    /**
+     * Let A be this object with foreground adjacency k and N*_k(p)
+     * the proper k-neighborhood of p. Returns the set A intersected
+     * with N*_k(p).
+     *
+     * @param p any point (in the domain of the digital object, not
+     * necessarily in the object).
+     *
+     * @return the kappa-neighborhood of [p] in this object, without p.
+     *
+     * @see properNeighborhoodSize
+     *
+     * NB: if you need only the size of the proper neighborhood, use
+     * properNeighborhoodSize.
+     */
+    SmallObject properNeighborhood( const Point & p ) const;
 
-      /**
-       * @param p any point (in the domain of the digital object, not
-       * necessarily in the object).
-       *
-       * @return the cardinal of the kappa-neighborhood of [p] in this object.
-       *
-       * @see properNeighborhood
-       *
-       * NB: faster than computing the proper neighborhood then
-       * computing its cardinal.
-       */
-      Size properNeighborhoodSize( const Point & p ) const;
-
-
-      // ----------------------- border services -------------------------------
-    public:
+    /**
+     * @param p any point (in the domain of the digital object, not
+     * necessarily in the object).
+     *
+     * @return the cardinal of the kappa-neighborhood of [p] in this object.
+     *
+     * @see properNeighborhood
+     *
+     * NB: faster than computing the proper neighborhood then
+     * computing its cardinal.
+     */
+    Size properNeighborhoodSize( const Point & p ) const;
 
 
-      /**
-       * @return the border of this object (the set of points of this
-       * which is lambda()-adjacent with some point of the background).
-       *
-       * NB : the background adjacency should be a symmetric relation.
-       */
-      Object border() const;
+    // ----------------------- border services -------------------------------
+  public:
 
 
-      // ----------------------- Connectedness services -------------------------
-    public:
+    /**
+     * @return the border of this object (the set of points of this
+     * which is lambda()-adjacent with some point of the background).
+     *
+     * NB : the background adjacency should be a symmetric relation.
+     */
+    Object border() const;
 
-      /**
-         Computes the connected components of the object and writes
-         them on the output iterator [it].
-        
-         @tparam OutputObjectIterator the type of an output iterator in
-         a container of Object s.
-        
-         @param it the output iterator. *it is an Object.
-         @return the number of components.
-        
-         NB: Be careful that the [it] should not be an output iterator
-         pointing in the same container containing 'this'. The following
-         example might make a 'bus error' because the vector might be
-         resized during insertion.
-        
-         @code
-   typedef ... MyObject;
-         vector<MyObject> objects;
-         objects[ 0 ] = ... some object;
-         ...
-         back_insert_iterator< vector<MyObject> > it( objects );
-         objects[ 0 ].writeComponents( it ); // it points in same container as this.
-         // might 'bus error'.
-         @endcode
-        
-         If you wish to use an output iterator (like a
-         std::back_insert_iterator) in the same container containing
-         your object, you can write:
-        
-         @code
-         MyObject( objects[ 0 ] ).writeComponents( it );
-         @endcode
-        
-         It is nearly as efficient (the clone uses smart copy on write
-         pointers) and works in any case. You might even overwrite your
-         object while doing this.
-       */
-      template <typename OutputObjectIterator>
+
+    // ----------------------- Connectedness services -------------------------
+  public:
+
+    /**
+      Computes the connected components of the object and writes
+      them on the output iterator [it].
+
+      @tparam OutputObjectIterator the type of an output iterator in
+      a container of Object s.
+
+      @param it the output iterator. *it is an Object.
+      @return the number of components.
+
+NB: Be careful that the [it] should not be an output iterator
+pointing in the same container containing 'this'. The following
+example might make a 'bus error' because the vector might be
+resized during insertion.
+
+@code
+typedef ... MyObject;
+vector<MyObject> objects;
+objects[ 0 ] = ... some object;
+...
+back_insert_iterator< vector<MyObject> > it( objects );
+objects[ 0 ].writeComponents( it ); // it points in same container as this.
+    // might 'bus error'.
+    @endcode
+
+    If you wish to use an output iterator (like a
+    std::back_insert_iterator) in the same container containing
+    your object, you can write:
+
+    @code
+    MyObject( objects[ 0 ] ).writeComponents( it );
+    @endcode
+
+    It is nearly as efficient (the clone uses smart copy on write
+    pointers) and works in any case. You might even overwrite your
+    object while doing this.
+    */
+    template <typename OutputObjectIterator>
       Size writeComponents( OutputObjectIterator & it ) const;
 
-      /**
-       * @return the connectedness of this object. Either CONNECTED,
-       * DISCONNECTED, or UNKNOWN.
-       *
-       * @see computeConnectedness
-       */
-      Connectedness connectedness() const;
+    /**
+     * @return the connectedness of this object. Either CONNECTED,
+     * DISCONNECTED, or UNKNOWN.
+     *
+     * @see computeConnectedness
+     */
+    Connectedness connectedness() const;
 
-      /**
-       * If 'connectedness() == UNKNOWN', computes the connectedness of
-       * this object. After that, the connectedness of 'this' is either
-       * CONNECTED or DISCONNECTED.
-       *
-       * @return the connectedness of this object. Either CONNECTED or
-       * DISCONNECTED.
-       *
-       * @see connectedness
-       */
-      Connectedness computeConnectedness() const;
+    /**
+     * If 'connectedness() == UNKNOWN', computes the connectedness of
+     * this object. After that, the connectedness of 'this' is either
+     * CONNECTED or DISCONNECTED.
+     *
+     * @return the connectedness of this object. Either CONNECTED or
+     * DISCONNECTED.
+     *
+     * @see connectedness
+     */
+    Connectedness computeConnectedness() const;
 
-      // ----------------------- Graph services ------------------------------
-    public:
-    
+    // ----------------------- Graph services ------------------------------
+  public:
+
     /**
      * @return a ConstIterator to the first element (begin).
      */
-      ConstIterator begin() const;
-      
-    
+    ConstIterator begin() const;
+
+
     /**
-     * @return a ConstIterator corresponding to the "end" of 
+     * @return a ConstIterator corresponding to the "end" of
      * the object element range.
      */
     ConstIterator end() const;
-      
-      /** 
-       * @param v any vertex of the object
-       * 
-       * @return the number of neighbors of this vertex
-       */
-      Size degree( const Vertex & v ) const;
-      
-      /**
-       * @return the maximum number of neighbors for a vertex of this object
-       */
-      Size bestCapacity() const;
-      
-      /**
-       * Writes the neighbors of a vertex using an output iterator
-       * 
-       * 
-       * @tparam OutputIterator the type of an output iterator writing
-       * in a container of vertices.
-       * 
-       * @param it the output iterator
-       * @param v the vertex whose neighbors will be writeNeighbors
-       */
-      template <typename OutputIterator>
+
+    /**
+     * @param v any vertex of the object
+     *
+     * @return the number of neighbors of this vertex, excluding itself.
+     */
+    Size degree( const Vertex & v ) const;
+
+    /**
+     * @return the maximum number of neighbors for a vertex of this object
+     */
+    Size bestCapacity() const;
+
+    /**
+     * Writes the neighbors of a vertex using an output iterator
+     *
+     *
+     * @tparam OutputIterator the type of an output iterator writing
+     * in a container of vertices.
+     *
+     * @param it the output iterator
+     * @param v the vertex whose neighbors will be writeNeighbors
+     */
+    template <typename OutputIterator>
       void
       writeNeighbors( OutputIterator &it ,
-                      const Vertex & v ) const;
+	  const Vertex & v ) const;
 
-      /**
-       * Writes the neighbors of a vertex which satisfy a predicate using an 
-       * output iterator
-       * 
-       * 
-       * @tparam OutputIterator the type of an output iterator writing
-       * in a container of vertices.
-       * 
-       * @tparam VertexPredicate the type of the predicate
-       * 
-       * @param it the output iterator
-       * 
-       * @param v the vertex whose neighbors will be written
-       * 
-       * @param pred the predicate that must be satisfied
-       */
-      template <typename OutputIterator, typename VertexPredicate>
+    /**
+     * Writes the neighbors of a vertex which satisfy a predicate using an
+     * output iterator
+     *
+     *
+     * @tparam OutputIterator the type of an output iterator writing
+     * in a container of vertices.
+     *
+     * @tparam VertexPredicate the type of the predicate
+     *
+     * @param it the output iterator
+     *
+     * @param v the vertex whose neighbors will be written
+     *
+     * @param pred the predicate that must be satisfied
+     */
+    template <typename OutputIterator, typename VertexPredicate>
       void
       writeNeighbors( OutputIterator &it ,
-                      const Vertex & v,
-                      const VertexPredicate & pred) const;
-      
-      
-      // ----------------------- Simple points -------------------------------
-    public:
+	  const Vertex & v,
+	  const VertexPredicate & pred) const;
 
-      /**
-       * Geodesic neighborhood of point [p] and order [k] in the object
-       * for the given metric adjacency.
-       */
-      template <typename TAdjacency>
+    /**
+     * Create on-the-fly vector of edges with size the degree of the input vertex.
+     * Each edge has source equal to the input vertex target, and target, a neighbor.
+     *
+     * @param v vertex to get edges from.
+     *
+     * @return container of Edges between input and connected vertices.
+     */
+    EdgeRange outEdges( const Vertex & v) const;
+
+    /**
+     * Return the opposite edge.
+     * Swap between source (head) and target (tail).
+     *
+     * @param e edge
+     *
+     * @return opposite edge.
+     */
+    Edge opposite(const Edge & e) const;
+
+    // ----------------------- Simple points -------------------------------
+  public:
+
+    /**
+     * Geodesic neighborhood of point [p] and order [k] in the object
+     * for the given metric adjacency.
+     */
+    template <typename TAdjacency>
       SmallObject
       geodesicNeighborhood( const TAdjacency & adj,
-          const Point & p, unsigned int k ) const;
+	  const Point & p, unsigned int k ) const;
 
-      /**
-       * Geodesic neighborhood of point [p] and order [k] in the
-       * complemented object for the given metric adjacency.
-       */
-      template <typename TAdjacency>
+    /**
+     * Geodesic neighborhood of point [p] and order [k] in the
+     * complemented object for the given metric adjacency.
+     */
+    template <typename TAdjacency>
       SmallComplementObject
       geodesicNeighborhoodInComplement( const TAdjacency & adj,
-          const Point & p, unsigned int k ) const;
+	  const Point & p, unsigned int k ) const;
 
 
-      /**
-       * [Bertrand, 1994] A voxel v is simple for a set X if #C6 [G6 (v,
-       * X)] = #C18[G18(v, X^c)] = 1, where #Ck [Y] denotes the number
-       * of k-connected components of a set Y.
-       *
-       * We adapt this definition to (kappa,lambda) connectednesses. Be
-       * careful, such a definition is valid only for Jordan couples in
-       * dimension 2 and 3.
-       *
-       * @return 'true' if this point is simple.
-       */
-      bool isSimple( const Point & v ) const;
+    /**
+     * [Bertrand, 1994] A voxel v is simple for a set X if #C6 [G6 (v,
+     * X)] = #C18[G18(v, X^c)] = 1, where #Ck [Y] denotes the number
+     * of k-connected components of a set Y.
+     *
+     * We adapt this definition to (kappa,lambda) connectednesses. Be
+     * careful, such a definition is valid only for Jordan couples in
+     * dimension 2 and 3.
+     *
+     * @return 'true' if this point is simple.
+     */
+    bool isSimple( const Point & v ) const;
 
-      // ----------------------- Interface --------------------------------------
-    public:
+    // ----------------------- Interface --------------------------------------
+  public:
 
-      /**
-       * Writes/Displays the object on an output stream.
-       * @param out the output stream where the object is written.
-       */
-      void selfDisplay ( std::ostream & out ) const;
+    /**
+     * Writes/Displays the object on an output stream.
+     * @param out the output stream where the object is written.
+     */
+    void selfDisplay ( std::ostream & out ) const;
 
-      /**
-       * Checks the validity/consistency of the object.
-       * @return 'true' if the object is valid, 'false' otherwise.
-       */
-      bool isValid() const;
+    /**
+     * Checks the validity/consistency of the object.
+     * @return 'true' if the object is valid, 'false' otherwise.
+     */
+    bool isValid() const;
 
-      // ------------------------- Protected Datas ------------------------------
-    private:
-      // ------------------------- Private Datas --------------------------------
-    private:
+    // ------------------------- Protected Datas ------------------------------
+  private:
+    // ------------------------- Private Datas --------------------------------
+  private:
 
-      /**
-       * the digital topology of the object.
-       */
-      CowPtr<DigitalTopology> myTopo;
+    /**
+     * the digital topology of the object.
+     */
+    CowPtr<DigitalTopology> myTopo;
 
-      /**
-       * A copy on write pointer on the associated (owned or not) point set
-       */
-      CowPtr<DigitalSet> myPointSet;
+    /**
+     * A copy on write pointer on the associated (owned or not) point set
+     */
+    CowPtr<DigitalSet> myPointSet;
 
-      /**
-       * Connectedness of this object. Either CONNECTED, DISCONNECTED, or UNKNOWN.
-       */
-      mutable Connectedness myConnectedness;
-      
+    /**
+     * Connectedness of this object. Either CONNECTED, DISCONNECTED, or UNKNOWN.
+     */
+    mutable Connectedness myConnectedness;
 
-      // --------------- CDrawableWithBoard2D realization ------------------
-    public:
-      /**
-       * @return the style name used for drawing this object.
-       */
-      std::string className() const;
 
- 
+    // --------------- CDrawableWithBoard2D realization ------------------
+  public:
+    /**
+     * @return the style name used for drawing this object.
+     */
+    std::string className() const;
+
+
   }; // end of class Object
 
 
@@ -542,9 +613,9 @@ namespace DGtal
    * @return the output stream after the writing.
    */
   template <typename TDigitalTopology, typename TDigitalSet>
-  std::ostream&
-  operator<< ( std::ostream & out,
-      const Object<TDigitalTopology, TDigitalSet> & object );
+    std::ostream&
+    operator<< ( std::ostream & out,
+	const Object<TDigitalTopology, TDigitalSet> & object );
 
 
 

--- a/src/DGtal/topology/Object.h
+++ b/src/DGtal/topology/Object.h
@@ -98,6 +98,10 @@ namespace DGtal
    *
    * \b Model of CUndirectedSimpleLocalGraph and CUndirectedSimpleGraph.
    *
+   * \b Object has a Boost Graph Interface to directly use an object
+   * instance into boost graph library algorithms.
+   *	@see ObjectBoostGraphInterface.h
+   *
    * @tparam TDigitalTopology any realization of DigitalTopology.
    * @tparam TDigitalSet any model of CDigitalSet.
    *
@@ -159,26 +163,23 @@ namespace DGtal
        * Invalid default constructor.
        */
       inline Edge(){}
-	// vertices{
-	//   std::numeric_limits<Vertex>::max(),
-	//   std::numeric_limits<Vertex>::max()}
-	// {}
 
       /**
-	Constructor from vertices with no order.
+	Constructor from vertices with no auto-order.
 	@param v1 the first vertex.
 	@param v2 the second vertex.
+	@param bool unused flag to select this constructor.
 	*/
-      Edge( const Vertex & v1, const Vertex & v2, const bool b )
+      Edge( const Vertex & v1, const Vertex & v2, const bool )
       {
 	vertices[ 0 ] = v1;
 	vertices[ 1 ] = v2;
-	boost::ignore_unused_variable_warning(b);
       }
       /**
 	Constructor from vertices with auto-ordering.
 	@param v1 the first vertex.
 	@param v2 the second vertex.
+	@note Edge(v1,v2) = Edge(v2,v1), stored vertices[0] will be the lowest of the two.
 	*/
       Edge( const Vertex & v1, const Vertex & v2 )
       {

--- a/src/DGtal/topology/Object.ih
+++ b/src/DGtal/topology/Object.ih
@@ -724,6 +724,24 @@ outEdges( const Vertex & v) const
 
 template <typename TDigitalTopology, typename TDigitalSet>
 inline
+typename DGtal::Object<TDigitalTopology, TDigitalSet>::Vertex
+DGtal::Object<TDigitalTopology, TDigitalSet>::
+head( const Edge & e ) const
+{
+  return e.vertices[1];
+}
+//-----------------------------------------------------------------------------
+template <typename TDigitalTopology, typename TDigitalSet>
+inline
+typename DGtal::Object<TDigitalTopology, TDigitalSet>::Vertex
+DGtal::Object<TDigitalTopology, TDigitalSet>::
+tail( const Edge & e ) const
+{
+  return e.vertices[0];
+}
+//-----------------------------------------------------------------------------
+template <typename TDigitalTopology, typename TDigitalSet>
+inline
 typename DGtal::Object<TDigitalTopology, TDigitalSet>::Edge
 DGtal::Object<TDigitalTopology, TDigitalSet>::
 opposite( const Edge & v) const

--- a/src/DGtal/topology/Object.ih
+++ b/src/DGtal/topology/Object.ih
@@ -19,7 +19,10 @@
  * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr )
  * Laboratory of Mathematics (CNRS, UMR 5807), University of Savoie, France
  *
- * @date 2010/07/07
+ * @author Pablo Hernandez-Cerdan. Institute of Fundamental Sciences.
+ * Massey University. Palmerston North, New Zealand
+ *
+ * @date 2016/02/01
  *
  * Implementation of inline methods defined in Object.h
  *
@@ -575,7 +578,7 @@ DGtal::Object<TDigitalTopology, TDigitalSet>::computeConnectedness() const
 
 template <typename TDigitalTopology, typename TDigitalSet>
 inline
-typename DGtal::Object<TDigitalTopology, TDigitalSet>::ConstIterator 
+typename DGtal::Object<TDigitalTopology, TDigitalSet>::ConstIterator
 DGtal::Object<TDigitalTopology, TDigitalSet>::begin() const
 {
   return myPointSet->begin();
@@ -583,15 +586,15 @@ DGtal::Object<TDigitalTopology, TDigitalSet>::begin() const
 
 template <typename TDigitalTopology, typename TDigitalSet>
 inline
-typename DGtal::Object<TDigitalTopology, TDigitalSet>::ConstIterator 
+typename DGtal::Object<TDigitalTopology, TDigitalSet>::ConstIterator
 DGtal::Object<TDigitalTopology, TDigitalSet>::end() const
 {
   return myPointSet->end();
 }
 
-/** 
+/**
  * @param v any vertex of the object
- * 
+ *
  * @return the number of neighbors of this vertex
  */
 template <typename TDigitalTopology, typename TDigitalSet>
@@ -600,7 +603,7 @@ typename DGtal::Object<TDigitalTopology, TDigitalSet>::Size
 DGtal::Object<TDigitalTopology, TDigitalSet>::degree
 ( const Vertex & v ) const
 {
-  return neighborhoodSize( v );
+  return properNeighborhoodSize( v );
 }
 
 /**
@@ -616,13 +619,13 @@ DGtal::Object<TDigitalTopology, TDigitalSet>::bestCapacity() const
 
 /**
  * Writes the neighbors of a vertex using an output iterator
- * 
- * 
+ *
+ *
  * @tparam OutputObjectIterator the type of an output iterator writing
  * in a container of vertices.
- * 
+ *
  * @param it the output iterator
- * 
+ *
  * @param v the vertex whose neighbors will be writeNeighbors
  */
 template <typename TDigitalTopology, typename TDigitalSet>
@@ -653,19 +656,19 @@ writeNeighbors( OutputIterator & it,
 }
 
 /**
- * Writes the neighbors of a vertex which satisfy a predicate using an 
+ * Writes the neighbors of a vertex which satisfy a predicate using an
  * output iterator
- * 
- * 
+ *
+ *
  * @tparam OutputObjectIterator the type of an output iterator writing
  * in a container of vertices.
- * 
+ *
  * @tparam VertexPredicate the type of the predicate
- * 
+ *
  * @param it the output iterator
- * 
+ *
  * @param v the vertex whose neighbors will be written
- * 
+ *
  * @param pred the predicate that must be satisfied
  */
 template <typename TDigitalTopology, typename TDigitalSet>
@@ -694,6 +697,39 @@ writeNeighbors( OutputIterator & it,
       ++cit )
     if ( ( pointSet().find( *cit ) != not_found ) && pred(*cit) )
       *it++ = *cit;
+}
+
+/**
+ * @note For this to work with graph algorithms, the source of the edge must be the input vertex, even on undirected graphs.
+ */
+template <typename TDigitalTopology, typename TDigitalSet>
+inline
+typename DGtal::Object<TDigitalTopology, TDigitalSet>::EdgeRange
+DGtal::Object<TDigitalTopology, TDigitalSet>::
+outEdges( const Vertex & v) const
+{
+  typedef std::vector<Vertex> Container;
+
+  Container tmp_local_points;
+  std::back_insert_iterator< Container > back_ins_it( tmp_local_points );
+
+  EdgeRange out_edges;
+  this->writeNeighbors(back_ins_it, v);
+  for ( auto && cit = tmp_local_points.begin();
+      cit != tmp_local_points.end(); ++cit )
+    out_edges.emplace_back(Edge(v, *cit, true));
+
+  return out_edges;
+}
+
+template <typename TDigitalTopology, typename TDigitalSet>
+inline
+typename DGtal::Object<TDigitalTopology, TDigitalSet>::Edge
+DGtal::Object<TDigitalTopology, TDigitalSet>::
+opposite( const Edge & v) const
+{
+  // boolean constructor to force order of vertices.
+  return Edge(v.vertices[1],v.vertices[0], true);
 }
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Simple points -------------------------------
@@ -750,7 +786,7 @@ DGtal::Object<TDigitalTopology, TDigitalSet>
     }
   visitor.terminate();
   SmallObject geodesicN( this->topology(), aDomain );
-  geodesicN.pointSet().insertNew( visitor.markedVertices().begin(), 
+  geodesicN.pointSet().insertNew( visitor.markedVertices().begin(),
                                   visitor.markedVertices().end()  );
 
   // JOL: 2012/11/16 There is apparently now a bug in expander !
@@ -818,10 +854,10 @@ DGtal::Object<TDigitalTopology, TDigitalSet>
       else break; // to far away, we exit
     }
   visitor.terminate();
-	
+
   SmallComplementObject geodesicN( this->topology().reverseTopology(),
-                                   aDomain ); 
-  geodesicN.pointSet().insertNew( visitor.markedVertices().begin(), 
+                                   aDomain );
+  geodesicN.pointSet().insertNew( visitor.markedVertices().begin(),
                                   visitor.markedVertices().end()  );
 
   // JOL: 2012/11/16 There is apparently now a bug in expander !
@@ -854,9 +890,9 @@ bool
 DGtal::Object<TDigitalTopology, TDigitalSet>
 ::isSimple( const Point & v ) const
 {
-  static const int kappa_n = 
+  static const int kappa_n =
     DigitalTopologyTraits< ForegroundAdjacency, BackgroundAdjacency, Space::dimension >::GEODESIC_NEIGHBORHOOD_SIZE;
-  static const int lambda_n = 
+  static const int lambda_n =
     DigitalTopologyTraits< BackgroundAdjacency, ForegroundAdjacency, Space::dimension >::GEODESIC_NEIGHBORHOOD_SIZE;
 
   SmallObject Gkappa_X

--- a/tests/graph/CMakeLists.txt
+++ b/tests/graph/CMakeLists.txt
@@ -1,7 +1,8 @@
 SET(DGTAL_TESTS_SRC
    testBreadthFirstPropagation
    testDepthFirstPropagation
-   ##testDigitalSurfaceBoostGraphInterface
+   # testDigitalSurfaceBoostGraphInterface
+   testObjectBoostGraphInterface
    testDistancePropagation
    testExpander
    testSTLMapToVertexMapAdapter

--- a/tests/graph/testObjectBoostGraphInterface.cpp
+++ b/tests/graph/testObjectBoostGraphInterface.cpp
@@ -239,8 +239,8 @@ TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Breadth first visit and sear
     StdDistanceMap distanceMap;
     boost::associative_property_map< StdDistanceMap > propDistanceMap( distanceMap );
     boost::queue< vertex_descriptor > Q; // std::queue does not have top().
-    vertex_descriptor start = *( obj_fixture.begin() );
-
+    // Start in +z corner of diamond.
+    vertex_descriptor start { Point{ 0, 0, 3 } };
 
     THEN( "Test IncidenceGraph interface with breadth_first_search" ){
       using PredecessorMap = std::map< vertex_descriptor, vertex_descriptor > ;

--- a/tests/graph/testObjectBoostGraphInterface.cpp
+++ b/tests/graph/testObjectBoostGraphInterface.cpp
@@ -493,16 +493,6 @@ TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Connected Components", "[con
         }
       }
 
-      // TODO use copy_graph directly to an Object.
-      // using StdVertexIndexMap = std::map< vertex_descriptor, vertices_size_type > ;
-      // StdVertexIndexMap vertexIndexMap;
-      // boost::associative_property_map< StdVertexIndexMap > propVertexIndexMap( vertexIndexMap );
-      // boost::copy_graph( obj_fixture, obj_copy,
-      //     boost::vertex_copy( my_vertex_copier<Graph,Graph,StdVertexIndexMap>( obj_fixture, obj_copy, vertexIndexMap ) )
-      //     .edge_copy( my_edge_copier<Graph,Graph>( obj_fixture, obj_copy ) )
-      //     .vertex_index_map( propVertexIndexMap )
-      //     );
-
       }// filtered_graph
     }// connected_components
   }//given

--- a/tests/graph/testObjectBoostGraphInterface.cpp
+++ b/tests/graph/testObjectBoostGraphInterface.cpp
@@ -104,7 +104,6 @@ struct Fixture_object_diamond_with_hole {
         );
     FixtureSurfelAdjacency surfAdj( true ); // interior in all directions.
 
-    using FixtureDigitalSet = DigitalSetByAssociativeContainer<Z3i::Domain , std::unordered_set< typename Z3i::Domain::Point> >;
     FixtureDigitalTopology::ForegroundAdjacency adjF;
     FixtureDigitalTopology::BackgroundAdjacency adjB;
     FixtureDigitalTopology topo(adjF, adjB, DGtal::DigitalTopologyProperties::JORDAN_DT);
@@ -116,14 +115,6 @@ struct Fixture_object_diamond_with_hole {
 
 TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Basic Graph functions", "[interface]" ){
   GIVEN( "A diamond object with graph properties" ){
-    typedef FixtureObject Graph;
-    typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
-    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
-    typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
-    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
-    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
-    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
-
     THEN( "Vertices, Num Vertices" ){
       auto num_verts = boost::num_vertices(obj_fixture);
       auto verts = boost::vertices(obj_fixture);
@@ -176,14 +167,7 @@ TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Basic Graph functions", "[in
 
 TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Boost Graph Concepts", "[concepts]" ){
   GIVEN( "A diamond object with graph properties" ){
-
     typedef FixtureObject Graph;
-    typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
-    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
-    typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
-    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
-    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
-    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
 
     THEN( "Check Graph Concepts" ){
 
@@ -200,11 +184,7 @@ TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Breadth first visit and sear
   GIVEN( "A diamond object with graph properties" ){
     typedef FixtureObject Graph;
     typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
-    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
-    typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
     typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
-    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
-    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
 
     // get the property map for coloring vertices.
     typedef std::map< vertex_descriptor, boost::default_color_type > StdColorMap;
@@ -277,11 +257,8 @@ TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Connected Components", "[con
   GIVEN( "A diamond object with graph properties and an isolated vertex" ){
     typedef FixtureObject Graph;
     typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
-    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
+    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Edge
     typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
-    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
-    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
-    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
 
     // Add an isolated point in the domain.
     obj_fixture.pointSet().insertNew(FixtureObject::Point(0,0,7));
@@ -390,7 +367,6 @@ struct vertex_position {
 typedef boost::property< boost::vertex_index_t, std::size_t,
         boost::property<vertex_position_t, vertex_position> > VertexProperties;
 
-
 template <typename Graph1, typename Graph2, typename VertexIndexMap>
 struct my_vertex_copier {
   typedef typename boost::property_map< Graph2, boost::vertex_index_t>::type graph_vertex_index_map;
@@ -422,7 +398,7 @@ struct my_vertex_copier {
 };
 template <typename Graph1, typename Graph2>
 struct my_edge_copier {
-  my_edge_copier(const Graph1& UNUSED1, Graph2& UNUSED2)
+  my_edge_copier(const Graph1& , Graph2& )
   {}
   template <typename Edge1, typename Edge2>
     void operator()(const Edge1& /*v1*/, Edge2& /*v2*/) const {
@@ -434,12 +410,7 @@ TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Copy graph", "[copy]" ){
   GIVEN( "A diamond object with graph properties" ){
     typedef FixtureObject Graph;
     typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
-    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
     typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
-    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
-    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
-    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
-
     THEN( "Test copy_graph"){
 
       // trace.beginBlock ( "Testing AdjacencyListGraph with copy_graph ..." );
@@ -477,7 +448,7 @@ TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Copy graph", "[copy]" ){
 //   GIVEN( "A diamond object with graph properties, and a breadth_first_visit" ){
 //     typedef FixtureObject Graph;
 //     typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
-//     typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
+//     typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Edge
 //     typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
 //     typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
 //     typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;

--- a/tests/graph/testObjectBoostGraphInterface.cpp
+++ b/tests/graph/testObjectBoostGraphInterface.cpp
@@ -1,0 +1,654 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file testObjectBoostGraphInterface.cpp
+ * @ingroup Tests
+ * @author Pablo Hernandez-Cerdan. Institute of Fundamental Sciences. Massey University. Palmerston North, New Zealand
+ *
+ * @date 2016/02/01
+ *
+ * Functions for testing class ObjectBoostGraphInterface.
+ *
+ * This file is part of the DGtal library.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+#include "DGtalCatch.h"
+#include <iostream>
+#include <queue>
+#include <boost/property_map/property_map.hpp>
+#include <boost/pending/queue.hpp>
+#include "DGtal/base/Common.h"
+#include "DGtal/graph/ObjectBoostGraphInterface.h"
+#include "DGtal/helpers/StdDefs.h"
+#include "DGtal/topology/Object.h"
+#include "DGtal/topology/DigitalTopology.h"
+#include "DGtal/topology/SurfelAdjacency.h"
+/// JOL: Since using boost::vertices is enforced before we define it,
+/// the compiler is unable to find our function boost::vertices. We
+/// *must* include graph_concepts.hpp after defining our graph wrapper.
+#include <boost/graph/graph_concepts.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/copy.hpp>
+#include <boost/graph/breadth_first_search.hpp>
+#include <boost/graph/connected_components.hpp>
+#include <boost/graph/stoer_wagner_min_cut.hpp>
+#include <boost/graph/boykov_kolmogorov_max_flow.hpp>
+#include <boost/graph/filtered_graph.hpp>
+///////////////////////////////////////////////////////////////////////////
+using namespace std;
+using namespace DGtal;
+
+///////////////////////////////////////////////////////////////////////////
+// Fixture for object from a diamond set and DT26_6 topology.
+///////////////////////////////////////////////////////////////////////////
+struct Fixture_object_diamond_with_hole {
+  ///////////////////////////////////////////////////////////
+  // type aliases
+  ///////////////////////////////////////////////////////////
+  using Point  = DGtal::Z3i::Point;
+  using Domain = DGtal::Z3i::Domain;
+  using KSpace = DGtal::Z3i::KSpace;
+
+  using FixtureSurfelAdjacency =
+    DGtal::SurfelAdjacency<DGtal::Z3i::KSpace::dimension> ;
+  using FixtureDigitalTopology =
+    DGtal::Z3i::DT26_6;
+  using FixtureDigitalSet =
+    DGtal::DigitalSetByAssociativeContainer<DGtal::Z3i::Domain , std::unordered_set< typename DGtal::Z3i::Domain::Point> >;
+  using FixtureObject =
+    DGtal::Object<FixtureDigitalTopology, FixtureDigitalSet>;
+
+  ///////////////////////////////////////////////////////////
+  // fixture data
+  FixtureObject obj_fixture;
+  ///////////////////////////////////////////////////////////
+
+  ///////////////////////////////////////////////////////////
+  // Constructor
+  ///////////////////////////////////////////////////////////
+  Fixture_object_diamond_with_hole() {
+    using namespace DGtal;
+
+    // trace.beginBlock ( "Create Fixture_object_diamond" );
+    Point p1( -10, -10, -10 );
+    Point p2( 10, 10, 10 );
+    Domain domain( p1, p2 );
+    Point c( 0, 0, 0 );
+
+    // diamond of radius 4
+    FixtureDigitalSet diamond_set( domain );
+    for ( auto it = domain.begin(); it != domain.end(); ++it )
+    {
+      if ( (*it - c ).norm1() <= 3 ) diamond_set.insertNew( *it );
+    }
+    diamond_set.erase( c );
+
+    KSpace K;
+    bool space_ok = K.init( domain.lowerBound(),
+        domain.upperBound(), true // necessary
+        );
+    FixtureSurfelAdjacency surfAdj( true ); // interior in all directions.
+
+    using FixtureDigitalSet = DigitalSetByAssociativeContainer<Z3i::Domain , std::unordered_set< typename Z3i::Domain::Point> >;
+    FixtureDigitalTopology::ForegroundAdjacency adjF;
+    FixtureDigitalTopology::BackgroundAdjacency adjB;
+    FixtureDigitalTopology topo(adjF, adjB, DGtal::DigitalTopologyProperties::JORDAN_DT);
+    obj_fixture = FixtureObject(topo,diamond_set);
+
+    // trace.endBlock();
+  }
+ };
+
+TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Basic Graph functions", "[interface]" ){
+  GIVEN( "A diamond object with graph properties" ){
+    typedef FixtureObject Graph;
+    typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
+    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
+    typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
+    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
+    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
+    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
+
+    THEN( "Vertices, Num Vertices" ){
+      auto num_verts = boost::num_vertices(obj_fixture);
+      auto verts = boost::vertices(obj_fixture);
+      size_t count_verts{0};
+      for(auto v = verts.first; v != verts.second; ++v, ++count_verts){};
+      REQUIRE(count_verts == num_verts);
+    }
+    THEN( "Edges, Num Edges" ){
+      auto num_edges = boost::num_edges(obj_fixture);
+      auto edges = boost::edges(obj_fixture);
+      size_t count_edges{0};
+      for(auto v = edges.first; v != edges.second; ++v, ++count_edges){};
+      REQUIRE(count_edges == num_edges);
+    }
+    THEN( "Out Edges, Out Degree, Degree, and Adjacencies of a vertex" ){
+      // Map relating point and known degree in the diamond.
+      std::map<Point, size_t> point_numedges;
+      Point north{ 0 , 0 , 3 };
+      point_numedges[north] = 5;
+
+      Point x3{ 3 , 0 , 0 };
+      point_numedges[x3] = 5;
+
+      Point x1y1z1{ 1 , 1 , 1 };
+      point_numedges[x1y1z1] = 15;
+
+      Point cz2{ 0 , 0 , 2 };
+      point_numedges[cz2] = 14;
+
+      Point cz1{ 0 , 0 , 1 };
+      point_numedges[cz1] = 21;
+
+      for(auto && pm : point_numedges){
+        auto out_edges = boost::out_edges(pm.first, obj_fixture);
+        size_t count_edges{0};
+        for(auto v = out_edges.first; v != out_edges.second; ++v, ++count_edges){};
+        REQUIRE(count_edges == pm.second);
+        auto out_degree = boost::out_degree(pm.first, obj_fixture);
+        REQUIRE(out_degree == count_edges);
+        auto degree = obj_fixture.degree(pm.first);
+        REQUIRE(degree == out_degree);
+        auto adj_vp = boost::adjacent_vertices(pm.first, obj_fixture);
+        size_t count_verts{0};
+        for(auto v = adj_vp.first; v != adj_vp.second; ++v, ++count_verts){};
+        REQUIRE(count_verts == degree);
+      }
+    }
+  }
+}
+
+TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Boost Graph Concepts", "[concepts]" ){
+  GIVEN( "A diamond object with graph properties" ){
+
+    typedef FixtureObject Graph;
+    typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
+    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
+    typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
+    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
+    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
+    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
+
+    THEN( "Check Graph Concepts" ){
+
+      BOOST_CONCEPT_ASSERT(( boost::VertexListGraphConcept<Graph> ));
+      BOOST_CONCEPT_ASSERT(( boost::AdjacencyGraphConcept<Graph> ));
+      BOOST_CONCEPT_ASSERT(( boost::IncidenceGraphConcept<Graph> ));
+      BOOST_CONCEPT_ASSERT(( boost::EdgeListGraphConcept<Graph> ));
+      // BOOST_CONCEPT_ASSERT(( boost::BidirectionalGraphConcept<Graph> ));
+    }
+  }
+}
+
+TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Breadth first visit and search", "[breadth]" ){
+  GIVEN( "A diamond object with graph properties" ){
+    typedef FixtureObject Graph;
+    typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
+    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
+    typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
+    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
+    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
+    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
+
+    // get the property map for coloring vertices.
+    typedef std::map< vertex_descriptor, boost::default_color_type > StdColorMap;
+    StdColorMap colorMap;
+    boost::associative_property_map< StdColorMap > propColorMap( colorMap );
+    // get the property map for storing distances
+    typedef std::map< vertex_descriptor, uint64_t > StdDistanceMap;
+    StdDistanceMap distanceMap;
+    boost::associative_property_map< StdDistanceMap > propDistanceMap( distanceMap );
+    boost::queue< vertex_descriptor > Q; // std::queue does not have top().
+    vertex_descriptor start = *( obj_fixture.begin() );
+
+    THEN( "Test IncidenceGraph interface with breadth_first_visit" ){
+
+      boost::breadth_first_visit // boost graph breadth first visiting algorithm.
+        ( obj_fixture, // the graph
+          start, // the starting vertex
+          Q, // the buffer for breadth first queueing
+          boost::make_bfs_visitor( boost::record_distances( propDistanceMap, boost::on_tree_edge() ) ), // only record distances
+          propColorMap  // necessary for the visiting vertices
+        );
+
+      uint64_t maxD = 0;
+      vertex_descriptor furthest = start;
+      uint64_t nbV = 0;
+      for ( std::pair<vertex_iterator, vertex_iterator>
+          vp = boost::vertices( obj_fixture ); vp.first != vp.second; ++vp.first, ++nbV )
+      {
+        uint64_t d = boost::get( propDistanceMap, *vp.first );
+        if ( d > maxD )
+        {
+          maxD = d;
+          furthest = *vp.first;
+        }
+      }
+
+      REQUIRE( nbV == obj_fixture.size() );
+      INFO("- d[ " << start << " ] = " << boost::get( propDistanceMap, start));
+      INFO("- d[ " << furthest << " ] = " << maxD);
+      CHECK( maxD == 6 );
+    }
+
+    THEN( "Test IncidenceGraph interface with breadth_first_search" ){
+      typedef std::map< vertex_descriptor, vertex_descriptor > PredecessorMap;
+      PredecessorMap predecessorMap;
+      boost::associative_property_map< PredecessorMap >
+        propPredecessorMap( predecessorMap );
+
+      boost::breadth_first_search(
+         obj_fixture,
+         start,
+         Q,
+         boost::make_bfs_visitor( boost::record_predecessors( propPredecessorMap, boost::on_tree_edge() ) ), // only record predecessors
+         propColorMap  // necessary for the visiting vertices
+         );
+
+      INFO("predecessorMap");
+      INFO("starting point: " << *( obj_fixture.begin() ) );
+      size_t visited{0};
+      for(auto && v : predecessorMap){
+        ++visited;
+        INFO(v.first << " : " << v.second) ;
+      }
+      // +1 to count the starting point;
+      CHECK((visited + 1) == obj_fixture.size());
+    }
+  }
+}
+TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Connected Components", "[connected]" ){
+  GIVEN( "A diamond object with graph properties and an isolated vertex" ){
+    typedef FixtureObject Graph;
+    typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
+    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
+    typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
+    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
+    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
+    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
+
+    // Add an isolated point in the domain.
+    obj_fixture.pointSet().insertNew(FixtureObject::Point(0,0,7));
+
+    THEN( "VertexListGraph interface with connected_components" ){
+      // get the property map for labelling vertices.
+      // get the property map for coloring vertices.
+      typedef std::map< vertex_descriptor, boost::default_color_type > StdColorMap;
+      StdColorMap colorMap;
+      boost::associative_property_map< StdColorMap > propColorMap( colorMap );
+
+      typedef std::map< vertex_descriptor, vertices_size_type > StdComponentMap;
+      StdComponentMap componentMap;
+      boost::associative_property_map< StdComponentMap > propComponentMap( componentMap );
+      vertices_size_type nbComp =
+        boost::connected_components // boost graph connected components algorithm.
+        ( obj_fixture, // the graph
+          propComponentMap, // the mapping vertex -> label
+          boost::color_map( propColorMap ) // this map is used internally when computing connected components.
+        );
+      CHECK(nbComp == 2);
+
+      THEN( "Filter graph and get components" ){
+        using ComponentGraph =
+          boost::filtered_graph<
+          Graph,
+          function<bool(edge_descriptor)>,
+          function<bool(vertex_descriptor)>
+            >;
+        auto &g = obj_fixture;
+
+        std::vector<ComponentGraph> component_graphs;
+
+        for (size_t i = 0; i < nbComp; i++)
+          component_graphs.emplace_back(g,
+              [componentMap,i,&g](edge_descriptor e) {
+              return componentMap.at(boost::source(e,g) )==i
+              || componentMap.at(boost::target(e,g))==i;
+              },
+              [componentMap,i](vertex_descriptor v) {
+              return componentMap.at(v)==i;
+              });
+
+
+        CHECK( component_graphs.size() == 2);
+        std::vector<FixtureObject> obj_components;
+        // Copying object and clear pointSet instead of creating from scratch. Lazy?
+        FixtureObject obj_copy(obj_fixture);
+        obj_copy.pointSet().clear();
+
+        // Create new object from the component_graph.
+      for (auto && c : component_graphs){
+        obj_components.push_back(obj_copy);
+        for (auto && vp = boost::vertices(c); vp.first != vp.second ; ++vp.first){
+          obj_components.back().pointSet().insertNew(*vp.first);
+        }
+      }
+
+      // THEN( "[visualize] visualize the components" ){
+      // //#include "DGtal/io/viewers/Viewer3D.h"
+      //   int argc(1);
+      //   char** argv(nullptr);
+      //   QApplication app(argc, argv);
+      //   Viewer3D<> viewer;
+      //   viewer.show();
+      //
+      //   viewer.setFillColor(Color(255, 255, 255, 255));
+      //   viewer << obj_components[0].pointSet();
+      //   viewer.setFillColor(Color(20, 30, 30, 255));
+      //   viewer << obj_components[1].pointSet();
+      //   viewer.setFillColor(Color(10, 10, 10, 20));
+      //   viewer << obj_fixture.pointSet();
+      //   viewer << Viewer3D<>::updateDisplay;
+      //   app.exec();
+      // }
+
+      // TODO use copy_graph directly to an Object.
+      // using StdVertexIndexMap = std::map< vertex_descriptor, vertices_size_type > ;
+      // StdVertexIndexMap vertexIndexMap;
+      // boost::associative_property_map< StdVertexIndexMap > propVertexIndexMap( vertexIndexMap );
+      // boost::copy_graph( obj_fixture, obj_copy,
+      //     boost::vertex_copy( my_vertex_copier<Graph,Graph,StdVertexIndexMap>( obj_fixture, obj_copy, vertexIndexMap ) )
+      //     .edge_copy( my_edge_copier<Graph,Graph>( obj_fixture, obj_copy ) )
+      //     .vertex_index_map( propVertexIndexMap )
+      //     );
+
+      }// filtered_graph
+    }// connected_components
+  }//given
+}//scenario
+
+////////////////////////////////////////////////////////
+// copiers between Object and boost::adjacency_list
+////////////////////////////////////////////////////////
+struct vertex_position_t {
+  typedef boost::vertex_property_tag kind;
+};
+
+struct vertex_position {
+  Z3i::Point myP;
+  vertex_position() : myP()
+  {
+  }
+};
+
+typedef boost::property< boost::vertex_index_t, std::size_t,
+        boost::property<vertex_position_t, vertex_position> > VertexProperties;
+
+
+template <typename Graph1, typename Graph2, typename VertexIndexMap>
+struct my_vertex_copier {
+  typedef typename boost::property_map< Graph2, boost::vertex_index_t>::type graph_vertex_index_map;
+  typedef typename boost::property_map< Graph2, vertex_position_t>::type graph_vertex_position_map;
+  typedef typename boost::graph_traits< Graph1 >::vertex_descriptor Vertex1;
+  typedef typename boost::graph_traits< Graph2 >::vertex_descriptor Vertex2;
+
+  const Graph1 & myG1;
+  graph_vertex_index_map graph_vertex_index;
+  graph_vertex_position_map graph_vertex_position;
+  VertexIndexMap & myIndexMap;
+
+  my_vertex_copier(const Graph1& g1, Graph2& g2, VertexIndexMap & indexMap )
+    : myG1( g1 ),
+    graph_vertex_index( boost::get( boost::vertex_index_t(), g2 ) ),
+    graph_vertex_position( boost::get( vertex_position_t(), g2) ),
+    myIndexMap( indexMap )
+  {}
+
+  void operator()( const Vertex1& v1, const Vertex2& v2 ) const {
+    //  std::size_t idx = myIndexMap[ v1 ];
+    // Does not work !
+    // put( graph_vertex_index, v2, idx);
+    vertex_position pos;
+    pos.myP = v1;
+    //std::cout << "vertex " << idx << " at " << pos.myP << std::endl;
+    put( graph_vertex_position, v2, pos);
+  }
+};
+template <typename Graph1, typename Graph2>
+struct my_edge_copier {
+  my_edge_copier(const Graph1& UNUSED1, Graph2& UNUSED2)
+  {}
+  template <typename Edge1, typename Edge2>
+    void operator()(const Edge1& /*v1*/, Edge2& /*v2*/) const {
+      // does nothing
+    }
+};
+
+TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Copy graph", "[copy]" ){
+  GIVEN( "A diamond object with graph properties" ){
+    typedef FixtureObject Graph;
+    typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
+    typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
+    typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
+    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
+    typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
+    typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
+
+    THEN( "Test copy_graph"){
+
+      // trace.beginBlock ( "Testing AdjacencyListGraph with copy_graph ..." );
+      using StdVertexIndexMap = std::map< vertex_descriptor, vertices_size_type > ;
+      StdVertexIndexMap vertexIndexMap;
+      boost::associative_property_map< StdVertexIndexMap > propVertexIndexMap( vertexIndexMap );
+      using BGraph = boost::adjacency_list< boost::vecS, boost::vecS, boost::undirectedS, VertexProperties > ;
+      BGraph bG;
+      boost::copy_graph( obj_fixture, bG,
+          boost::vertex_copy( my_vertex_copier<Graph,BGraph,StdVertexIndexMap>( obj_fixture, bG, vertexIndexMap ) )
+          .edge_copy( my_edge_copier<Graph,BGraph>( obj_fixture, bG ) )
+          .vertex_index_map( propVertexIndexMap )
+          );
+      using vertex_descriptor_2 = boost::graph_traits< BGraph >::vertex_descriptor ;
+      using vertex_iterator_2 = boost::graph_traits< BGraph >::vertex_iterator ;
+      using GraphVertexPositionMap = boost::property_map< BGraph, vertex_position_t>::type ;
+      GraphVertexPositionMap vertexPos( boost::get( vertex_position_t(), bG) );
+      for ( std::pair<vertex_iterator_2, vertex_iterator_2>
+          vp = boost::vertices( bG ); vp.first != vp.second; ++vp.first )
+      {
+        vertex_descriptor_2 v1 = *vp.first;
+        vertex_position pos = boost::get( vertexPos, v1 );
+        // trace.info() << "- " << v1 << " was at " << pos.myP << std::endl;
+      }
+      INFO("after copy: Boost graph has " << num_vertices( bG ) << " vertices.");
+      CHECK(boost::num_vertices( bG ) == boost::num_vertices( obj_fixture ));
+      // trace.endBlock();
+
+    }
+  }
+}
+
+
+// TEST_CASE_METHOD(Fixture_object_diamond_with_hole, "Wagner-Stoe min-cut and Boykov-Kolmogorov max-flow", "[mincut][maxflow]" ){
+//   GIVEN( "A diamond object with graph properties, and a breadth_first_visit" ){
+//     typedef FixtureObject Graph;
+//     typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor; // ie Object::Vertex
+//     typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor; // ie Object::Arc
+//     typedef boost::graph_traits<Graph>::vertices_size_type vertices_size_type; // ie Object::Size
+//     typedef boost::graph_traits<Graph>::vertex_iterator vertex_iterator;
+//     typedef boost::graph_traits<Graph>::out_edge_iterator out_edge_iterator;
+//     typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
+//
+//     ///////////////////////////////////////
+//     // Breadth first
+//
+//     // get the property map for coloring vertices.
+//     using StdColorMap = std::map< vertex_descriptor, boost::default_color_type > ;
+//     StdColorMap colorMap;
+//     boost::associative_property_map< StdColorMap > propColorMap( colorMap );
+//     // get the property map for storing distances
+//     using StdDistanceMap = std::map< vertex_descriptor, uint64_t > ;
+//     StdDistanceMap distanceMap;
+//     boost::associative_property_map< StdDistanceMap > propDistanceMap( distanceMap );
+//     boost::queue< vertex_descriptor > Q; // std::queue does not have top().
+//     vertex_descriptor start = *( obj_fixture.begin() );
+//
+//     boost::breadth_first_visit // boost graph breadth first visiting algorithm.
+//       ( obj_fixture, // the graph
+//         start, // the starting vertex
+//         Q, // the buffer for breadth first queueing
+//         boost::make_bfs_visitor( boost::record_distances( propDistanceMap, boost::on_tree_edge() ) ), // only record distances
+//         propColorMap  // necessary for the visiting vertices
+//       );
+//
+//     uint64_t maxD = 0;
+//     vertex_descriptor furthest = start;
+//     uint64_t nbV = 0;
+//     for ( std::pair<vertex_iterator, vertex_iterator>
+//         vp = boost::vertices( obj_fixture ); vp.first != vp.second; ++vp.first, ++nbV )
+//     {
+//       uint64_t d = boost::get( propDistanceMap, *vp.first );
+//       if ( d > maxD )
+//       {
+//         maxD = d;
+//         furthest = *vp.first;
+//       }
+//     }
+//     THEN( "Test Wagner Stoer min-cut"){
+//
+//       trace.beginBlock ( "Testing UndirectedGraph interface with Wagner-Stoer min cut ..." );
+//       // get the property map for weighting edges.
+//       using weight_type = double ;
+//       using StdWeightMap = std::map< edge_descriptor, weight_type > ;
+//       StdWeightMap weightMap;
+//       boost::associative_property_map< StdWeightMap > propWeightMap( weightMap );
+//       using StdVertexIndexMap = std::map< vertex_descriptor, vertices_size_type > ;
+//       StdVertexIndexMap vertexIndexMap;
+//       boost::associative_property_map< StdVertexIndexMap > propVertexIndexMap( vertexIndexMap );
+//       vertices_size_type idxV = 0;
+//       // The weight is smaller for edges traversing plane z=0 than anywhere else.
+//       // The min cut thus cuts the sphere in two approximate halves.
+//       for ( std::pair<vertex_iterator, vertex_iterator>
+//           vp = boost::vertices( obj_fixture ); vp.first != vp.second; ++vp.first, ++idxV )
+//       {
+//         vertex_descriptor v1 = *vp.first;
+//         vertexIndexMap[ v1 ] = idxV;
+//         for ( std::pair<out_edge_iterator, out_edge_iterator>
+//             ve = boost::out_edges( v1, obj_fixture ); ve.first != ve.second; ++ve.first )
+//         {
+//           vertex_descriptor v2 = boost::target( *ve.first, obj_fixture );
+//           if ( v1 < v2 )
+//           {
+//             // KSpace::SCell sep = obj_fixture.separator( *ve.first );
+//             // weight_type weight = ( K.sKCoord( sep, 2 ) == 0 ) ? 0.01 : 1.0;
+//             weight_type weight = 0.5;
+//             weightMap[ *ve.first ] = weight;
+//             // weightMap[ obj_fixture.opposite( *ve.first ) ] = weight;
+//           }
+//         }
+//       }
+//       // get the parity map for assigning a set to each vertex.
+//       using StdParityMap = std::map< vertex_descriptor, bool > ;
+//       StdParityMap parityMap;
+//       boost::associative_property_map< StdParityMap > propParityMap( parityMap );
+//
+//       weight_type total_weight =
+//         boost::stoer_wagner_min_cut // boost wagner stoer min cut algorithm.
+//         ( obj_fixture, // the graph
+//           propWeightMap, // the mapping edge -> weight
+//           boost::parity_map( propParityMap ) // this map stores the vertex assignation
+//           .vertex_index_map( propVertexIndexMap )
+//         );
+//       trace.info() << "- total weight = " << total_weight << std::endl;
+//       uint64_t nb0 = 0;
+//       uint64_t nb1 = 0;
+//       for ( std::pair<vertex_iterator, vertex_iterator>
+//           vp = boost::vertices( obj_fixture ); vp.first != vp.second; ++vp.first, ++idxV )
+//       {
+//         vertex_descriptor v1 = *vp.first;
+//         INFO("- " << v1 << " in " << parityMap[ v1 ] );
+//         if ( parityMap[ v1 ] ) ++nb1;
+//         else ++nb0;
+//       }
+//       INFO("parityMap: True components: " << nb1 << " False: " << nb0);
+//       INFO("- parity[ " << start << " ] = " << parityMap[ start ]);
+//       INFO("- parity[ " << furthest << " ] = " << parityMap[ furthest ]);
+//       CHECK( parityMap[start] != parityMap[furthest]);
+//       CHECK(total_weight < 1.0);
+//
+//       trace.endBlock();
+//
+//       THEN( "Test Boykov-Kolmogorov max flow"){
+//         using weight_type = double ;
+//         using StdWeightMap = std::map< edge_descriptor, weight_type > ;
+//         StdWeightMap weightMap;
+//         boost::associative_property_map< StdWeightMap > propWeightMap( weightMap );
+//         using StdVertexIndexMap = std::map< vertex_descriptor, vertices_size_type > ;
+//         StdVertexIndexMap vertexIndexMap;
+//
+//         trace.beginBlock ( "Testing EdgeListGraph and IncidenceGraph interfaces with Boykov-Kolmogorov max flow ..." );
+//         typedef double capacity_type;
+//         // get the property map for edge capacity.
+//         typedef std::map< edge_descriptor, weight_type > StdEdgeCapacityMap;
+//         StdEdgeCapacityMap edgeCapacityMap;
+//         boost::associative_property_map< StdEdgeCapacityMap > propEdgeCapacityMap( edgeCapacityMap );
+//         // get the property map for edge residual capacity.
+//         typedef std::map< edge_descriptor, weight_type > StdEdgeResidualCapacityMap;
+//         StdEdgeResidualCapacityMap edgeResidualCapacityMap;
+//         boost::associative_property_map< StdEdgeResidualCapacityMap > propEdgeResidualCapacityMap( edgeResidualCapacityMap );
+//         // get the property map for reverse edge.
+//         typedef std::map< edge_descriptor, edge_descriptor > StdReversedEdgeMap;
+//         StdReversedEdgeMap reversedEdgeMap;
+//         boost::associative_property_map< StdReversedEdgeMap > propReversedEdgeMap( reversedEdgeMap );
+//         // get the property map for vertex predecessor.
+//         typedef std::map< vertex_descriptor, edge_descriptor > StdPredecessorMap;
+//         StdPredecessorMap predecessorMap;
+//         boost::associative_property_map< StdPredecessorMap > propPredecessorMap( predecessorMap );
+//         // We already have vertex color map, vertex distance map and vertex index map.
+//         uint64_t nbEdges = 0;
+//         // The weight is smaller for edges traversing plane z=0 than anywhere else.
+//         // The min cut thus cuts the sphere in two approximate halves.
+//         for ( std::pair<edge_iterator, edge_iterator>
+//             ve = boost::edges( obj_fixture ); ve.first != ve.second; ++ve.first, ++nbEdges )
+//         {
+//           edge_descriptor e = *ve.first;
+//           edge_descriptor rev_e = obj_fixture.opposite( e );
+//           vertex_descriptor v1 = boost::source( e, obj_fixture );
+//           vertex_descriptor v2 = boost::target( e, obj_fixture );
+//           ASSERT( boost::source( rev_e, obj_fixture ) == v2 );
+//           ASSERT( boost::target( rev_e, obj_fixture ) == v1 );
+//           if ( v1 < v2 )
+//           {
+//             // KSpace::SCell sep = obj_fixture.separator( *ve.first );
+//             // capacity_type capacity = ( K.sKCoord( sep, 2 ) == 0 ) ? 0.01 : 1.0;
+//             capacity_type capacity = 0.5;
+//             edgeCapacityMap[ e ] = capacity;
+//             edgeCapacityMap[ obj_fixture.opposite( e ) ] = capacity;
+//             reversedEdgeMap[ e ] = obj_fixture.opposite( e );
+//             reversedEdgeMap[ obj_fixture.opposite( e ) ] = e;
+//           }
+//         }
+//         trace.info() << "- nb edges = " << nbEdges << std::endl;
+//         distanceMap.clear();
+//         colorMap.clear();
+//         capacity_type max_flow =
+//           boost::boykov_kolmogorov_max_flow // boykov kolmogorov max flow algorithm.
+//           ( obj_fixture, // the graph
+//             propEdgeCapacityMap, propEdgeResidualCapacityMap,
+//             propReversedEdgeMap, propPredecessorMap, propColorMap, propDistanceMap, propVertexIndexMap,
+//             start, furthest );
+//         INFO( "- max flow = " << max_flow)
+//           CHECK(abs(max_flow) == Approx(total_weight));
+//         trace.endBlock();
+//       }// maxflow
+//     }// mincut
+//   }
+// }
+
+
+
+///////////////////////////////////////////////////////////////////////////////

--- a/tests/topology/testObject.cpp
+++ b/tests/topology/testObject.cpp
@@ -78,11 +78,11 @@ bool testObject()
 {
   unsigned int nbok = 0;
   unsigned int nb = 0;
-  
+
   typedef SpaceND< 2 > Z2;
   typedef Z2::Point Point;
   typedef Point::Coordinate Coordinate;
-  typedef HyperRectDomain< Z2 > DomainType; 
+  typedef HyperRectDomain< Z2 > DomainType;
   Point p1(  -449, -449  );
   Point p2( 449, 449  );
   DomainType domain( p1, p2 );
@@ -94,9 +94,9 @@ bool testObject()
   typedef DomainAdjacency< DomainType, MetricAdj4 > Adj4;
   typedef DomainAdjacency< DomainType, MetricAdj8 > Adj8;
   typedef DigitalTopology< Adj4, Adj8 > DT48;
-  typedef DigitalSetSelector< DomainType, MEDIUM_DS+HIGH_BEL_DS >::Type 
+  typedef DigitalSetSelector< DomainType, MEDIUM_DS+HIGH_BEL_DS >::Type
      MediumSet;
-//   typedef DigitalSetSelector< DomainType, SMALL_DS >::Type 
+//   typedef DigitalSetSelector< DomainType, SMALL_DS >::Type
 //     MediumSet;
   typedef Object<DT48, MediumSet> ObjectType;
   typedef ObjectType::SmallSet SmallSet;
@@ -119,7 +119,7 @@ bool testObject()
   ostringstream sstr;
   sstr << "Creating disk( r < " << radius << " ) ...";
   trace.beginBlock ( sstr.str() );
-  for ( DomainType::ConstIterator it = domain.begin(); 
+  for ( DomainType::ConstIterator it = domain.begin();
   it != domain.end();
   ++it )
     {
@@ -162,29 +162,29 @@ bool testObject()
 
   trace.beginBlock ( "Testing neighborhoods ..." );
   Object<DT48, SmallSet> neigh = disk_object.neighborhood( c );
-  nbok += neigh.size() == 4 ? 1 : 0; 
+  nbok += neigh.size() == 4 ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
-         << "N_4(Disk, c).size() = " << neigh.size() 
+         << "N_4(Disk, c).size() = " << neigh.size()
          << " == 4" << std::endl;
   neigh = disk_object.properNeighborhood( l );
-  nbok += neigh.size() == 3 ? 1 : 0; 
+  nbok += neigh.size() == 3 ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
          << "N*_4(Disk, " << l << ").size() = " << neigh.size()
          << " == 3" << std::endl;
   Size size = disk_object.properNeighborhoodSize( l );
-  nbok += size == 3 ? 1 : 0; 
+  nbok += size == 3 ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
          << "#N*_4(Disk, " << l << ") = " << size
          << " == 3" << std::endl;
 
   neigh = disk_object2.neighborhood( c );
-  nbok += neigh.size() == 5 ? 1 : 0; 
+  nbok += neigh.size() == 5 ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
-         << "N_4(Disk2, c).size() = " << neigh.size() 
+         << "N_4(Disk2, c).size() = " << neigh.size()
          << " == 5" << std::endl;
   trace.endBlock();
 
@@ -194,15 +194,15 @@ bool testObject()
     nbok += neigh.size() == 7824 ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
-         << "neigh = disk_object, size() = " << neigh.size() 
+         << "neigh = disk_object, size() = " << neigh.size()
          << " == 636100" << std::endl;
   SmallObjectType neigh2 = disk_object2.neighborhood( c );
   DigitalSetConverter<SmallSet>::assign
     ( neigh.pointSet(), neigh2.pointSet() );
-  nbok += neigh.size() == 5 ? 1 : 0; 
+  nbok += neigh.size() == 5 ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
-         << "neigh = N_4(Disk2, c), size() = " << neigh.size() 
+         << "neigh = N_4(Disk2, c), size() = " << neigh.size()
          << " == 5" << std::endl;
   trace.endBlock();
 
@@ -211,13 +211,13 @@ bool testObject()
   nbok += bdisk.size() == 400 ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
-         << "Border(Disk, c), size() = " << bdisk.size() 
+         << "Border(Disk, c), size() = " << bdisk.size()
          << " == 3372" << std::endl;
   ObjectType bdisk2 = disk_object2.border();
   nbok += bdisk2.size() == 392 ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
-         << "Border(Disk2, c), size() = " << bdisk2.size() 
+         << "Border(Disk2, c), size() = " << bdisk2.size()
          << " == 3364" << std::endl;
   trace.endBlock();
 
@@ -226,10 +226,10 @@ bool testObject()
   ObjectExpander expander( bdisk, *(bdisk.pointSet().begin()) );
   while ( ! expander.finished() )
     {
-      nbok += expander.layer().size() <= 2 ? 1 : 0; 
+      nbok += expander.layer().size() <= 2 ? 1 : 0;
       nb++;
       trace.info() << "(" << nbok << "/" << nb << ") "
-       << "expander.layer.size() <= 2 " 
+       << "expander.layer.size() <= 2 "
        << expander << std::endl;
       expander.nextLayer();
     }
@@ -242,7 +242,7 @@ bool testObject()
       trace.info() << expander2 << std::endl;
       expander2.nextLayer();
     }
-  nbok += expander2.distance() <= sqrt(2.0)*radius ? 1 : 0; 
+  nbok += expander2.distance() <= sqrt(2.0)*radius ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
          << "expander.distance() = " << expander2.distance()
@@ -265,14 +265,14 @@ bool testObject3D()
   typedef MetricAdjacency< Z3, 2 > Adj18;
   typedef DigitalTopology< Adj6, Adj18 > DT6_18;
   typedef Z3::Point Point;
-  typedef HyperRectDomain< Z3 > Domain; 
-  typedef Domain::ConstIterator DomainConstIterator; 
+  typedef HyperRectDomain< Z3 > Domain;
+  typedef Domain::ConstIterator DomainConstIterator;
   typedef DigitalSetSelector< Domain, BIG_DS+HIGH_BEL_DS >::Type DigitalSet;
   typedef Object<DT6_18, DigitalSet> ObjectType;
   Adj6 adj6;
   Adj18 adj18;
   DT6_18 dt6_18( adj6, adj18, JORDAN_DT );
- 
+
   Point p1( -50, -50, -50 );
   Point p2( 50, 50, 50 );
   Domain domain( p1, p2 );
@@ -301,11 +301,11 @@ bool testObject3D()
   back_insert_iterator< vector< ObjectType > > inserter( objects );
   *inserter++ = diamond;
   *inserter++ = diamond_clone;
-  
+
   for (  vector<ObjectType>::const_iterator it = objects.begin();
    it != objects.end();
    ++it )
-    trace.info() << "- objects[" << (it - objects.begin() ) << "]" 
+    trace.info() << "- objects[" << (it - objects.begin() ) << "]"
      << " = " << *it << endl;
 
   INBLOCK_TEST( objects[ 0 ].size() == ( objects[ 1 ].size() + 2 ) );
@@ -314,7 +314,7 @@ bool testObject3D()
 
   trace.beginBlock ( "Testing connected component extraction  ..." );
   // JOL: do like this for output iterators pointing on the same
-  // container as 'this'. Works fine and nearly as fast. 
+  // container as 'this'. Works fine and nearly as fast.
   //
   // ObjectType( objects[ 0 ] ).writeComponents( inserter );
 
@@ -333,7 +333,7 @@ bool testObject3D()
   for (  vector<ObjectType>::const_iterator it = objects2.begin();
    it != objects2.end();
    ++it )
-    trace.info() << "- objects2[" << (it - objects2.begin() ) << "]" 
+    trace.info() << "- objects2[" << (it - objects2.begin() ) << "]"
      << " = " << *it << endl;
   INBLOCK_TEST( objects2[ 0 ].size() == objects2[ 1 ].size() );
   INBLOCK_TEST( objects2[ 2 ].size() == objects2[ 3 ].size() );
@@ -359,8 +359,8 @@ bool testSimplePoints3D()
   typedef MetricAdjacency< Z3, 2 > Adj18;
   typedef DigitalTopology< Adj6, Adj18 > DT6_18;
   typedef Z3::Point Point;
-  typedef HyperRectDomain< Z3 > Domain; 
-  typedef Domain::ConstIterator DomainConstIterator; 
+  typedef HyperRectDomain< Z3 > Domain;
+  typedef Domain::ConstIterator DomainConstIterator;
   typedef DigitalSetSelector< Domain, BIG_DS+HIGH_BEL_DS >::Type DigitalSet;
   typedef Object<DT6_18, DigitalSet> ObjectType;
   typedef Object<DT6_18, DigitalSet>::SmallObject SmallObjectType;
@@ -368,7 +368,7 @@ bool testSimplePoints3D()
   Adj6 adj6;
   Adj18 adj18;
   DT6_18 dt6_18( adj6, adj18, JORDAN_DT );
- 
+
   Point p1( -10, -10, -10 );
   Point p2( 10, 10, 10 );
   Domain domain( p1, p2 );
@@ -401,11 +401,11 @@ bool testSimplePoints3D()
   for ( DigitalSet::ConstIterator it = diamond.pointSet().begin();
   it != diamond.pointSet().end();
   ++it )
-    trace.info() << "- " << *it 
+    trace.info() << "- " << *it
      << " " << ( diamond.isSimple( *it ) ? "Simple" : "Not simple" )
      << endl;
   trace.endBlock();
-  
+
 
   return nbok == nb;
 }
@@ -417,11 +417,11 @@ bool testDraw()
   unsigned int nb = 0;
 
   trace.beginBlock ( "testDraw(): testing drawing commands." );
-  
+
   typedef SpaceND<  2 > Z2;
   typedef Z2::Point Point;
   typedef Point::Coordinate Coordinate;
-  typedef HyperRectDomain< Z2 > DomainType; 
+  typedef HyperRectDomain< Z2 > DomainType;
   Point p1(  -10, -10  );
   Point p2( 10, 10  );
   DomainType domain( p1, p2 );
@@ -434,9 +434,9 @@ bool testDraw()
   typedef DomainAdjacency< DomainType, MetricAdj8 > Adj8;
   typedef DigitalTopology< Adj4, Adj8 > DT48;
   typedef DigitalTopology< Adj8, Adj4 > DT84;
-  typedef DigitalSetSelector< DomainType, MEDIUM_DS+HIGH_BEL_DS >::Type 
+  typedef DigitalSetSelector< DomainType, MEDIUM_DS+HIGH_BEL_DS >::Type
      MediumSet;
-//   typedef DigitalSetSelector< DomainType, SMALL_DS >::Type 
+//   typedef DigitalSetSelector< DomainType, SMALL_DS >::Type
 //     MediumSet;
   typedef Object<DT48, MediumSet> ObjectType;
   typedef Object<DT84, MediumSet> ObjectType84;
@@ -453,7 +453,7 @@ bool testDraw()
   Adj8 adj8( domain, madj8 );
   DT48 dt48( adj4, adj8, JORDAN_DT );
   DT84 dt84( adj8, adj4, JORDAN_DT );
-  
+
   Coordinate r = 5;
   double radius = (double) (r+1);
   Point c(  0, 0  );
@@ -462,7 +462,7 @@ bool testDraw()
   ostringstream sstr;
   sstr << "Creating disk( r < " << radius << " ) ...";
   trace.beginBlock ( sstr.str() );
-  for ( DomainType::ConstIterator it = domain.begin(); 
+  for ( DomainType::ConstIterator it = domain.begin();
   it != domain.end();
   ++it )
     {
@@ -484,30 +484,30 @@ bool testDraw()
 
   board << SetMode( domain.className(), "Grid" ) << domain;
   board << disk_object;
-  
+
   board.saveSVG("disk-object.svg");
-  
+
   Board2D board2;
   board2.setUnit(Board::UCentimeter);
 
   board2 << SetMode( domain.className(), "Grid" ) << domain;
-  board2 << SetMode( disk_object.className(), "DrawAdjacencies" ) << disk_object; 
-  
+  board2 << SetMode( disk_object.className(), "DrawAdjacencies" ) << disk_object;
+
   board2.saveSVG("disk-object-adj.svg");
 
   Board2D board3;
   board3.setUnit(Board::UCentimeter);
 
-  board3 << SetMode( domain.className(), "Grid" ) << domain; 
+  board3 << SetMode( domain.className(), "Grid" ) << domain;
   board3 << SetMode( disk_object2.className(), "DrawAdjacencies" ) << disk_object2;
-  
+
   board3.saveSVG("disk-object-adj-bis.svg");
   trace.endBlock();
 
   trace.endBlock();
 
   return nbok == nb;
-  
+
 }
 
 struct MyDrawStyleCustomRed : public DrawableWithBoard2D
@@ -547,8 +547,8 @@ bool testSimplePoints2D()
   unsigned int nbok = 0;
   unsigned int nb = 0;
   typedef DGtal::Z2i::Point Point;
-  //typedef Domain::ConstIterator DomainConstIterator; 
- 
+  //typedef Domain::ConstIterator DomainConstIterator;
+
   Point p1( -17, -17 );
   Point p2( 17, 17 );
   Domain domain( p1, p2 );
@@ -584,7 +584,7 @@ bool testSimplePoints2D()
   DGtal::uint64_t nb_simple;
   trace.beginBlock ( "Greedy homotopic thinning ..." );
   int layer = 0;
-  do 
+  do
     {
       DigitalSet & S = shape.pointSet();
       std::queue<DigitalSet::Iterator> Q;
@@ -598,7 +598,7 @@ bool testSimplePoints2D()
     Q.pop();
     if ( shape.isSimple( *it ) )
       {
-        board << CustomStyle( it->className(), 
+        board << CustomStyle( it->className(),
                    new MyDrawStyleCustomFillColor
                    ( cmap_grad( layer ) ) )
         << *it;
@@ -614,7 +614,7 @@ bool testSimplePoints2D()
   // Greedy thinning.
   trace.beginBlock ( "Greedy homotopic thinning ..." );
   layer = 0;
-  do 
+  do
     {
       DigitalSet & S = shape2.pointSet();
       std::queue<DigitalSet::Iterator> Q;
@@ -628,7 +628,7 @@ bool testSimplePoints2D()
     Q.pop();
     if ( shape2.isSimple( *it ) )
       {
-        board2 << CustomStyle( it->className(), 
+        board2 << CustomStyle( it->className(),
                    new MyDrawStyleCustomFillColor
              ( cmap_grad( layer ) ) )
          << *it;
@@ -640,7 +640,7 @@ bool testSimplePoints2D()
     }
   while ( nb_simple != 0 );
   trace.endBlock();
-  
+
   board  << CustomStyle( shape.className(), new MyDrawStyleCustomRed )
   << shape;
   board.saveSVG( "shape-thinning-4-8.svg");
@@ -650,12 +650,92 @@ bool testSimplePoints2D()
    << shape2;
   board2.saveSVG( "shape-thinning-8-4.svg");
   board2.clear();
-  
+
   return nbok == nb;
 }
 
+bool testObjectGraph()
+{
 
+  unsigned int nbok = 0;
+  unsigned int nb = 0;
 
+  using namespace DGtal;
+  using namespace Z3i;
+  using Point = Z3i::Point ;
+  using Domain = Z3i::Domain ;
+  using DigitalSet = Z3i::DigitalSet ;
+  using KSpace = Z3i::KSpace ;
+  trace.beginBlock ( "Create Diamond Object" );
+  Point p1( -10, -10, -10 );
+  Point p2( 10, 10, 10 );
+  Domain domain( p1, p2 );
+  Point c( 0, 0, 0 );
+  Point r( 3, 0, 0 );
+
+  // diamond of radius 4
+  DigitalSet diamond_set( domain );
+  for ( auto it = domain.begin(); it != domain.end(); ++it )
+    {
+      if ( (*it - c ).norm1() <= 3 ) diamond_set.insertNew( *it );
+    }
+  // diamond_set.erase( c );
+
+  KSpace K;
+  bool space_ok = K.init( domain.lowerBound(),
+                          domain.upperBound(), true // necessary
+                          );
+
+  using MyDigitalTopology = Z3i::DT26_6;
+  // using MyDigitalSet = Z3i::DigitalSet ;
+  using MyDigitalSet = DigitalSetByAssociativeContainer<Z3i::Domain , std::unordered_set< typename Z3i::Domain::Point> >;
+  using MyObject = Object<MyDigitalTopology, MyDigitalSet>;
+  MyDigitalTopology::ForegroundAdjacency adjF;
+  MyDigitalTopology::BackgroundAdjacency adjB;
+  MyDigitalTopology topo(adjF, adjB, DGtal::DigitalTopologyProperties::JORDAN_DT);
+  MyObject obj(topo,diamond_set);
+
+  INBLOCK_TEST( obj.size() == diamond_set.size() );
+  trace.endBlock();
+  trace.beginBlock( "Check edges" );
+
+  std::set<Point> corner_points;
+  Point north( 0 , 0 , 3 );
+  corner_points.insert(north);
+  Point south( 0 , 0 , -3 );
+  corner_points.insert(south);
+  Point east( 3 , 0 , 0 );
+  corner_points.insert(east);
+  Point west( -3 , 0 , 0 );
+  corner_points.insert(west);
+
+  for(auto && p : corner_points){
+    auto pit = obj.pointSet().find(p);
+    if(pit == obj.pointSet().end()){
+      trace.info() << "point not found" << std::endl;
+      return false;
+    }
+    auto edges = obj.outEdges(*pit);
+    INBLOCK_TEST2( edges.size() == 5, edges.size() );
+  }
+  Point center( 0 , 0 , 0 );
+  auto cpit = obj.pointSet().find(center);
+  auto cedges = obj.outEdges(*cpit);
+  INBLOCK_TEST2( cedges.size() == 26, cedges.size() );
+
+  // opposites edge
+  for(auto && e : cedges){
+    auto rev_e = obj.opposite(e);
+    INBLOCK_TEST(
+        (e.vertices[0] == rev_e.vertices[1]) &&
+        (e.vertices[1] == rev_e.vertices[0])
+    )
+  }
+  trace.endBlock();
+
+  return nbok == nb;
+
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Standard services - public :
@@ -668,10 +748,11 @@ int main( int argc, char** argv )
     trace.info() << " " << argv[ i ];
   trace.info() << endl;
 
-  bool res = testObject() && 
+  bool res = testObject() &&
     testObject3D() && testDraw()
     && testSimplePoints3D()
-    && testSimplePoints2D();
+    && testSimplePoints2D()
+    && testObjectGraph();
 
   trace.emphase() << ( res ? "Passed." : "Error." ) << endl;
   trace.endBlock();

--- a/tests/topology/testObject.cpp
+++ b/tests/topology/testObject.cpp
@@ -685,6 +685,7 @@ bool testObjectGraph()
   bool space_ok = K.init( domain.lowerBound(),
                           domain.upperBound(), true // necessary
                           );
+  INBLOCK_TEST( space_ok == true ) ;
 
   using MyDigitalTopology = Z3i::DT26_6;
   // using MyDigitalSet = Z3i::DigitalSet ;


### PR DESCRIPTION
Same role than DigitalSurfaceBoostGraphInterface, but with Objects.
Minor changes to Object.
 * outEdges has been added to run some useful BoostGraphLibrary algorithms, such as connected_components.
* default constructor to Edge, and constructor with dummy bool flag to avoid re-ordering of head and tail vertices.
* added tests of added methods to testObject.cpp

Added ObjectBoostGraphInterface.
* I have followed the template from DigitalSurfaceBoostGraphInterface
* The test uses Catch. Note that min-cut and max-flow are not tested.

Doxygen comments added in code, but I haven't generated them.
 