### PR TITLE
Light viewer custom

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,16 @@
    some improvements on bounding box computation with orientation check.
    (B. Kerautret, [#1123](https://github.com/DGtal-team/DGtal/pull/1123))
 
+
+- *IO Package*
+ - Viewer3D: add three new modes for shape rendering (default, metallic and
+   plastic). The rendering can be changed by using the key M. The user can
+   also choose its own rendering with some setter/getter on the opengl
+   lightning/properties. (B. Kerautret,
+   [#1128](https://github.com/DGtal-team/DGtal/pull/1128))
+
+
+
 # DGtal 0.9.1
 
 ## New Features / Critical Changes

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -278,7 +278,7 @@ namespace DGtal
     /**
      * Change the current rendering mode of the viewer.
      * 
-     * @param aRenderMode the mode of the rendering.
+     * @param[in] aRenderMode the mode of the rendering.
      * 
      **/
     void updateRenderingCoefficients(const RenderingMode aRenderMode);

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -144,6 +144,8 @@ namespace DGtal
     using Display::getSelectCallback3D;
     typedef typename Display::RealPoint RealPoint;
 
+    enum RenderingMode {RenderingDefault, RenderingMetallic, RenderingPlastic };
+
     // ----------------------- Standard services ------------------------------
   public:
 
@@ -232,6 +234,56 @@ namespace DGtal
     }
 
 
+    /**
+     * Change the light shininess coefficients used in opengl
+     * rendering (used in glMaterialf with GL_SPECULAR parameters). 
+     *
+     * @param[in] matShininessCoeff the value of the shininess coefficient (defined in [0, 128], default 50.0).
+     * 
+     **/
+    void setGLMaterialShininessCoefficient(const GLfloat matShininessCoeff);
+
+    
+    /**
+     * Change the light ambient coefficients used in opengl
+     * rendering (used in glLightfv with GL_AMBIENT parameters). 
+     *
+     * @param[in] lightAmbientCoeffs the values of specular coefficient of RGBA channels (defined in [0,1], default: {0.0,0.0,0.0,1.0}).
+
+     * 
+     **/
+    void setGLLightAmbientCoefficients(const GLfloat lightAmbientCoeffs [4]);
+
+    /**
+     * Change the material ambient coefficients used in opengl
+     * rendering (used in glMaterialf with GL_AMBIENT parameters). 
+     *
+     * @param[in] lightDiffuseCoeffs the values of specular coefficient of RGBA channels (defined in [0,1], default: {1.0,1.0,1.0,1.0}).
+
+     * 
+     **/
+    void setGLLightDiffuseCoefficients(const GLfloat lightDiffuseCoeffs [4]);
+
+
+    /**
+     * Change the light specular coefficients used in opengl
+     * rendering (used in glLightfv with GL_SPECULAR parameters). 
+     *
+     * @param[in] lightSpecularCoeffs the values of specular coefficient of RGBA channels (defined in [0,1], default: {1.0,1.0,1.0,1.0}).
+     * 
+     **/
+    void setGLLightSpecularCoefficients(const GLfloat lightSpecularCoeffs [4]);
+    
+    
+    /**
+     * Change the current rendering mode of the viewer.
+     * 
+     * @param aRenderMode the mode of the rendering.
+     * 
+     **/
+    void updateRenderingCoefficients(const RenderingMode aRenderMode);
+    
+    
     /// the 3 possible axes for the image direction
     enum ImageDirection {xDirection, yDirection, zDirection, undefDirection };
     /// the modes of representation of an image
@@ -249,6 +301,8 @@ namespace DGtal
     double myGLLineMinWidth;
     /// flag to save automatically or not the Viewer3d state when closing the viewer
     bool myAutoSaveState;
+    // define the default rendering mode of the viewer
+    RenderingMode myRenderingMode = RenderingDefault;
     
     /**
      * Used to display the 2D domain of an image.
@@ -718,16 +772,6 @@ namespace DGtal
     void  rotateDomain(Image2DDomainD3D &anDom, double angle, ImageDirection rotationDir);
 
 
-    /**
-     * Change the material specular/shininess coefficients used in opengl
-     * rendering (used in glMaterialf with GL_SPECULAR/GL_SHININESS parameters). 
-     *
-     * @param[in] matSpecularCoeff the values of specular coefficient of RGBA channels (defined in [0,1], default: {1.0,1.0,1.0,1.0}).
-     * @param[in] matShininessCoeff the value of the shininess coefficient (defined in [0, 128], default 50.0).
-     * 
-     **/
-    void setGlMaterialSpecularCoefficients(const GLfloat matSpecularCoeff [4], const GLfloat matShininessCoeff);
-    
 
 
     
@@ -1342,9 +1386,21 @@ namespace DGtal
     double myLightTheta; /// the light position (inclination)
     double myLightPhi; /// the light position (azimuth)
     double myLightR; /// the light position (distance)
-    GLfloat myLightPosition [4]; // the light position in cartesian coordinates
-    GLfloat myMaterialSpecularCoeff[4] = { 1.0, 1.0, 1.0, 1.0 }; // the material specular coefficients used in opengl rendering 
-    GLfloat myMaterialShininessCoeff[1] = { 50.0 }; // the material shininess coefficient used in opengl rendering 
+    GLfloat myLightPosition [4]; // the light position in cartesian coordinate
+    GLfloat myMaterialShininessCoeff[1] =  {50.0} ; // the material shininess coefficient used in opengl rendering 
+    GLfloat myMaterialSpecularCoeffs[4] = { 1.0, 1.0, 1.0, 1.0 }; // the light specular coefficients used in opengl rendering 
+    GLfloat myLightSpecularCoeffs[4] = { 1.0, 1.0, 1.0, 1.0 }; // the light specular coefficients used in opengl rendering 
+    GLfloat myLightAmbientCoeffs[4] = { 0.0, 0.0, 0.0, 1.0 }; // the material ambient coefficients used in opengl rendering  
+    GLfloat myLightDiffuseCoeffs[4] = { 1.0, 1.0, 1.0, 1.0 }; // the material diffuse coefficients used in opengl rendering  
+    
+    const GLfloat myDefaultRenderSpec = 1.0; // default specular coefficients for default mode rendering
+    const GLfloat myDefaultRenderDiff = 1.0; // default diffuse coefficients for metallic mode rendering
+    const GLfloat myMetallicRenderSpec = 0.6; // default specular coefficients for metallic mode rendering
+    const GLfloat myMetallicRenderDiff = 0.5; // default diffuse coefficients for metallic mode rendering
+    const GLfloat myPlasticRenderSpec = 0.8; // default specular coefficients for platic mode rendering
+    const GLfloat myPlasticRenderDiff = 0.2; // default diffuse coefficients for platic mode rendering
+    
+
 
     double ZNear; ///< znear distance
     double ZFar; ///< zfar distance

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -718,7 +718,19 @@ namespace DGtal
     void  rotateDomain(Image2DDomainD3D &anDom, double angle, ImageDirection rotationDir);
 
 
+    /**
+     * Change the material specular/shininess coefficients used in opengl
+     * rendering (used in glMaterialf with GL_SPECULAR/GL_SHININESS parameters). 
+     *
+     * @param[in] matSpecularCoeff the values of specular coefficient of RGBA channels (defined in [0,1], default: {1.0,1.0,1.0,1.0}).
+     * @param[in] matShininessCoeff the value of the shininess coefficient (defined in [0, 128], default 50.0).
+     * 
+     **/
+    void setGlMaterialSpecularCoefficients(const GLfloat matSpecularCoeff [4], const GLfloat matShininessCoeff);
+    
 
+
+    
 
     // ------------------------- Protected Datas ------------------------------
   private:
@@ -1331,6 +1343,9 @@ namespace DGtal
     double myLightPhi; /// the light position (azimuth)
     double myLightR; /// the light position (distance)
     GLfloat myLightPosition [4]; // the light position in cartesian coordinates
+    GLfloat myMaterialSpecularCoeff[4] = { 1.0, 1.0, 1.0, 1.0 }; // the material specular coefficients used in opengl rendering 
+    GLfloat myMaterialShininessCoeff[1] = { 50.0 }; // the material shininess coefficient used in opengl rendering 
+
     double ZNear; ///< znear distance
     double ZFar; ///< zfar distance
 

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -674,6 +674,8 @@ DGtal::Viewer3D<Space, KSpace>::draw()
   glMultMatrixd ( manipulatedFrame()->matrix() );
   glPushMatrix();
   glScalef(myGLScaleFactorX, myGLScaleFactorY, myGLScaleFactorZ);
+  glMaterialfv(GL_FRONT, GL_SPECULAR, myMaterialSpecularCoeff);
+  glMaterialfv(GL_FRONT, GL_SHININESS, myMaterialShininessCoeff);
   glLightfv(GL_LIGHT0, GL_POSITION, myLightPosition);
   unsigned int i = 0;
   typename vector< typename Viewer3D<Space, KSpace>::ClippingPlaneD3D >::const_iterator it = Viewer3D<Space, KSpace>::myClippingPlaneList.begin();
@@ -810,8 +812,6 @@ template< typename Space, typename KSpace>
 void
 DGtal::Viewer3D<Space, KSpace>::init()
 {
-  GLfloat mat_specular[] = { 1.0, 1.0, 1.0, 1.0 };
-  GLfloat mat_shininess[] = { 50.0 };
   myAutoSaveState = false;
   myIsMovingLight = false;
   myLigthRotationStep = 0.01;
@@ -826,10 +826,10 @@ DGtal::Viewer3D<Space, KSpace>::init()
   myLightPosition[3] = 0.0;
 
   glClearColor (0.0, 0.0, 0.0, 0.0);
-  glShadeModel (GL_SMOOTH);
-  
-  glMaterialfv(GL_FRONT, GL_SPECULAR, mat_specular);
-  glMaterialfv(GL_FRONT, GL_SHININESS, mat_shininess);
+  glShadeModel (GL_SMOOTH);  
+
+  glMaterialfv(GL_FRONT, GL_SPECULAR, myMaterialSpecularCoeff);
+  glMaterialfv(GL_FRONT, GL_SHININESS, myMaterialShininessCoeff);
   glLightfv(GL_LIGHT0, GL_POSITION, myLightPosition);
   
   glEnable(GL_LIGHTING);
@@ -1223,7 +1223,6 @@ DGtal::Viewer3D<Space, KSpace>::keyPressEvent ( QKeyEvent *e )
       updateList(false);
       updateGL();
     }
-
 
   if ( ( e->key() ==Qt::Key_R ) )
     {
@@ -1774,6 +1773,20 @@ DGtal::Viewer3D<Space, KSpace>::closeEvent	(	QCloseEvent * 	e	){
   }
   QGLWidget::closeEvent(e);
 }
+
+
+
+template< typename Space, typename KSpace>
+void 
+DGtal::Viewer3D<Space, KSpace>::setGlMaterialSpecularCoefficients(const GLfloat matSpecularCoeff [4], 
+                                                                  const GLfloat matShininessCoeff){
+  myMaterialShininessCoeff[0] = matShininessCoeff;
+  myMaterialSpecularCoeff[0] =  matSpecularCoeff[0];
+  myMaterialSpecularCoeff[1] =  matSpecularCoeff[1];
+  myMaterialSpecularCoeff[2] =  matSpecularCoeff[2];
+  updateGL();
+}
+
 
 
 

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -888,6 +888,7 @@ DGtal::Viewer3D<Space, KSpace>::init()
   setKeyDescription ( Qt::Key_R, "Reset default scale for 3 axes to 1.0f." );
   setKeyDescription ( Qt::Key_D, "Enable/Disable the two side face rendering." );
   setKeyDescription ( Qt::Key_R, "Reset default scale for 3 axes to 1.0f." );
+  setKeyDescription ( Qt::Key_M, "Switch the rendering mode bewteen Default, Metallic and Plastic mode." );
 #if !defined (QGLVIEWER_VERSION) || QGLVIEWER_VERSION < 0x020500
   setMouseBindingDescription((Qt::ControlModifier|Qt::ShiftModifier) + Qt::LeftButton, "move light source position defined in the main coordinate system (an x-axis (resp. y-axis) mouse move changes the azimuth (resp. inclination) angle of the light source). Note that light source is always looking at the center point (0,0,0).");
 #else

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -674,9 +674,15 @@ DGtal::Viewer3D<Space, KSpace>::draw()
   glMultMatrixd ( manipulatedFrame()->matrix() );
   glPushMatrix();
   glScalef(myGLScaleFactorX, myGLScaleFactorY, myGLScaleFactorZ);
-  glMaterialfv(GL_FRONT, GL_SPECULAR, myMaterialSpecularCoeff);
+
   glMaterialfv(GL_FRONT, GL_SHININESS, myMaterialShininessCoeff);
+  glMaterialfv(GL_FRONT, GL_SPECULAR, myMaterialSpecularCoeffs);
+  glLightfv(GL_LIGHT0, GL_SPECULAR, myLightSpecularCoeffs);
+  glLightfv(GL_LIGHT0, GL_DIFFUSE, myLightDiffuseCoeffs);
+  glLightfv(GL_LIGHT0, GL_AMBIENT, myLightAmbientCoeffs);
+  
   glLightfv(GL_LIGHT0, GL_POSITION, myLightPosition);
+
   unsigned int i = 0;
   typename vector< typename Viewer3D<Space, KSpace>::ClippingPlaneD3D >::const_iterator it = Viewer3D<Space, KSpace>::myClippingPlaneList.begin();
   
@@ -828,8 +834,12 @@ DGtal::Viewer3D<Space, KSpace>::init()
   glClearColor (0.0, 0.0, 0.0, 0.0);
   glShadeModel (GL_SMOOTH);  
 
-  glMaterialfv(GL_FRONT, GL_SPECULAR, myMaterialSpecularCoeff);
   glMaterialfv(GL_FRONT, GL_SHININESS, myMaterialShininessCoeff);
+  glMaterialfv(GL_FRONT, GL_SPECULAR, myMaterialSpecularCoeffs);
+  glLightfv(GL_LIGHT0, GL_SPECULAR, myLightSpecularCoeffs);
+  glLightfv(GL_LIGHT0, GL_DIFFUSE, myLightDiffuseCoeffs);
+  glLightfv(GL_LIGHT0, GL_AMBIENT, myLightAmbientCoeffs);
+  
   glLightfv(GL_LIGHT0, GL_POSITION, myLightPosition);
   
   glEnable(GL_LIGHTING);
@@ -1215,7 +1225,24 @@ DGtal::Viewer3D<Space, KSpace>::keyPressEvent ( QKeyEvent *e )
       operator>> <Space, KSpace>(*this, "exportedMesh.off");
       trace.info() << "[done]"<< endl ;
     }
+  if( e->key() == Qt::Key_M)
+    {
+      switch (myRenderingMode)
+        {
+        case RenderingMode::RenderingDefault : 
+          myRenderingMode = RenderingMode::RenderingMetallic;
+          break;
+        case RenderingMode::RenderingMetallic : 
+          myRenderingMode = RenderingMode::RenderingPlastic;
+          break;
+        case RenderingMode::RenderingPlastic : 
+          myRenderingMode = RenderingMode::RenderingDefault;
+          break;
+        } 
+      updateRenderingCoefficients(myRenderingMode);
+    }
 
+  
 
   if ( ( e->key() ==Qt::Key_W ) )
     {
@@ -1775,17 +1802,81 @@ DGtal::Viewer3D<Space, KSpace>::closeEvent	(	QCloseEvent * 	e	){
 }
 
 
+template< typename Space, typename KSpace>
+void 
+DGtal::Viewer3D<Space, KSpace>::setGLMaterialShininessCoefficient(const GLfloat matShininessCoeff)
+{
+  myMaterialShininessCoeff = matShininessCoeff;  
+  updateGL();
+}
+
 
 template< typename Space, typename KSpace>
 void 
-DGtal::Viewer3D<Space, KSpace>::setGlMaterialSpecularCoefficients(const GLfloat matSpecularCoeff [4], 
-                                                                  const GLfloat matShininessCoeff){
-  myMaterialShininessCoeff[0] = matShininessCoeff;
-  myMaterialSpecularCoeff[0] =  matSpecularCoeff[0];
-  myMaterialSpecularCoeff[1] =  matSpecularCoeff[1];
-  myMaterialSpecularCoeff[2] =  matSpecularCoeff[2];
+DGtal::Viewer3D<Space, KSpace>::setGLLightAmbientCoefficients(const GLfloat lightAmbientCoeffs [4])
+{
+  myLightAmbientCoeffs[0] =  lightAmbientCoeffs[0];
+  myLightAmbientCoeffs[1] =  lightAmbientCoeffs[1];
+  myLightAmbientCoeffs[2] =  lightAmbientCoeffs[2];
+  myLightAmbientCoeffs[3] =  lightAmbientCoeffs[3]; 
   updateGL();
 }
+
+
+template< typename Space, typename KSpace>
+void 
+DGtal::Viewer3D<Space, KSpace>::setGLLightDiffuseCoefficients(const GLfloat lightDiffuseCoeffs [4])
+{
+  myLightDiffuseCoeffs[0] =  lightDiffuseCoeffs[0];
+  myLightDiffuseCoeffs[1] =  lightDiffuseCoeffs[1];
+  myLightDiffuseCoeffs[2] =  lightDiffuseCoeffs[2];
+  myLightDiffuseCoeffs[3] =  lightDiffuseCoeffs[3];
+  updateGL();
+}
+
+
+template< typename Space, typename KSpace>
+void 
+DGtal::Viewer3D<Space, KSpace>::updateRenderingCoefficients(const RenderingMode aRenderMode)
+{
+  GLfloat newCoefDiff, newCoefSpec = 1.0;
+  switch (aRenderMode) 
+    {
+    case RenderingMode::RenderingDefault :
+      newCoefDiff = myDefaultRenderDiff;
+      newCoefSpec = myDefaultRenderSpec;
+      break;
+    case RenderingMode::RenderingMetallic :
+      newCoefDiff = myMetallicRenderDiff;
+      newCoefSpec = myMetallicRenderSpec;
+      break;
+    case RenderingMode::RenderingPlastic :
+      newCoefDiff = myPlasticRenderDiff;
+      newCoefSpec = myPlasticRenderSpec;
+      break;
+    }
+  for (unsigned int i = 0; i<3; i++) 
+    myLightDiffuseCoeffs[i] = newCoefDiff;
+  myLightDiffuseCoeffs[3] = 1.0;
+  for (unsigned int i = 0; i<3; i++) 
+    myLightSpecularCoeffs[i] = newCoefSpec;
+  myLightSpecularCoeffs[3] = 1.0;
+  updateGL();
+}
+
+
+
+template< typename Space, typename KSpace>
+void
+DGtal::Viewer3D<Space, KSpace>::setGLLightSpecularCoefficients(const GLfloat lightSpecularCoeffs [4])
+{
+  myLightSpecularCoeffs[0] =  lightSpecularCoeffs[0];
+  myLightSpecularCoeffs[1] =  lightSpecularCoeffs[1];
+  myLightSpecularCoeffs[2] =  lightSpecularCoeffs[2];
+  myLightSpecularCoeffs[3] =  lightSpecularCoeffs[3];
+  updateGL();
+}
+
 
 
 


### PR DESCRIPTION
Add three new modes for shape rendering (default, metallic and plastic). The rendering can be changed by using the key M. The user can also choose its own rendering with some setter/getter on the opengl
lightning/properties.


<img width="597" alt="capture d ecran 2016-02-08 a 23 14 54" src="https://cloud.githubusercontent.com/assets/772865/12901937/7b6d7adc-cebe-11e5-8341-4d4e888f5539.png">
<img width="598" alt="capture d ecran 2016-02-08 a 23 15 00" src="https://cloud.githubusercontent.com/assets/772865/12901946/83b3c962-cebe-11e5-8248-57293ef7ae1b.png">
<img width="598" alt="capture d ecran 2016-02-08 a 23 14 47" src="https://cloud.githubusercontent.com/assets/772865/12901956/87f23dec-cebe-11e5-9443-54b31a051c83.png">
