### PR TITLE
Bug fix: without 'struct', we can't include <DGtal/io/viewers/Viewer3…

### DIFF
--- a/src/DGtal/io/viewers/CDrawableWithViewer3D.h
+++ b/src/DGtal/io/viewers/CDrawableWithViewer3D.h
@@ -110,7 +110,7 @@ An object x satisfying this concept may then be used as:
   private:
 
     T myT; //! the drawable class
-    DrawableWithViewer3D *myD;
+    struct DrawableWithViewer3D *myD;
 
     std::string myS;
 


### PR DESCRIPTION
…D.h> in an external project.

DrawableWithViewer3D is a structure define in "DGtal/base/Common.h" when you compîle DGtal with the WITH_VISU3D_QGLVIEWER option.
I suppose that this can be reproduce just by trying to compile a small code with the "#include <DGtal/io/viewers/Viewer3D.h>" line.