### PR TITLE
Fix vol/pgm/raw reading bug on Win 10

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,8 +17,8 @@
    [#1128](https://github.com/DGtal-team/DGtal/pull/1128))
  - readers: fix a vol/pgm/raw reading bug occurring on Windows 10 due to the
    different interpretations of end of line \r\n on Window versus \n on
-   unix/mac. Changing reading mode with binary mode instead text mode the
-   issue. (Bertrand Kerautret
+   unix/mac. Changing reading mode with binary mode instead text mode fix
+   the issue. (Bertrand Kerautret
    [#1130](https://github.com/DGtal-team/DGtal/pull/1130))
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,11 @@
    also choose its own rendering with some setter/getter on the opengl
    lightning/properties. (B. Kerautret,
    [#1128](https://github.com/DGtal-team/DGtal/pull/1128))
-
+ - readers: fix a vol/pgm/raw reading bug occurring on Windows 10 due to the
+   different interpretations of end of line \r\n on Window versus \n on
+   unix/mac. Changing reading mode with binary mode instead text mode the
+   issue. (Bertrand Kerautret
+   [#1130](https://github.com/DGtal-team/DGtal/pull/1130))
 
 
 # DGtal 0.9.1

--- a/src/DGtal/io/readers/LongvolReader.ih
+++ b/src/DGtal/io/readers/LongvolReader.ih
@@ -54,7 +54,7 @@ DGtal::LongvolReader<T, TFunctor>::importLongvol( const std::string & filename,
 
   HeaderField header[ MAX_HEADERNUMLINES ];
 
-  fin = fopen( filename.c_str() , "r" );
+  fin = fopen( filename.c_str() , "rb" );
 
   if ( fin == NULL )
   {

--- a/src/DGtal/io/readers/PGMReader.ih
+++ b/src/DGtal/io/readers/PGMReader.ih
@@ -60,7 +60,7 @@ DGtal::PGMReader<TImageContainer, TFunctor>::importPGM(const std::string & aFile
   BOOST_STATIC_ASSERT( (ImageContainer::Domain::dimension == 2));
   try 
     {
-      infile.open (aFilename.c_str(), std::ifstream::in);
+      infile.open (aFilename.c_str(), std::ifstream::in | std::ifstream::binary);
     }
   catch( ... )
     {
@@ -180,7 +180,7 @@ DGtal::PGMReader<TImageContainer,TFunctor>::importPGM3D(const std::string & aFil
   BOOST_STATIC_ASSERT( (ImageContainer::Domain::dimension == 3));
   try 
     {
-      infile.open (aFilename.c_str(), std::ifstream::in);
+      infile.open (aFilename.c_str(), std::ifstream::in | std::ifstream::binary);
     }
   catch( ... )
     {

--- a/src/DGtal/io/readers/RawReader.ih
+++ b/src/DGtal/io/readers/RawReader.ih
@@ -44,7 +44,7 @@ throw(DGtal::IOException)
     BOOST_CONCEPT_ASSERT((  concepts::CUnaryFunctor<TFunctor, Word, Value > )) ;
 
     FILE * fin;
-    fin = fopen( filename.c_str() , "r" );
+    fin = fopen( filename.c_str() , "rb" );
 
     if (fin == NULL)
         trace.error() << "RawReader : can't open "<< filename << std::endl;

--- a/src/DGtal/io/readers/VolReader.ih
+++ b/src/DGtal/io/readers/VolReader.ih
@@ -58,14 +58,14 @@ DGtal::VolReader<T, TFunctor>::importVol( const std::string & filename,
 
 #ifdef WIN32
   errno_t err;
-  err = fopen_s( &fin, filename.c_str() , "r" );
+  err = fopen_s( &fin, filename.c_str() , "rb" );
   if ( err )
   {
     trace.error() << "VolReader : can't open " << filename << std::endl;
     throw dgtalexception;
   }
 #else
-  fin = fopen( filename.c_str() , "r" );
+  fin = fopen( filename.c_str() , "rb" );
 #endif
 
   if ( fin == NULL )


### PR DESCRIPTION
Fix a vol/pgm/raw reading bug occurring on Windows 10 due to the  different interpretations of end of line \r\n on Window versus \n on unix/mac.  Changing reading mode with binary mode instead text mode fix  the issue.
We have now the tools sliceViewer working on Windows 10:
![capture d ecran 2016-02-13 a 00 22 21](https://cloud.githubusercontent.com/assets/772865/13023469/750351de-d1e9-11e5-88cf-61cdc8d9c11b.png)
