### PR TITLE
Add a new travis matrix entry to make sure that DGtalTools compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ script:
   - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  cd examples && make  -j 3 ; fi
   - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  cd ../tests &&  make -j 3 &&  cd .. ; fi
   - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  make test ARGS=--output-on-failure ; fi
-  - if [ $CONFIG == "DGtalTools" ]; then pwd ; .travis/getAndTestDGtalTools.sh ; fi
+  - if [ $CONFIG == "DGtalTools" ]; then pwd ; .travis/getAndCheckDGtalTools.sh ; fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,12 +70,14 @@ addons:
 before_install:
   - if [ $CXX == "g++" ]; then CCOMPILER="gcc-4.8"; CXXCOMPILER="g++-4.8"; fi
   - DOC="false"
-  - NEEDBUILD="true";
-  - if [ $CONFIG == "Documentation,Debug,Cairo,GMP" ]; then NEEDBUILD="false"; if [ $OriginalRepo == "true" ];  then if [ $TRAVIS_PULL_REQUEST == "false" ]; then DOC="true"; fi; fi; fi
+  - DGTALCOREONLY="false"
+  - NEEDCORE="true";
+  - NEEDEXAMPLESANDTESTS="true";
+  - if [ $CONFIG == "Documentation,Debug,Cairo,GMP" ]; then NEEDEXAMPLESANDTESTS="false"; NEEDBUILD="false"; if [ $OriginalRepo == "true" ];  then if [ $TRAVIS_PULL_REQUEST == "false" ]; then DOC="true"; fi; fi; fi
   - if [ $CONFIG == "Debug,Magick,GMP,ITK" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug  -DWITH_MAGICK=true -DWITH_GMP=true  -DBUILD_TESTING=ON  -DWARNING_AS_ERROR=ON";  fi
   - if [ $CONFIG == "Debug,Cairo,QGLviewer,HDF5" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DBUILD_TESTING=ON -DWARNING_AS_ERROR=OFF";   fi
   - if [ $DOC == "true" ]; then  .travis/install_doxygen.sh;  BTYPE="-DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen -DCMAKE_BUILD_TYPE=Debug -DWITH_CAIRO=true  -DWITH_GMP=true"; DOC="true"; openssl aes-256-cbc -K $encrypted_47769ec71275_key -iv $encrypted_47769ec71275_iv -in .travis/dgtal_rsa.enc -out .travis/dgtal_rsa -d; chmod 600 .travis/dgtal_rsa; DOC="true"; fi
-  - if [ $CONFIG == "DGtalTools" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug  -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=off";  fi
+  - if [ $CONFIG == "DGtalTools" ]; then NEEDEXAMPLESANDTESTS="false"; BTYPE="-DCMAKE_BUILD_TYPE=Debug  -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=off";  fi
 
 
 ########
@@ -94,10 +96,10 @@ script:
   - echo $DOC
   - echo $BTYPE
   - if [ $NEEDBUILD == "true" ]; then  make DGtal && make DGtalIO; fi
-  - if [ $NEEDBUILD == "true" ]; then  cd examples && make  -j 3 ; fi
-  - if [ $NEEDBUILD == "true" ]; then  cd ../tests &&  make -j 3 &&  cd .. ; fi
-  - if [ $NEEDBUILD == "true" ]; then  make test ARGS=--output-on-failure ; fi
-  - if [ $CONFIG == "DGtalTools"]; then .travis/getAndTestDGtalTools.sh ; fi
+  - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  cd examples && make  -j 3 ; fi
+  - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  cd ../tests &&  make -j 3 &&  cd .. ; fi
+  - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  make test ARGS=--output-on-failure ; fi
+  - if [ $DGTALCOREONLY == "true" ]; then .travis/getAndTestDGtalTools.sh ; fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ notifications:
 #    - one build for the documentation on macosx (clang) and only for commits on
 #      DGtal-team repo (no pull request). Encrypted var. required.
 #    - No gcc on macos
-#    - clang build of dgtaltools in linux only. In this case, no deps are considerd in DGtal
+#    - clang build of dgtaltools in linux only. In this case, some dependencies are considerd in DGtal (GMP, QGLViewer, CAIRO, HDF5)
 #    - Otherwise, 2 os x 2 configs
 #
 ########
@@ -77,7 +77,7 @@ before_install:
   - if [ $CONFIG == "Debug,Magick,GMP,ITK" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug  -DWITH_MAGICK=true -DWITH_GMP=true  -DBUILD_TESTING=ON  -DWARNING_AS_ERROR=ON";  fi
   - if [ $CONFIG == "Debug,Cairo,QGLviewer,HDF5" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DBUILD_TESTING=ON -DWARNING_AS_ERROR=OFF";   fi
   - if [ $DOC == "true" ]; then  .travis/install_doxygen.sh;  BTYPE="-DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen -DCMAKE_BUILD_TYPE=Debug -DWITH_CAIRO=true  -DWITH_GMP=true"; DOC="true"; openssl aes-256-cbc -K $encrypted_47769ec71275_key -iv $encrypted_47769ec71275_iv -in .travis/dgtal_rsa.enc -out .travis/dgtal_rsa -d; chmod 600 .travis/dgtal_rsa; DOC="true"; fi
-  - if [ $CONFIG == "DGtalTools" ]; then NEEDEXAMPLESANDTESTS="false"; BTYPE="-DCMAKE_BUILD_TYPE=Debug  -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=off";  fi
+  - if [ $CONFIG == "DGtalTools" ]; then NEEDEXAMPLESANDTESTS="false"; BTYPE="-DCMAKE_BUILD_TYPE=Debug  -DWITH_MAGICK=true -DWITH_GMP=true -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=off";  fi
 
 
 ########

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ script:
   - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  cd examples && make  -j 3 ; fi
   - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  cd ../tests &&  make -j 3 &&  cd .. ; fi
   - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  make test ARGS=--output-on-failure ; fi
-  - if [ $CONFIG == "DGtalTools" ]; then .travis/getAndTestDGtalTools.sh ; fi
+  - if [ $CONFIG == "DGtalTools" ]; then pwd ; .travis/getAndTestDGtalTools.sh ; fi
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ addons:
    packages:
     - libhdf5-serial-dev
     - libboost-dev
+    - libboost-program-options-dev
     - libcairo2-dev
     - doxygen
     - doxygen-latex

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ notifications:
 # matrix details:
 #    - one build for the documentation on macosx (clang) and only for commits on
 #      DGtal-team repo (no pull request). Encrypted var. required.
-#    - No gcc on macosx
+#    - No gcc on macos
+#    - clang build of dgtaltools in linux only. In this case, no deps are considerd in DGtal
 #    - Otherwise, 2 os x 2 configs
 #
 ########
@@ -27,15 +28,20 @@ env:
   - CONFIG="Debug,Magick,GMP,ITK"
   - CONFIG="Debug,Cairo,QGLviewer,HDF5"
   - CONFIG="Documentation,Debug,Cairo,GMP"
+  - CONFIG="DGtalTools"
 
 matrix:
-  fast_finish: true 
+  fast_finish: true
   exclude:
     - os: osx
       env: CONFIG="Documentation,Debug,Cairo,GMP"
     - compiler: gcc
       os: linux
       env: CONFIG="Documentation,Debug,Cairo,GMP"
+    - compiler: gcc
+      env: CONFIG="DGtalTools"
+    - os: osx
+      env: CONFIG="DGtalTools"
     - os: osx
       compiler: gcc
 
@@ -53,13 +59,13 @@ addons:
     - graphviz
     - libboost-system-dev
     - libgmp-dev
-    - libgdcm2-dev 
+    - libgdcm2-dev
     - libgraphicsmagick++1-dev
     - libqglviewer-qt4-dev
     - libinsighttoolkit3-dev
     - g++-4.8
     - gcc-4.8
-    
+
 
 before_install:
   - if [ $CXX == "g++" ]; then CCOMPILER="gcc-4.8"; CXXCOMPILER="g++-4.8"; fi
@@ -69,6 +75,7 @@ before_install:
   - if [ $CONFIG == "Debug,Magick,GMP,ITK" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug  -DWITH_MAGICK=true -DWITH_GMP=true  -DBUILD_TESTING=ON  -DWARNING_AS_ERROR=ON";  fi
   - if [ $CONFIG == "Debug,Cairo,QGLviewer,HDF5" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DBUILD_TESTING=ON -DWARNING_AS_ERROR=OFF";   fi
   - if [ $DOC == "true" ]; then  .travis/install_doxygen.sh;  BTYPE="-DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen -DCMAKE_BUILD_TYPE=Debug -DWITH_CAIRO=true  -DWITH_GMP=true"; DOC="true"; openssl aes-256-cbc -K $encrypted_47769ec71275_key -iv $encrypted_47769ec71275_iv -in .travis/dgtal_rsa.enc -out .travis/dgtal_rsa -d; chmod 600 .travis/dgtal_rsa; DOC="true"; fi
+  - if [ $CONFIG == "DGtalTools" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug  -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=off";  fi
 
 
 ########
@@ -90,6 +97,9 @@ script:
   - if [ $NEEDBUILD == "true" ]; then  cd examples && make  -j 3 ; fi
   - if [ $NEEDBUILD == "true" ]; then  cd ../tests &&  make -j 3 &&  cd .. ; fi
   - if [ $NEEDBUILD == "true" ]; then  make test ARGS=--output-on-failure ; fi
+  - if [ $CONFIG == "DGtalTools"]; then .travis/getAndTestDGtalTools.sh ; fi
+
+
 
 ###########
 ## Building the documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,9 @@ addons:
 before_install:
   - if [ $CXX == "g++" ]; then CCOMPILER="gcc-4.8"; CXXCOMPILER="g++-4.8"; fi
   - DOC="false"
-  - DGTALCOREONLY="false"
   - NEEDCORE="true";
   - NEEDEXAMPLESANDTESTS="true";
-  - if [ $CONFIG == "Documentation,Debug,Cairo,GMP" ]; then NEEDEXAMPLESANDTESTS="false"; NEEDBUILD="false"; if [ $OriginalRepo == "true" ];  then if [ $TRAVIS_PULL_REQUEST == "false" ]; then DOC="true"; fi; fi; fi
+  - if [ $CONFIG == "Documentation,Debug,Cairo,GMP" ]; then NEEDEXAMPLESANDTESTS="false"; NEEDCORE="false"; if [ $OriginalRepo == "true" ];  then if [ $TRAVIS_PULL_REQUEST == "false" ]; then DOC="true"; fi; fi; fi
   - if [ $CONFIG == "Debug,Magick,GMP,ITK" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug  -DWITH_MAGICK=true -DWITH_GMP=true  -DBUILD_TESTING=ON  -DWARNING_AS_ERROR=ON";  fi
   - if [ $CONFIG == "Debug,Cairo,QGLviewer,HDF5" ]; then BTYPE="-DCMAKE_BUILD_TYPE=Debug -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DBUILD_TESTING=ON -DWARNING_AS_ERROR=OFF";   fi
   - if [ $DOC == "true" ]; then  .travis/install_doxygen.sh;  BTYPE="-DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen -DCMAKE_BUILD_TYPE=Debug -DWITH_CAIRO=true  -DWITH_GMP=true"; DOC="true"; openssl aes-256-cbc -K $encrypted_47769ec71275_key -iv $encrypted_47769ec71275_iv -in .travis/dgtal_rsa.enc -out .travis/dgtal_rsa -d; chmod 600 .travis/dgtal_rsa; DOC="true"; fi
@@ -95,11 +94,11 @@ script:
   - cmake . $BTYPE -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER
   - echo $DOC
   - echo $BTYPE
-  - if [ $NEEDBUILD == "true" ]; then  make DGtal && make DGtalIO; fi
+  - if [ $NEEDCORE == "true" ]; then  make DGtal && make DGtalIO; fi
   - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  cd examples && make  -j 3 ; fi
   - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  cd ../tests &&  make -j 3 &&  cd .. ; fi
   - if [ $NEEDEXAMPLESANDTESTS == "true" ]; then  make test ARGS=--output-on-failure ; fi
-  - if [ $DGTALCOREONLY == "true" ]; then .travis/getAndTestDGtalTools.sh ; fi
+  - if [ $CONFIG == "DGtalTools" ]; then .travis/getAndTestDGtalTools.sh ; fi
 
 
 

--- a/.travis/getAndCheckDGtalTools.sh
+++ b/.travis/getAndCheckDGtalTools.sh
@@ -1,8 +1,8 @@
-## Get and test if DGtalTools compiles in default mode
+## Get and test if DGtalTools compiles
 DGTALPATH=`pwd`
 echo "DGtal path = $DGTALPATH"
 git clone --depth 1 git://github.com/DGtal-team/DGtalTools.git
 cd DGtalTools
 mkdir build ; cd build
-echo cmake .. -DDGtal_DIR=DGTALPATH
+echo cmake .. -DDGtal_DIR=$DGTALPATH
 make -j 2

--- a/.travis/getAndCheckDGtalTools.sh
+++ b/.travis/getAndCheckDGtalTools.sh
@@ -1,6 +1,6 @@
 ## Get and test if DGtalTools compiles in default mode
 
-cd .. && git clone --depth 1 git://github.com/DGtal-team/DGtalTools.git
+git clone --depth 1 git://github.com/DGtal-team/DGtalTools.git
 cd DGtalTools
 mkdir build ; cd build
 cmake .. -DDGtal_DIR=../../

--- a/.travis/getAndCheckDGtalTools.sh
+++ b/.travis/getAndCheckDGtalTools.sh
@@ -4,5 +4,5 @@ echo "DGtal path = $DGTALPATH"
 git clone --depth 1 git://github.com/DGtal-team/DGtalTools.git
 cd DGtalTools
 mkdir build ; cd build
-echo cmake .. -DDGtal_DIR=$DGTALPATH
+cmake .. -DDGtal_DIR=$DGTALPATH
 make -j 2

--- a/.travis/getAndCheckDGtalTools.sh
+++ b/.travis/getAndCheckDGtalTools.sh
@@ -1,7 +1,8 @@
 ## Get and test if DGtalTools compiles in default mode
-pwd
+DGTALPATH=`pwd`
+echo "DGtal path = $DGTALPATH"
 git clone --depth 1 git://github.com/DGtal-team/DGtalTools.git
 cd DGtalTools
 mkdir build ; cd build
-cmake .. -DDGtal_DIR=~/
+echo cmake .. -DDGtal_DIR=DGTALPATH
 make -j 2

--- a/.travis/getAndCheckDGtalTools.sh
+++ b/.travis/getAndCheckDGtalTools.sh
@@ -1,7 +1,7 @@
 ## Get and test if DGtalTools compiles in default mode
-
+pwd
 git clone --depth 1 git://github.com/DGtal-team/DGtalTools.git
 cd DGtalTools
 mkdir build ; cd build
-cmake .. -DDGtal_DIR=../../
+cmake .. -DDGtal_DIR=/home/travis/build/dcoeurjo/DGtal
 make -j 2

--- a/.travis/getAndCheckDGtalTools.sh
+++ b/.travis/getAndCheckDGtalTools.sh
@@ -1,0 +1,7 @@
+## Get and test if DGtalTools compiles in default mode
+
+cd .. && git clone git://github.com/DGtal-team/DGtalTools.git
+cd DGtalTools
+mkdir build ; cd build
+cmake .. -DDGtal_DIR=../../
+make -j 2

--- a/.travis/getAndCheckDGtalTools.sh
+++ b/.travis/getAndCheckDGtalTools.sh
@@ -1,6 +1,6 @@
 ## Get and test if DGtalTools compiles in default mode
 
-cd .. && git clone git://github.com/DGtal-team/DGtalTools.git
+cd .. && git clone --depth 1 git://github.com/DGtal-team/DGtalTools.git
 cd DGtalTools
 mkdir build ; cd build
 cmake .. -DDGtal_DIR=../../

--- a/.travis/getAndCheckDGtalTools.sh
+++ b/.travis/getAndCheckDGtalTools.sh
@@ -3,5 +3,5 @@ pwd
 git clone --depth 1 git://github.com/DGtal-team/DGtalTools.git
 cd DGtalTools
 mkdir build ; cd build
-cmake .. -DDGtal_DIR=/home/travis/build/dcoeurjo/DGtal
+cmake .. -DDGtal_DIR=~/
 make -j 2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 # DGtal 0.9.2
 
 
+## New Features / Critical Changes
+
+## Changes
+- *Configuration*
+ - Travis Continuous integration will check that DGtalTools will compile with
+ changes of new pull-requests. (David Coeurjolly, [#1123](https://github.com/DGtal-team/DGtal/pull/1123))
+
 ## Bug Fixes
 - *Geometry Package*
  - AlphaThickSegmentComputer: fix segment display errors which could appear
@@ -97,7 +104,7 @@
    the compiled library. This reduces compilation time when such types
    are used. (David Coeurjolly,
    [#1117](https://github.com/DGtal-team/DGtal/pull/1117))
-   
+
 - *DEC Package*
  - DiscreteExteriorCalculus holds both primal and dual sizes of each cell.
    Subsequent changes have been made to insertSCell.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
 ## Changes
 - *Configuration*
  - Travis Continuous integration will check that DGtalTools will compile with
- changes of new pull-requests. (David Coeurjolly, [#1123](https://github.com/DGtal-team/DGtal/pull/1123))
+ changes of new pull-requests. (David Coeurjolly, [#1133](https://github.com/DGtal-team/DGtal/pull/1133))
 
 ## Bug Fixes
 - *Geometry Package*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,13 @@ environment:
     CONFIGQGL: Release
     QGLDIR: C:\Libraries
     B_NAME: Win32
-    QTDIR: C:\Qt\5.4\msvc2013_opengl 
+    QTDIR: C:\Qt\5.4\msvc2013_opengl
   # - VS_GEN: Visual Studio 14 2015 Win64
   #   CONFIG: Release
   #   B_NAME: Win64
 
 cache:
-  - C:\Libraries\libqglviewer 
+  - C:\Libraries\libqglviewer
 
 matrix:
   fast_finish: true
@@ -37,21 +37,21 @@ init:
   - msbuild /version
   - cmake --version
   - set PATH=%QTDIR%\bin;%PATH%
-  - set CACHEOK=FALSE 
+  - set CACHEOK=FALSE
 
 # scripts that run after cloning repository
 install:
 
 before_build:
 #install QGLViewer:
-  - IF EXIST %QGLDIR%\libqglviewer SET CACHEOK=TRUE 
-  - IF %CACHEOK%==FALSE git clone https://github.com/kerautret/libQGLViewer.git %QGLDIR%\libqglviewer
+  - IF EXIST %QGLDIR%\libqglviewer SET CACHEOK=TRUE
+  - IF %CACHEOK%==FALSE git clone --depth 1 https://github.com/kerautret/libQGLViewer.git %QGLDIR%\libqglviewer
   - IF %CACHEOK%==FALSE cd %QGLDIR%\libqglviewer\QGLViewer
   - IF %CACHEOK%==FALSE qmake -t vclib QGLViewer.pro -spec win32-msvc2013 -o  qglviewer.vcxproj
-  - IF %CACHEOK%==FALSE msbuild /m /p:Configuration=%CONFIGQGL% /p:Platform=%B_NAME% qglviewer.vcxproj 
+  - IF %CACHEOK%==FALSE msbuild /m /p:Configuration=%CONFIGQGL% /p:Platform=%B_NAME% qglviewer.vcxproj
   - cd %APPVEYOR_BUILD_FOLDER%
   - cmake -Wno-dev -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG% -DWITH_QGLVIEWER:BOOL=ON -DQGLVIEWER_INCLUDE_DIR=%QGLDIR%\libQGLViewer -DQGLVIEWER_LIBRARIES=%QGLDIR%\libQGLViewer\QGLViewer\QGLViewer2.lib -DWITH_QT5:BOOL=ON -DBUILD_EXAMPLES:BOOL=ON -DBUILD_TESTING:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=FALSE  -DBOOST_ROOT=C:\Libraries\boost .
-  
+
 #  - cmake -Wno-dev -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG% -DGDCM_BUILD_TESTING:BOOL=ON -DGDCM_BUILD_APPLICATIONS:BOOL=ON -DGDCM_BUILD_SHARED_LIBS:BOOL=ON -DGDCM_ALLOW_INSOURCE_BUILD:BOOL=ON -DBUILDNAME:STRING=%COMPUTERNAME%-%B_NAME% -DGDCM_WRAP_CSHARP:BOOL=ON -DGDCM_WRAP_JAVA:BOOL=ON -DGDCM_WRAP_PYTHON:BOOL=ON -DGDCM_USE_PVRG:BOOL=ON .
 
 build_script:
@@ -61,11 +61,11 @@ build_script:
   #- msbuild gdcm.sln /m /p:Configuration=%config% /toolsversion:14.0 /p:Platform=x64 /p:PlatformToolset=v140
   # Do not run Test=Update/Configure, only Start/Build/Test/Submit (TODO: Coverage)
 
-  - msbuild /m /p:Configuration=%CONFIG% /p:Platform=%B_NAME% DGtal.sln 
+  - msbuild /m /p:Configuration=%CONFIG% /p:Platform=%B_NAME% DGtal.sln
 
 # - ctest -D ExperimentalStart -C %CONFIG%
  # - ctest -D ExperimentalBuild -j2 -C %CONFIG%
- # - ctest -D ExperimentalTest -j2 -C %CONFIG% 
+ # - ctest -D ExperimentalTest -j2 -C %CONFIG%
 
 test: off
 deploy: off


### PR DESCRIPTION
# PR Description

This PR adds a new entry in travis to compile DGtalTools against the current pull-request.

# Checklist

- [n.a.] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [n.a.] Doxygen documentation of the code completed (classes, methods, types, members...)
- [n.a.] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)