### PR TITLE
longvol generic reader fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,7 +29,7 @@
    the issue. (Bertrand Kerautret
    [#1130](https://github.com/DGtal-team/DGtal/pull/1130))
 
- - readers: include longvol reader in GenericReader for 64 bits images. Update
+ - readers: include longvol reader in GenericReader for 64 bit images. Update
    the test for 64 bit longvol. (Bertrand Kerautret
    [#1135](https://github.com/DGtal-team/DGtal/pull/1135))
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,10 @@
    the issue. (Bertrand Kerautret
    [#1130](https://github.com/DGtal-team/DGtal/pull/1130))
 
+ - readers: include longvol reader in GenericReader for 64 bits images. Update
+   the test for 64 bit longvol. (Bertrand Kerautret
+   [#1135](https://github.com/DGtal-team/DGtal/pull/1135))
+
 
 # DGtal 0.9.1
 

--- a/src/DGtal/io/readers/GenericReader.h
+++ b/src/DGtal/io/readers/GenericReader.h
@@ -287,19 +287,13 @@ namespace DGtal
   {
     BOOST_CONCEPT_ASSERT((  concepts::CImage<TContainer> )) ;
     /**
-     * Import a volume image file.  For the special format of longvol
-     * image, the default parameter x,y, z need to be updated
-     * according to the dimension if the image.
+     * Import a volume image file.  
      *
      * @param filename the image filename to be imported.
-     * @param x the size in the x direction.
-     * @param y the size in the y direction.
-     * @param z the size in the z direction.
      *
      **/
 
-    static TContainer import(const std::string &filename,  unsigned int x=0,
-                             unsigned int y=0, unsigned int z=0)  throw(DGtal::IOException);
+    static TContainer import(const std::string &filename)  throw(DGtal::IOException);
 
   };
 

--- a/src/DGtal/io/readers/GenericReader.h
+++ b/src/DGtal/io/readers/GenericReader.h
@@ -276,6 +276,34 @@ namespace DGtal
   };
 
 
+
+
+  /**
+   * GenericReader
+   * Template partial specialisation for volume images with 32 bits values
+   **/
+  template <typename TContainer>
+  struct GenericReader<TContainer, 3 , DGtal::uint64_t>
+  {
+    BOOST_CONCEPT_ASSERT((  concepts::CImage<TContainer> )) ;
+    /**
+     * Import a volume image file.  For the special format of longvol
+     * image, the default parameter x,y, z need to be updated
+     * according to the dimension if the image.
+     *
+     * @param filename the image filename to be imported.
+     * @param x the size in the x direction.
+     * @param y the size in the y direction.
+     * @param z the size in the z direction.
+     *
+     **/
+
+    static TContainer import(const std::string &filename,  unsigned int x=0,
+                             unsigned int y=0, unsigned int z=0)  throw(DGtal::IOException);
+
+  };
+
+
   /**
    * GenericReader
    * Template partial specialisation for volume images of dimension 2

--- a/src/DGtal/io/readers/GenericReader.ih
+++ b/src/DGtal/io/readers/GenericReader.ih
@@ -79,7 +79,7 @@ import( const std::string & filename,
     {
       return VolReader<TContainer>::importVol( filename );
     }
-  else if ( extension == "longvol" )
+  else if ( extension == "longvol" || extension == "lvol" )
     {
       return LongvolReader<TContainer>::importLongvol( filename );
     }
@@ -118,7 +118,7 @@ import( const std::string & filename,
   DGtal::IOException dgtalio;
   const std::string extension = filename.substr( filename.find_last_of(".") + 1 );
 
-  if ( extension == "longvol" )
+  if ( extension == "longvol" || extension == "lvol" )
     {
       return LongvolReader<TContainer>::importLongvol( filename );
     }
@@ -145,7 +145,7 @@ import( const std::string & filename) throw( DGtal::IOException )
   DGtal::IOException dgtalio;
   const std::string extension = filename.substr( filename.find_last_of(".") + 1 );
 
-  if ( extension == "longvol" )
+  if ( extension == "longvol" || extension == "lvol" )
     {
       return LongvolReader<TContainer>::importLongvol( filename );
     }

--- a/src/DGtal/io/readers/GenericReader.ih
+++ b/src/DGtal/io/readers/GenericReader.ih
@@ -140,11 +140,7 @@ template <typename TContainer>
 inline
 TContainer
 DGtal::GenericReader<TContainer, 3, DGtal::uint64_t>::
-import( const std::string & filename,
-        unsigned int x,
-        unsigned int y,
-        unsigned int z
-      ) throw( DGtal::IOException )
+import( const std::string & filename) throw( DGtal::IOException )
 {
   DGtal::IOException dgtalio;
   const std::string extension = filename.substr( filename.find_last_of(".") + 1 );

--- a/src/DGtal/io/readers/GenericReader.ih
+++ b/src/DGtal/io/readers/GenericReader.ih
@@ -136,6 +136,30 @@ import( const std::string & filename,
 
 
 
+template <typename TContainer>
+inline
+TContainer
+DGtal::GenericReader<TContainer, 3, DGtal::uint64_t>::
+import( const std::string & filename,
+        unsigned int x,
+        unsigned int y,
+        unsigned int z
+      ) throw( DGtal::IOException )
+{
+  DGtal::IOException dgtalio;
+  const std::string extension = filename.substr( filename.find_last_of(".") + 1 );
+
+  if ( extension == "longvol" )
+    {
+      return LongvolReader<TContainer>::importLongvol( filename );
+    }
+
+  trace.error() << "Extension " << extension << " with DGtal::uint64_t in 3D, not yet implemented in DGtal GenericReader." << std::endl;
+  throw dgtalio;
+}
+
+
+
 template <typename TContainer, typename TValue>
 inline
 TContainer

--- a/tests/io/readers/testGenericReader.cpp
+++ b/tests/io/readers/testGenericReader.cpp
@@ -58,7 +58,7 @@ bool testGenericReader()
   typedef DGtal::ImageContainerBySTLVector<DGtal::Z3i::Domain, unsigned char> Image3D;
   typedef DGtal::ImageContainerBySTLVector<DGtal::Z2i::Domain, unsigned char> Image2D;
 
-  typedef DGtal::ImageContainerBySTLVector<DGtal::Z3i::Domain, unsigned int> Image3D32bits;
+  typedef DGtal::ImageContainerBySTLVector<DGtal::Z3i::Domain, DGtal::uint32_t> Image3D32bits;
   typedef DGtal::ImageContainerBySTLVector<DGtal::Z3i::Domain, DGtal::uint64_t> Image3D64bits;
   typedef DGtal::ImageContainerBySTLVector<DGtal::Z2i::Domain, unsigned int> Image2D32bits;
 

--- a/tests/io/readers/testGenericReader.cpp
+++ b/tests/io/readers/testGenericReader.cpp
@@ -59,7 +59,9 @@ bool testGenericReader()
   typedef DGtal::ImageContainerBySTLVector<DGtal::Z2i::Domain, unsigned char> Image2D;
 
   typedef DGtal::ImageContainerBySTLVector<DGtal::Z3i::Domain, unsigned int> Image3D32bits;
+  typedef DGtal::ImageContainerBySTLVector<DGtal::Z3i::Domain, DGtal::uint64_t> Image3D64bits;
   typedef DGtal::ImageContainerBySTLVector<DGtal::Z2i::Domain, unsigned int> Image2D32bits;
+
 
   std::string filenameImage1 = testPath + "samples/cat10.vol";    
   Image3D anImportedImage1= DGtal::GenericReader<Image3D>::import(filenameImage1);
@@ -73,7 +75,7 @@ bool testGenericReader()
   nbok += (size0Img1==40 && size1Img1==40 && size2Img1==40) ? 1 : 0; 
   nb++;
   std::string filenameImage0 = testPath + "samples/test.longvol";    
-  Image3D anImportedImage0= DGtal::GenericReader<Image3D>::import(filenameImage0);
+  Image3D64bits anImportedImage0= DGtal::GenericReader<Image3D64bits>::import(filenameImage0);
   DGtal::Z3i::Domain domain0 = anImportedImage0.domain(); 
   unsigned int size0Img0= domain0.upperBound()[0]-domain0.lowerBound()[0]+1;
   unsigned int size1Img0= domain0.upperBound()[1]-domain0.lowerBound()[1]+1;


### PR DESCRIPTION
# PR Description
The generic reader was set to deal with longvol on 32 bits images. This PR fix it with the update of test.

*your description here*

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [n.a.] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)

