### PR TITLE
fix bug show() is called at the end of prg

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,8 +19,8 @@
 
 - *IO Package*
 
- - Viewer3D: Fix a problem when the show() method was called at the of the main
-   program (the list creation was not called).
+ - Viewer3D: Fix a problem when the show() method was called at the end of the
+   main program (the list creation was not called).
    (Bertrand Kerautret [##1138](https://github.com/DGtal-team/DGtal/pull/1138))
  - Viewer3D: add three new modes for shape rendering (default, metallic and
    plastic). The rendering can be changed by using the key M. The user can

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,10 @@
 
 
 - *IO Package*
+
+ - Viewer3D: Fix a problem when the show() method was called at the of the main
+   program (the list creation was not called).
+   (Bertrand Kerautret [##1138](https://github.com/DGtal-team/DGtal/pull/1138))
  - Viewer3D: add three new modes for shape rendering (default, metallic and
    plastic). The rendering can be changed by using the key M. The user can
    also choose its own rendering with some setter/getter on the opengl

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -639,6 +639,15 @@ namespace DGtal
 
 
     /**
+     *  @brief Overload QWidget method in order to add a call to
+     * updateList() method (to ensure that the lists are well created
+     * in the particular case where show() is called at the end of the
+     * program).
+     **/    
+    virtual void show();
+
+
+    /**
      * Add a TextureImage in the list of image to be displayed.
      * @param image a TextureImage including image data buffer and position, orientation.
      *

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -1884,7 +1884,7 @@ inline
 void 
 DGtal::Viewer3D<Space, KSpace>::show(){
   QGLWidget::show();
-  updateList();
+  updateList(false);
 }
 
 

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -1879,7 +1879,13 @@ DGtal::Viewer3D<Space, KSpace>::setGLLightSpecularCoefficients(const GLfloat lig
 }
 
 
-
+template<typename Space, typename KSpace>
+inline
+void 
+DGtal::Viewer3D<Space, KSpace>::show(){
+  QGLWidget::show();
+  updateList();
+}
 
 
 template<typename Space, typename KSpace>


### PR DESCRIPTION
# PR Description
Fix a bug which appears with this case of use:

```
viewer << Z3i::Point(0,0,0);
viewer << MyViewer::updateDisplay;
viewer.show();
return application.exec();
```

instead :
```
viewer.show();
viewer << Z3i::Point(0,0,0);
viewer << MyViewer::updateDisplay;
return application.exec();
```


# Checklist

- [n.a. ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [n.a. ] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)