### PR TITLE
Fixing embedder usage in Display3D

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@
    (B. Kerautret, [#1123](https://github.com/DGtal-team/DGtal/pull/1123))
 
 - *IO Package*
+ - Display3D: Fix embedder usage when using default constructor in Debug mode.
+   (Roland Denis [##1143](https://github.com/DGtal-team/DGtal/pull/1143))
  - Viewer3D: Fix a problem when the show() method was called at the end of the
    main program (the list creation was not called).
    (Bertrand Kerautret [##1138](https://github.com/DGtal-team/DGtal/pull/1138))

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -138,6 +138,7 @@ namespace DGtal
     struct CommonD3D {
       DGtal::Color   color; ///< Color used for displaying the graphical structure 
       DGtal::int32_t name;  ///< The "OpenGL name" associated with the graphical structure, used for selecting it (-1 is none).
+      ~CommonD3D() = delete; ///< Deleted destructor to disallow polymorphism.
     };
 
     /**

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -306,21 +306,6 @@ namespace DGtal
       mySCellEmbedder = new SCellEmbedder(KSEmb);
     };
 
-    /**
-     * constructor with the Space and the Khalimsky Space
-     * @param Semb the space for embedding
-     * @param KSEmb the khalimsky space for embedding
-     */
-    Display3D(const Space &Semb, const KSpace &KSEmb)
-    {
-      myCurrentFillColor = Color ( 220, 220, 220 );
-      myCurrentLineColor = Color ( 22, 22, 222, 50 );
-      myBoundingPtEmptyTag = true;
-      myEmbedder = new Embedder(Semb);
-      myCellEmbedder = new CellEmbedder(KSEmb);
-      mySCellEmbedder = new SCellEmbedder(KSEmb);
-    };
-
 
     // ----------------------- Interface --------------------------------------
   public:

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -258,11 +258,11 @@ namespace DGtal
     /// The Khalimsky space
     KSpace myKSpace;
     /// an embeder from a dgtal space point to a real space point
-    Embedder* myEmbedder;
+    Embedder *myEmbedder;
     /// an embeder from a unsigned khalimsky space point to a real space point
-    CellEmbedder* myCellEmbedder;
+    CellEmbedder *myCellEmbedder;
     /// an embeder from a signed khalimsky space point to a real space point
-    SCellEmbedder* mySCellEmbedder;
+    SCellEmbedder *mySCellEmbedder;
 
 
 
@@ -276,11 +276,11 @@ namespace DGtal
      * Destructor.
      */
     virtual ~Display3D()
-      {
-        delete myEmbedder;
-        delete myCellEmbedder;
-        delete mySCellEmbedder;
-      }
+    {
+      delete myEmbedder;
+      delete mySCellEmbedder;
+      delete myCellEmbedder;
+    }
 
     /**
      * Constructor with the Khalimsky Space

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -138,7 +138,9 @@ namespace DGtal
     struct CommonD3D {
       DGtal::Color   color; ///< Color used for displaying the graphical structure 
       DGtal::int32_t name;  ///< The "OpenGL name" associated with the graphical structure, used for selecting it (-1 is none).
-      ~CommonD3D() = delete; ///< Deleted destructor to disallow polymorphism.
+
+    protected:
+      ~CommonD3D() = default; ///< Protected destructor to disallow polymorphism.
     };
 
     /**
@@ -253,12 +255,14 @@ namespace DGtal
 
 
   protected:
+    /// The Khalimsky space
+    KSpace myKSpace;
     /// an embeder from a dgtal space point to a real space point
-    Embedder *myEmbedder;
+    Embedder* myEmbedder;
     /// an embeder from a unsigned khalimsky space point to a real space point
-    CellEmbedder *myCellEmbedder;
+    CellEmbedder* myCellEmbedder;
     /// an embeder from a signed khalimsky space point to a real space point
-    SCellEmbedder *mySCellEmbedder;
+    SCellEmbedder* mySCellEmbedder;
 
 
 
@@ -271,42 +275,48 @@ namespace DGtal
     /**
      * Destructor.
      */
-    ~Display3D()
-    {
-      delete myEmbedder;
-      delete mySCellEmbedder;
-      delete myCellEmbedder;
-    };
+    virtual ~Display3D()
+      {
+        delete myEmbedder;
+        delete myCellEmbedder;
+        delete mySCellEmbedder;
+      }
 
     /**
-     * default constructor
+     * Constructor with the Khalimsky Space
+     * @param KSEmb the khalimsky space for embedding
+     */
+    Display3D( const KSpace & KSEmb )
+      : myKSpace( KSEmb )
+      , myEmbedder( new Embedder() )
+      , myCellEmbedder( new CellEmbedder( myKSpace ) )
+      , mySCellEmbedder( new SCellEmbedder( myKSpace )  )
+      , myCurrentFillColor( 220, 220, 220 )
+      , myCurrentLineColor( 22, 22, 222, 50 )
+      , myBoundingPtEmptyTag( true )
+    {
+    }
+    
+    /**
+     * Default constructor
      * Display3D
      */
     Display3D()
+      : Display3D( KSpace() )
     {
-      myCurrentFillColor = Color ( 220, 220, 220 );
-      myCurrentLineColor = Color ( 22, 22, 222, 50 );
-      myBoundingPtEmptyTag = true;
-      myEmbedder= new Embedder();
-      myCellEmbedder = new CellEmbedder();
-      mySCellEmbedder = new SCellEmbedder();
-
     }
 
-    /**
-     * constructor with the Khalimsky Space
-     * @param KSEmb the khalimsky space for embedding
-     */
-    Display3D(const KSpace &KSEmb)
-    {
-      myCurrentFillColor = Color ( 220, 220, 220 );
-      myCurrentLineColor = Color ( 22, 22, 222, 50 );
-      myBoundingPtEmptyTag = true;
-      myEmbedder= new Embedder();
-      myCellEmbedder = new CellEmbedder(KSEmb);
-      mySCellEmbedder = new SCellEmbedder(KSEmb);
-    };
+    /// Copy constructor. Deleted.
+    Display3D( const Display3D & ) = delete;
 
+    /// Move constructor. Deleted.
+    Display3D( Display3D && ) = delete;
+
+    /// Assignment operator. Deleted.
+    Display3D & operator= ( const Display3D & ) = delete;
+
+    /// Move operator. Deleted.
+    Display3D & operator= ( Display3D && ) = delete;
 
     // ----------------------- Interface --------------------------------------
   public:
@@ -325,7 +335,7 @@ namespace DGtal
 
     /// @return the cellular grid space.
     const KSpace& space() const 
-    { return mySCellEmbedder->space(); }
+    { return myKSpace; }
 
     /**
      * Used to set the current fill color
@@ -361,24 +371,11 @@ namespace DGtal
 
     virtual DGtal::Color getLineColor();
 
-
     /**
-     * Used to change the default embedder for point of the Digital 3D Space
-     * @param anEmbedder the new CanonicEmbedder
+     *  Used to change the Khalimsky 3D Space.
+     * @param aKSpace the new Khalimsky space.
      **/
-    virtual void  setSpaceEmbedder(Embedder *anEmbedder);
-
-    /**
-     *  Used to change the default embedder for unsigned cell of Khalimsky 3D Space.
-     * @param anEmbedder the new CanonicCellEmbedder
-     **/
-    virtual void  setKSpaceEmbedder(CellEmbedder *anEmbedder);
-
-    /**
-     * Used to change the default embedder for signed cell of Khalimsky 3D Space.
-     * @param anEmbedder the new CanonicSCellEmbedder
-     **/
-    virtual void  setSKSpaceEmbedder(SCellEmbedder *anEmbedder);
+    virtual void  setKSpace( const KSpace & aKSpace );
 
 
     /**
@@ -875,27 +872,6 @@ namespace DGtal
     std::set<SelectCallbackFctStore> mySelectCallBackFcts;
 
     //----end of protected datas
-
-    // ------------------------- Hidden services ------------------------------
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    Display3D ( const Display3D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    Display3D & operator= ( const Display3D & other );
-
-    //----end of hidden services
 
     // ------------------------- Internals ------------------------------------
   protected:

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -291,9 +291,9 @@ namespace DGtal
       , myEmbedder( new Embedder() )
       , myCellEmbedder( new CellEmbedder( myKSpace ) )
       , mySCellEmbedder( new SCellEmbedder( myKSpace )  )
+      , myBoundingPtEmptyTag( true )
       , myCurrentFillColor( 220, 220, 220 )
       , myCurrentLineColor( 22, 22, 222, 50 )
-      , myBoundingPtEmptyTag( true )
     {
     }
     

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -82,29 +82,13 @@ DGtal::Display3D< Space ,KSpace >::setLineColor(DGtal::Color aColor)
 template < typename Space ,typename KSpace >
 inline
 void
-DGtal::Display3D< Space ,KSpace >::setSpaceEmbedder(CanonicEmbedder<Space> *anEmbedder)
+DGtal::Display3D< Space ,KSpace >::setKSpace( const KSpace & aKSpace )
 {
-  delete myEmbedder;
-  myEmbedder = anEmbedder;
+  myKSpace = aKSpace;
+  *myCellEmbedder  = CellEmbedder( myKSpace );
+  *mySCellEmbedder = SCellEmbedder( myKSpace );
 }
 
-template < typename Space ,typename KSpace >
-inline
-void
-DGtal::Display3D< Space ,KSpace >::setKSpaceEmbedder( CanonicCellEmbedder<KSpace> *anEmbedder)
-{
-  delete myCellEmbedder;
-  myCellEmbedder = anEmbedder;
-}
-
-template < typename Space ,typename KSpace >
-inline
-void
-DGtal::Display3D< Space ,KSpace >::setSKSpaceEmbedder(CanonicSCellEmbedder<KSpace> *anEmbedder)
-{
-  delete mySCellEmbedder;
-  mySCellEmbedder = anEmbedder;
-}
 
 template < typename Space ,typename KSpace >
 inline

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -1390,6 +1390,16 @@ DGtal::Display3D< Space ,KSpace >::normalize (double vec[3])
 
 template < typename Space ,typename KSpace >
 inline
+bool
+DGtal::Display3D< Space ,KSpace >::isValid() const
+{
+  return      myEmbedder.isValid()
+          &&  myCellEmbedder.isValid()
+          &&  mySCellEmbedder.isValid();
+}
+
+template < typename Space ,typename KSpace >
+inline
 void
 DGtal::Display3D< Space ,KSpace >::clear()
 {

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -1393,9 +1393,9 @@ inline
 bool
 DGtal::Display3D< Space ,KSpace >::isValid() const
 {
-  return      myEmbedder.isValid()
-          &&  myCellEmbedder.isValid()
-          &&  mySCellEmbedder.isValid();
+  return      myEmbedder->isValid()
+          &&  myCellEmbedder->isValid()
+          &&  mySCellEmbedder->isValid();
 }
 
 template < typename Space ,typename KSpace >

--- a/src/DGtal/io/boards/Board3D.h
+++ b/src/DGtal/io/boards/Board3D.h
@@ -97,17 +97,6 @@ namespace DGtal
       init();
     }
 
-    /**
-     *Constructor with a space and a khalimsky space
-     *@param SEmb a space
-     *@param KSEmb a khalimsky space
-     **/
-    Board3D(const  Space &SEmb, const KSpace &KSEmb):Display3D<Space,KSpace>(SEmb,
-                                                                             KSEmb)
-    {
-      init();
-    }
-
 
     /*!
      * Destructor.

--- a/src/DGtal/io/boards/Board3DTo2D.h
+++ b/src/DGtal/io/boards/Board3DTo2D.h
@@ -88,14 +88,11 @@ public:
     * Constructor with a khalimsky space
     * @param KSEmb the Khalimsky space
     */
-    Board3DTo2D( KSpace KSEmb):Display3D<Space,KSpace>(KSEmb) {}
-
-    /**
-        *Constructor with a space and a khalimsky space
-        *@param SEmb a space
-        *@param KSEmb a khalimsky space
-        **/
-    Board3DTo2D( Space SEmb, KSpace KSEmb):Display3D<Space,KSpace>(SEmb, KSEmb){}
+    Board3DTo2D( KSpace KSEmb )
+        : Display3D<Space,KSpace>( KSEmb )
+      {
+        init();
+      }
 
 
     ~Board3DTo2D(){}

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -162,17 +162,9 @@ namespace DGtal
      * @param KSEmb the Khalimsky space
      */
     Viewer3D(const KSpace &KSEmb):QGLViewer(), Display3D<Space,KSpace>(KSEmb)
-    {};
-
-    /**
-     *Constructor with a space and a khalimsky space
-     *@param SEmb a space
-     *@param KSEmb a khalimsky space
-     **/
-    Viewer3D(const Space &SEmb, const KSpace &KSEmb) : QGLViewer(), Display3D<Space,KSpace>(SEmb, KSEmb)
-    {};
-
-
+    {
+      resize(800,600);
+    }
 
     /**
      * Set camera position.


### PR DESCRIPTION
# PR Description

Starting from the failed execution of `examples/topology/digitalSurfaceSlice` in Debug mode, it appears that default constructor of `Display3D` initializes invalid `(S)CellEmbedders`.

It was needed to add a `KhalimskySpace` member to `Display3D` in order to correctly initialize `(S)CellEmbeders` in the default constructor. Storing the embedders by pointer is unnecessary but it has been kept to ensure compatibility with current code.

Constructor trying to pass a parameter to `CanonicEmbedder` have been deleted since `CanonicEmbedder`doesn't have such constructor.

# Checklist

- [N/A] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [N/A] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
