### PR TITLE
Fixing wrong starting point for surface tracking in frontierAndBoundary.cpp

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,7 +16,7 @@
  - Fixing warnings in DiscreteExteriorCalculus and DiscreteExteriorCalculusFactory.
    (Roland Denis, [#1139](https://github.com/DGtal-team/DGtal/pull/1139))
 
-   - *Geometry Package*
+- *Geometry Package*
  - AlphaThickSegmentComputer: fix segment display errors which could appear
    when displaying a small segment. Fix a non initialized attribute with
    some improvements on bounding box computation with orientation check.
@@ -42,6 +42,12 @@
 -  GenericReader: include longvol reader in GenericReader for 64 bit images.
    Update the test for 64 bit longvol. (Bertrand Kerautret
    [#1135](https://github.com/DGtal-team/DGtal/pull/1135))
+
+- *Topology Package*
+  - Fix wrong starting point for surface tracking in example code
+    frontierAndBoundary.cpp.
+    (Roland Denis, [#1144](https://github.com/DGtal-team/DGtal/pull/1144))
+
 
 # DGtal 0.9.1
 

--- a/examples/topology/frontierAndBoundary.cpp
+++ b/examples/topology/frontierAndBoundary.cpp
@@ -98,19 +98,19 @@ int main( int argc, char** argv )
   typedef ExplicitDigitalSurface<KSpace,BSurfelPredicate> BoundaryContainer;
   typedef DigitalSurface<BoundaryContainer> Boundary;
   // frontier between label 1 and 0 (connected part containing bel10)
-  SCell vox1  = K.sSpel( c1 + Point( radius1 - 1, 0, 0 ), K.POS );
+  SCell vox1  = K.sSpel( c1 + Point( radius1, 0, 0 ), K.POS );
   SCell bel10 = K.sIncident( vox1, 0, true );
   FSurfelPredicate surfPredicate10( K, image, 1, 0 );
   Frontier frontier10 =
     new FrontierContainer( K, surfPredicate10, surfAdj, bel10 );
   // frontier between label 2 and 0 (connected part containing bel20)
-  SCell vox2  = K.sSpel( c2 - Point( radius2 - 1, 0, 0 ), K.POS );
+  SCell vox2  = K.sSpel( c2 - Point( radius2, 0, 0 ), K.POS );
   SCell bel20 = K.sIncident( vox2, 0, false );
   FSurfelPredicate surfPredicate20( K, image, 2, 0 );
   Frontier frontier20 =
     new FrontierContainer( K, surfPredicate20, surfAdj, bel20 );
   // boundary of label 3 (connected part containing bel32)
-  SCell vox3  = K.sSpel( c1 - Point( radius1 - 1, 0, 0 ), K.POS );
+  SCell vox3  = K.sSpel( c1 - Point( radius1, 0, 0 ), K.POS );
   SCell bel32 = K.sIncident( vox3, 0, false );
   BSurfelPredicate surfPredicate3( K, image, 3 );
   Boundary boundary3 =


### PR DESCRIPTION
# PR Description

Fixing wrong starting point for surface tracking in ` examples/topology/frontierAndBoundary.cpp` that causes it to crash in Debug mode (failed assertion).

This example still crashes but it is related to #1143.

# Checklist

- [N/A] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [N/A] Doxygen documentation of the code completed (classes, methods, types, members...)
- [N/A] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)

