### PR TITLE
Fix dimension-specific code in VoronoiCovarianceMeasure

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,5 @@
 # DGtal 0.9.2
 
-
 ## New Features / Critical Changes
 
 ## Changes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,7 +16,9 @@
  - Fixing warnings in DiscreteExteriorCalculus and DiscreteExteriorCalculusFactory.
    (Roland Denis, [#1139](https://github.com/DGtal-team/DGtal/pull/1139))
 
-   - *Geometry Package*
+- *Geometry Package*
+ - VoronoiCovarianceMeasure: fix dimension-specific code.
+   (Roland Denis, [#1145](https://github.com/DGtal-team/DGtal/pull/1145))
  - AlphaThickSegmentComputer: fix segment display errors which could appear
    when displaying a small segment. Fix a non initialized attribute with
    some improvements on bounding box computation with orientation check.

--- a/src/DGtal/geometry/surfaces/estimation/VoronoiCovarianceMeasureOnDigitalSurface.ih
+++ b/src/DGtal/geometry/surfaces/estimation/VoronoiCovarianceMeasureOnDigitalSurface.ih
@@ -127,7 +127,7 @@ VoronoiCovarianceMeasureOnDigitalSurface( ConstAlias< Surface > _surface,
         {
           Point p = *itPts;
           const EigenStructure& evcm = myPt2EigenStructure[ p ];
-          VectorN n = evcm.vectors.column( 2 );
+          VectorN n = evcm.vectors.column( Space::dimension-1 );
           if ( n.dot( normals.trivialNormal ) < 0 ) normals.vcmNormal -= n;
           else                                      normals.vcmNormal += n;
         }

--- a/src/DGtal/geometry/volumes/estimation/VoronoiCovarianceMeasure.ih
+++ b/src/DGtal/geometry/volumes/estimation/VoronoiCovarianceMeasure.ih
@@ -52,7 +52,7 @@ inline
 DGtal::VoronoiCovarianceMeasure<TSpace,TSeparableMetric>::
 VoronoiCovarianceMeasure( double _R, double _r, Metric aMetric, bool verbose )
   : myBigR( _R ), myMetric( aMetric ), myVerbose( verbose ),
-    myDomain( Point(0,0,0), Point(0,0,0) ), // dummy domain
+    myDomain( Point::diagonal(0), Point::diagonal(0) ), // dummy domain
     myCharSet( 0 ), 
     myVoronoi( 0 ),
     myProximityStructure( 0 )
@@ -224,10 +224,10 @@ init( PointInputIterator itb, PointInputIterator ite )
           double d = myMetric( q, p );
           if ( d <= myBigR ) // We restrict computation to the R offset of K.
             { 
-              VectorN v( p[ 0 ] - q[ 0 ], p[ 1 ] - q[ 1 ], p[ 2 ] - q[ 2 ] );
+              VectorN v = p - q;
               // Computes tensor product V^t x V
-              for ( Dimension i = 0; i < 3; ++i ) 
-                for ( Dimension j = 0; j < 3; ++j )
+              for ( Dimension i = 0; i < Space::dimension; ++i ) 
+                for ( Dimension j = 0; j < Space::dimension; ++j )
                   m.setComponent( i, j, v[ i ] * v[ j ] ); 
               myVCM[ q ] += m;
             }


### PR DESCRIPTION
# PR Description

This bug raises from the crash of `examples/geometry/surfaces/dvcm-2d-curvature` in Debug mode.

# Checklist

- [N/A] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [N/A] Doxygen documentation of the code completed (classes, methods, types, members...)
- [N/A] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
