### PR TITLE
Add voxel interaction in Viewer3D

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,13 @@
    changes in new pull-requests. (David Coeurjolly,
    [#1133](https://github.com/DGtal-team/DGtal/pull/1133))
 
+- *IO Package*
+ - Add the possibility to interact in QGLViewer Viewer3D class with the voxel
+   primitive (was limited to surfel). As with surfel, the user may assign integer
+   identifiers (OpenGL names) to voxel and callback functions, which are called
+   when voxel are selected. (Bertrand Kerautret,
+   [#1146](https://github.com/DGtal-team/DGtal/pull/1146))
+
 ## Bug Fixes
 - *DEC Package*
  - Fixing warnings in DiscreteExteriorCalculus and DiscreteExteriorCalculusFactory.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,7 @@
  - Add the possibility to interact in QGLViewer Viewer3D class with the voxel
    primitive (was limited to surfel). As with surfel, the user may assign integer
    identifiers (OpenGL names) to voxel and callback functions, which are called
-   when voxel are selected. The selected elements are now highlighted in red.
+   when voxel are selected. The selected elements are now highlighted.
    (Bertrand Kerautret, [#1146](https://github.com/DGtal-team/DGtal/pull/1146))
 
 ## Bug Fixes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,8 +15,8 @@
  - Add the possibility to interact in QGLViewer Viewer3D class with the voxel
    primitive (was limited to surfel). As with surfel, the user may assign integer
    identifiers (OpenGL names) to voxel and callback functions, which are called
-   when voxel are selected. (Bertrand Kerautret,
-   [#1146](https://github.com/DGtal-team/DGtal/pull/1146))
+   when voxel are selected. The selected elements are now highlighted in red.
+   (Bertrand Kerautret, [#1146](https://github.com/DGtal-team/DGtal/pull/1146))
 
 ## Bug Fixes
 - *DEC Package*

--- a/examples/io/viewers/viewer3D-10-interaction.cpp
+++ b/examples/io/viewers/viewer3D-10-interaction.cpp
@@ -20,6 +20,9 @@
  * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr )
  * Laboratory of Mathematics (CNRS, UMR 5127), University of Savoie, France
  *
+ * @author Bertrand Kerautret (\c bertrand.kerautret@loria.fr )
+ * LORIA (CNRS, UMR 7503), University of Lorraine, France
+ *
  * @date 2014/10/12
  *
  * Simple example of class Viewer3D.
@@ -50,6 +53,11 @@ struct BigData
   std::map< DGtal::int32_t, Z3i::SCell > cells;
 };
 
+struct BigDataV
+{
+  std::map< DGtal::int32_t, Z3i::Point > voxel;
+};
+
 int reaction1( void* viewer, DGtal::int32_t name, void* data )
 {
   BigData* bg = (BigData*) data;
@@ -68,6 +76,15 @@ int reaction23( void* viewer, DGtal::int32_t name, void* data )
   trace.info() << ssMessage.str() << std::endl;
   return 0;
 }
+int reaction4( void* viewer, DGtal::int32_t name, void* data )
+{
+  BigDataV* bg = (BigDataV*) data;
+  stringstream ssMessage;
+  ssMessage <<  "Reaction4 with name " << name << " Voxel " << bg->voxel[name] ;
+  ((MyViewer *) viewer)->displayMessage(QString(ssMessage.str().c_str()), 100000);
+  trace.info() << ssMessage.str() << std::endl;
+  return 0;
+}
 ///////////////////////////////////////////////////////////////////////////////
 // Standard services - public :
 
@@ -75,15 +92,24 @@ int main( int argc, char** argv )
 {
   QApplication application(argc,argv);
   BigData data;
+  BigDataV dataV;
   Point p1( 0, 0, 0 );
   Point p2( 5, 5 ,5 );
   Point p3( 2, 3, 4 );
   KSpace & K = data.K;
   K.init( p1, p2, true );
-
+  Point v1 = Z3i::Point(10, 10,10);
+  Point v2 = Z3i::Point(9, 9, 9);
+  Point v3 = Z3i::Point(11, 11,11);
+  
+  dataV.voxel[4001] = v1;
+  dataV.voxel[4002] = v2;
+  dataV.voxel[4003] = v3;
+  
+  
   MyViewer viewer( K );
   viewer.show();
-  viewer.displayMessage(QString("You can use [shift + click right] on surfels to interact ..."), 100000);
+  viewer.displayMessage(QString("You can use [shift + click right] on surfels or voxel to interact ..."), 100000);
   Z3i::SCell surfel1 = K.sCell( Point( 1, 1, 2 ), KSpace::POS );
   Z3i::SCell surfel2 = K.sCell( Point( 3, 3, 4 ), KSpace::NEG );
   Z3i::SCell surfel3 = K.sCell( Point( 5, 6, 5 ), KSpace::POS );
@@ -96,6 +122,12 @@ int main( int argc, char** argv )
   viewer << SetName3D( 10003 ) << CustomColors3D( Color::Blue, Color::Blue ) << surfel3;
   viewer << SetSelectCallback3D( reaction1,  &data, 10001, 10001 );
   viewer << SetSelectCallback3D( reaction23, &data, 10002, 10003 );
+ 
+  // example by using voxel interaction:
+  viewer << SetName3D( 4001 ) << v1;
+  viewer << SetName3D( 4002 ) << v2;
+  viewer << SetName3D( 4003 ) << v3;
+  viewer << SetSelectCallback3D( reaction4, &dataV, 4001,4003 );
   viewer<< MyViewer::updateDisplay;
   return application.exec();
 }

--- a/examples/io/viewers/viewer3D-10-interaction.cpp
+++ b/examples/io/viewers/viewer3D-10-interaction.cpp
@@ -47,20 +47,20 @@ typedef Viewer3D<Space,KSpace> MyViewer;
 typedef MyViewer::SelectCallbackFct SelectCallbackFct;
 typedef KSpace::SCell SCell;
 
-struct BigData
+struct BigDataCells
 {
   KSpace K;
   std::map< DGtal::int32_t, Z3i::SCell > cells;
 };
 
-struct BigDataV
+struct BigDataVoxels
 {
-  std::map< DGtal::int32_t, Z3i::Point > voxel;
+  std::map< DGtal::int32_t, Z3i::Point > voxels;
 };
 
 int reaction1( void* viewer, DGtal::int32_t name, void* data )
 {
-  BigData* bg = (BigData*) data;
+  BigDataCells* bg = (BigDataCells*) data;
   stringstream ssMessage;
   ssMessage << "Reaction1 with name " << name << " cell " << bg->K.sKCoords( bg->cells[ name ] )  ;
   ((MyViewer *) viewer)->displayMessage(QString(ssMessage.str().c_str()), 100000);
@@ -69,7 +69,7 @@ int reaction1( void* viewer, DGtal::int32_t name, void* data )
 }
 int reaction23( void* viewer, DGtal::int32_t name, void* data )
 {
-  BigData* bg = (BigData*) data;
+  BigDataCells* bg = (BigDataCells*) data;
   stringstream ssMessage;
   ssMessage <<  "Reaction23 with name " << name << " cell " << bg->K.sKCoords( bg->cells[ name ] );
   ((MyViewer *) viewer)->displayMessage(QString(ssMessage.str().c_str()), 100000);
@@ -78,9 +78,9 @@ int reaction23( void* viewer, DGtal::int32_t name, void* data )
 }
 int reaction4( void* viewer, DGtal::int32_t name, void* data )
 {
-  BigDataV* bg = (BigDataV*) data;
+  BigDataVoxels* bg = (BigDataVoxels*) data;
   stringstream ssMessage;
-  ssMessage <<  "Reaction4 with name " << name << " Voxel " << bg->voxel[name] ;
+  ssMessage <<  "Reaction4 with name " << name << " Voxel " << bg->voxels[name] ;
   ((MyViewer *) viewer)->displayMessage(QString(ssMessage.str().c_str()), 100000);
   trace.info() << ssMessage.str() << std::endl;
   return 0;
@@ -91,8 +91,8 @@ int reaction4( void* viewer, DGtal::int32_t name, void* data )
 int main( int argc, char** argv )
 {
   QApplication application(argc,argv);
-  BigData data;
-  BigDataV dataV;
+  BigDataCells data;
+  BigDataVoxels dataV;
   Point p1( 0, 0, 0 );
   Point p2( 5, 5 ,5 );
   Point p3( 2, 3, 4 );
@@ -102,9 +102,9 @@ int main( int argc, char** argv )
   Point v2 = Z3i::Point(9, 9, 9);
   Point v3 = Z3i::Point(11, 11,11);
   
-  dataV.voxel[4001] = v1;
-  dataV.voxel[4002] = v2;
-  dataV.voxel[4003] = v3;
+  dataV.voxels[4001] = v1;
+  dataV.voxels[4002] = v2;
+  dataV.voxels[4003] = v3;
   
   
   MyViewer viewer( K );

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -484,6 +484,14 @@ namespace DGtal
 
     DGtal::int32_t createNewCubeList();
 
+    
+    /**
+     * Delete the cube list identified by a its name.
+     * @param[in] name the name of the cube list.
+     * @return true if the list was found and removed.
+     *
+     **/
+    bool deleteCubeList(const DGtal::int32_t name);
 
      /**
       * Used to create a new list containing new 3D objects
@@ -491,6 +499,15 @@ namespace DGtal
       * @return the new key of the map associated to the new list.
       **/
     DGtal::int32_t createNewQuadList();
+
+
+    /**
+     * Delete the quad list identified by a its name.
+     * @param[in] name the name of the quad list.
+     * @return true if the list was found and removed.
+     *
+     **/
+    bool deleteQuadList(const DGtal::int32_t name);
 
     /**
      * Used to create a new list containing new 3D objects

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -249,6 +249,9 @@ namespace DGtal
   public:
     // The type that maps identifier name -> vector of QuadD3D.
     typedef std::map<DGtal::int32_t, std::vector< QuadD3D > > QuadsMap;
+    
+    // The type that maps identifier name -> vector of CubeD3D.
+    typedef std::map<DGtal::int32_t, std::vector< CubeD3D > > CubesMap;
 
 
   protected:
@@ -476,9 +479,11 @@ namespace DGtal
     /**
      * Used to create a new list containing new 3D objects
      * (useful to use transparency between different objects).
-     * @param s name of the new list
+     * @return the new key of the map associated to the new list.
      **/
-    void createNewCubeList(std::string s= "");
+
+    DGtal::int32_t createNewCubeList()
+
 
      /**
       * Used to create a new list containing new 3D objects
@@ -817,10 +822,6 @@ namespace DGtal
     ///
     double myCurrentfShiftVisuPrisms;
 
-    /// Used to represent all the list used in the display.
-    ///
-    std::vector< std::vector<CubeD3D> > myCubeSetList;
-
     /// Used to represent all the list of line primitive
     ///
     std::vector< std::vector<LineD3D> > myLineSetList;
@@ -848,6 +849,13 @@ namespace DGtal
 
     /// Represents all the polygon drawn in the Display3D
     std::vector<std::vector<PolygonD3D> > myPolygonSetList;
+
+
+    /// Represents all the cubes drawn in the Display3D.  The map int
+    /// --> vector<CubeD3D> associates to a vector of cubes to an
+    /// integer identifier (OpenGL name)
+    CubesMap myCubesMap;
+
 
     /// names of the lists in myCubeSetList
     ///

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -247,10 +247,10 @@ namespace DGtal
 
 
   public:
-    // The type that maps identifier name -> vector of QuadD3D.
+    /// The type that maps identifier name -> vector of QuadD3D.
     typedef std::map<DGtal::int32_t, std::vector< QuadD3D > > QuadsMap;
     
-    // The type that maps identifier name -> vector of CubeD3D.
+    /// The type that maps identifier name -> vector of CubeD3D.
     typedef std::map<DGtal::int32_t, std::vector< CubeD3D > > CubesMap;
 
 
@@ -840,7 +840,7 @@ namespace DGtal
 
     /// Represents all the planes drawn in the Display3D or to display
     /// Khalimsky Space Cell.  The map int --> vector< QuadD3D>
-    /// associates to a vector of quads to an integer identifier
+    /// associates a vector of quads to an integer identifier
     /// (OpenGL name)
     QuadsMap myQuadsMap;
 
@@ -852,7 +852,7 @@ namespace DGtal
 
 
     /// Represents all the cubes drawn in the Display3D.  The map int
-    /// --> vector<CubeD3D> associates to a vector of cubes to an
+    /// --> vector<CubeD3D> associates  a vector of cubes to an
     /// integer identifier (OpenGL name)
     CubesMap myCubesMap;
 

--- a/src/DGtal/io/Display3D.h
+++ b/src/DGtal/io/Display3D.h
@@ -482,7 +482,7 @@ namespace DGtal
      * @return the new key of the map associated to the new list.
      **/
 
-    DGtal::int32_t createNewCubeList()
+    DGtal::int32_t createNewCubeList();
 
 
      /**

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -1293,9 +1293,9 @@ DGtal::Display3D< Space ,KSpace >::exportToMesh(DGtal::Mesh<RealPoint> &aMesh) c
 
   // Export of cubeSet (generated from addCube)
   // Export CubesList
-  for (typename QuadsMap::const_iterator it = myCubesMap.begin(); it != myCubesMap.end(); it++)
+  for (typename CubesMap::const_iterator it = myCubesMap.begin(); it != myCubesMap.end(); it++)
     {
-      for (typename std::vector<CubeD3D>::const_iterator aCube = it->second.begin(); aQuad!=it->second.end();aQuad ++)
+      for (typename std::vector<CubeD3D>::const_iterator aCube = it->second.begin(); aCube!=it->second.end();aCube ++)
 	{
 
 	  CubeD3D cube = *aCube;

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -211,6 +211,14 @@ DGtal::Display3D< Space ,KSpace >::createNewCubeList()
    return -1;
 }
 
+template < typename Space ,typename KSpace >
+inline
+bool
+DGtal::Display3D< Space ,KSpace >::deleteCubeList(const DGtal::int32_t idList)
+{
+  return myCubesMap.erase(idList);
+}
+
 
 template < typename Space ,typename KSpace >
 inline
@@ -252,6 +260,18 @@ DGtal::Display3D< Space ,KSpace >::createNewLineList(std::string str)
 
    return -1;
  }
+
+
+
+template < typename Space ,typename KSpace >
+inline
+bool
+DGtal::Display3D< Space ,KSpace >::deleteQuadList(const DGtal::int32_t idList)
+{
+  return myQuadsMap.erase(idList);
+}
+
+
 
 template < typename Space ,typename KSpace >
 inline

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -1295,10 +1295,10 @@ DGtal::Display3D< Space ,KSpace >::exportToMesh(DGtal::Mesh<RealPoint> &aMesh) c
   // Export CubesList
   for (typename CubesMap::const_iterator it = myCubesMap.begin(); it != myCubesMap.end(); it++)
     {
-      for (typename std::vector<CubeD3D>::const_iterator aCube = it->second.begin(); aCube!=it->second.end();aCube ++)
+      for (typename std::vector<CubeD3D>::const_iterator itCube = it->second.begin(); itCube!=it->second.end(); itCube++)
 	{
 
-	  CubeD3D cube = *aCube;
+	  CubeD3D cube = *itCube;
 	  RealPoint p1, p2, p3, p4, p5, p6, p7, p8;
 	  double width= cube.width;
 

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -193,12 +193,21 @@ DGtal::Display3D< Space ,KSpace >::getMode( const std::string & objectName ) con
 
 template < typename Space ,typename KSpace >
 inline
-void
-DGtal::Display3D< Space ,KSpace >::createNewCubeList( std::string str)
+DGtal::int32_t
+DGtal::Display3D< Space ,KSpace >::createNewCubeList()
 {
-  std::vector< CubeD3D > v;
-  myCubeSetList.push_back(v);
-  myCubeSetNameList.push_back(str);
+  // looking for an empty key
+  DGtal::int32_t aKey=0;
+  bool found =  myCubesMap.count(aKey) == 0;
+   do{
+     aKey++;
+     found = myCubesMap.count(aKey) == 0; 
+   }while (!found && aKey < std::numeric_limits<DGtal::int32_t>::max());
+   if (found){
+     myName3d = aKey;
+     return aKey;
+   }
+   return -1;
 }
 
 
@@ -276,9 +285,8 @@ DGtal::Display3D< Space ,KSpace >::addCube(const RealPoint &center, double width
   v.color  = getFillColor();
   v.width  = width;
   v.name   = name3d(); 
-  if (myCubeSetList.size() ==0)
-    createNewCubeList("Cube Root");
-  (myCubeSetList.at(myCubeSetList.size()-1)).push_back(v);
+  myCubesMap[ v.name ].push_back( v );
+
 }
 
 
@@ -1284,11 +1292,13 @@ DGtal::Display3D< Space ,KSpace >::exportToMesh(DGtal::Mesh<RealPoint> &aMesh) c
     }
 
   // Export of cubeSet (generated from addCube)
-  for(unsigned int j=0; j<myCubeSetList.size(); j++)
+  // Export CubesList
+  for (typename QuadsMap::const_iterator it = myCubesMap.begin(); it != myCubesMap.end(); it++)
     {
-      for (unsigned int i=0; i< myCubeSetList.at(j).size(); i++)
+      for (typename std::vector<CubeD3D>::const_iterator aCube = it->second.begin(); aQuad!=it->second.end();aQuad ++)
 	{
-	  CubeD3D cube = myCubeSetList.at(j).at(i);
+
+	  CubeD3D cube = *aCube;
 	  RealPoint p1, p2, p3, p4, p5, p6, p7, p8;
 	  double width= cube.width;
 
@@ -1409,7 +1419,7 @@ inline
 void
 DGtal::Display3D< Space ,KSpace >::clear()
 {
-  myCubeSetList.clear();
+  myCubesMap.clear();
   myLineSetList.clear();
   myBallSetList.clear();
   myClippingPlaneList.clear();

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -201,7 +201,8 @@ DGtal::Display3D< Space ,KSpace >::createNewCubeList()
   bool found =  myCubesMap.count(aKey) == 0;
    do{
      aKey++;
-     found = myCubesMap.count(aKey) == 0; 
+     found = (myCubesMap.count(aKey) == 0) &&
+             (myQuadsMap.count(aKey) == 0); 
    }while (!found && aKey < std::numeric_limits<DGtal::int32_t>::max());
    if (found){
      myName3d = aKey;
@@ -241,7 +242,8 @@ DGtal::Display3D< Space ,KSpace >::createNewLineList(std::string str)
    bool found =  myQuadsMap.count(aKey) == 0;
    do{
      aKey++;
-     found = myQuadsMap.count(aKey) == 0; 
+     found = (myCubesMap.count(aKey) == 0) &&
+             (myQuadsMap.count(aKey) == 0); 
    }while (!found && aKey < std::numeric_limits<DGtal::int32_t>::max());
    if (found){
      myName3d = aKey;

--- a/src/DGtal/io/Display3DFactory.ih
+++ b/src/DGtal/io/Display3DFactory.ih
@@ -646,7 +646,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsPavingTransparent( Display & d
  
   ASSERT(Domain::Space::dimension == 3);
 
-  display.createNewCubeList( s.className());
+  display.createNewCubeList();
   for ( ConstIterator it = s.begin();
         it != s.end();
         ++it )
@@ -666,7 +666,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsPaving( Display & display,
 
   ASSERT(Domain::Space::dimension == 3);
 
-  display.createNewCubeList( s.className());
+  display.createNewCubeList( );
   for ( ConstIterator it = s.begin();
         it != s.end();
         ++it )
@@ -732,7 +732,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsPavingTransparent( Display & d
 
   ASSERT(Domain::Space::dimension == 3);
 
-  display.createNewCubeList( s.className());
+  display.createNewCubeList( );
   for ( ConstIterator it = s.begin();
         it != s.end();
         ++it )
@@ -752,7 +752,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsPaving( Display & display,
 
   ASSERT(Domain::Space::dimension == 3);
 
-  display.createNewCubeList( s.className());
+  display.createNewCubeList( );
   for ( ConstIterator it = s.begin();
         it != s.end();
         ++it )
@@ -820,7 +820,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsPavingTransparent( Display & d
 
   ASSERT(Domain::Space::dimension == 3);
 
-  display.createNewCubeList( v.className());
+  display.createNewCubeList( );
   for ( ConstIterator it = v.begin();
         it != v.end();
         ++it )
@@ -841,7 +841,7 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsPaving( Display & display,
 
   ASSERT(Domain::Space::dimension == 3);
 
-  display.createNewCubeList( v.className());
+  display.createNewCubeList( );
   for ( ConstIterator it = v.begin();
         it != v.end();
         ++it )
@@ -1208,7 +1208,7 @@ DGtal::Display3DFactory<Space,KSpace>::draw( Display & display, const DGtal::Hyp
       drawAsGrid( display, aDomain );
     } else if ( mode == "Paving" )
     {
-      display.createNewCubeList(aDomain.className());
+      display.createNewCubeList();
       drawAsPaving( display, aDomain );
     } else if ( mode == "PavingPoints" )
     {
@@ -1217,7 +1217,7 @@ DGtal::Display3DFactory<Space,KSpace>::draw( Display & display, const DGtal::Hyp
     }else if ( mode == "PavingGrids" )
     {
       display.createNewLineList(aDomain.className());
-      display.createNewCubeList( aDomain.className());
+      display.createNewCubeList( );
       drawAsGrid( display, aDomain );
       drawAsPaving( display, aDomain );
     }
@@ -1294,10 +1294,10 @@ void DGtal::Display3DFactory<Space,KSpace>::draw( Display & display,
       }
     if(mode=="Illustration"|| mode=="IllustrationCustomColor")
       {
-        display.createNewCubeList("khalimsky cell");
+        display.createNewCubeList();
         display.addCube(rp,0.80);
       }else{
-      display.createNewCubeList("khalimsky cell");
+      display.createNewCubeList();
       display.addCube(rp,0.90);
     }
     break;
@@ -1442,11 +1442,11 @@ void DGtal::Display3DFactory<Space,KSpace>::draw( Display & display,
       if(mode=="Illustration"|| mode=="IllustrationCustomColor")
         {
           //KSCube
-          display.createNewCubeList("signed khalimsky cell");
+          display.createNewCubeList();
           display.addCube(rps, 0.80);
         }else
         {
-          display.createNewCubeList("signed khalimsky cell");
+          display.createNewCubeList();
           display.addCube(rps, 0.90 );
         }
       break;

--- a/src/DGtal/io/boards/Board3D.ih
+++ b/src/DGtal/io/boards/Board3D.ih
@@ -376,11 +376,12 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
     
     
     //Foreach list
-    for(typename std::vector<std::vector< typename Board3D<Space, KSpace>::CubeD3D> >::const_iterator it =Board3D<Space, KSpace>::myCubesMap.begin();
+
+    for(typename Board3D<Space, KSpace>::CubesMap::const_iterator it =Board3D<Space, KSpace>::myCubesMap.begin();
         it != Board3D<Space, KSpace>::myCubesMap.end();   it++)
     {
-      //If we have at least a cube to export
-      if ( it->begin() != it->end() )
+      for (typename std::vector<typename Board3D<Space, KSpace>::CubeD3D>::const_iterator aCube = it->second.begin();
+           aCube!=it->second.end();aCube ++)
       {
         std::stringstream name;
         std::ostringstream tmpStream;
@@ -389,7 +390,7 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
         else
           name << Board3D<Space, KSpace>::myCubeSetNameList.at(k)<< "_"<<k;
         outOBJ << "o  " << name.str() << std::endl;
-      }
+      
       
       //For each list, we force the cube color to be set in the OBJ file
       unsigned int prevMaterialIndex = std::numeric_limits<unsigned int>::max();  //index to the last voxel material
@@ -482,8 +483,11 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
           j ++;
         }
       }
+      
       k++;
+      }
     }
+
   }
   
   //OPT quad

--- a/src/DGtal/io/boards/Board3D.ih
+++ b/src/DGtal/io/boards/Board3D.ih
@@ -372,23 +372,17 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
   // myCubeSetList++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
   {
     j  = 0 ; //id of each Cube sub list for the .OBJ identification
-    k = 0; // id of each list
     
     
     //Foreach list
-
     for(typename Board3D<Space, KSpace>::CubesMap::const_iterator it =Board3D<Space, KSpace>::myCubesMap.begin();
         it != Board3D<Space, KSpace>::myCubesMap.end();   it++)
     {
-      for (typename std::vector<typename Board3D<Space, KSpace>::CubeD3D>::const_iterator aCube = it->second.begin();
-           aCube!=it->second.end();aCube ++)
-      {
+    
         std::stringstream name;
         std::ostringstream tmpStream;
-        if ( Board3D<Space, KSpace>::myCubeSetNameList.at(k) == "" )
-          name << "myCubeSetList_" << k ;
-        else
-          name << Board3D<Space, KSpace>::myCubeSetNameList.at(k)<< "_"<<k;
+
+        name << "myCubeSetList_" << it->first ;
         outOBJ << "o  " << name.str() << std::endl;
       
       
@@ -480,12 +474,14 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
           outOBJ << "f " << "-4" << " " << "-1" << " " <<"-2" << " " <<"-3" << std::endl;//top
 
           
-          j ++;
+       
         }
-      }
+        
       
-      k++;
+      j++;
+      
       }
+      k++;
     }
 
   }

--- a/src/DGtal/io/boards/Board3D.ih
+++ b/src/DGtal/io/boards/Board3D.ih
@@ -376,8 +376,8 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
     
     
     //Foreach list
-    for(typename std::vector<std::vector< typename Board3D<Space, KSpace>::CubeD3D> >::const_iterator it =Board3D<Space, KSpace>::myCubeSetList.begin();
-        it != Board3D<Space, KSpace>::myCubeSetList.end();   it++)
+    for(typename std::vector<std::vector< typename Board3D<Space, KSpace>::CubeD3D> >::const_iterator it =Board3D<Space, KSpace>::myCubesMap.begin();
+        it != Board3D<Space, KSpace>::myCubesMap.end();   it++)
     {
       //If we have at least a cube to export
       if ( it->begin() != it->end() )
@@ -395,8 +395,8 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
       unsigned int prevMaterialIndex = std::numeric_limits<unsigned int>::max();  //index to the last voxel material
       
       //Foreach cube in the list
-      for (typename std::vector< typename Board3D<Space, KSpace>::CubeD3D>::const_iterator s_it = it->begin();
-           s_it != it->end(); ++s_it)
+      for (typename std::vector< typename Board3D<Space, KSpace>::CubeD3D>::const_iterator s_it = it->second.begin();
+           s_it != it->second.end(); ++s_it)
       {
         //Color
         unsigned int matid = getMaterialIndex(s_it->color);

--- a/src/DGtal/io/boards/Board3DTo2D.ih
+++ b/src/DGtal/io/boards/Board3DTo2D.ih
@@ -430,25 +430,25 @@ DGtal::Board3DTo2D<Space, KSpace>::saveCairo(const char *filename, CairoType typ
     }
 
     // myCubeSetList
-    for(unsigned int i=0; i<Board3DTo2D<Space, KSpace>::myCubeSetList.size(); i++)
+    for(typename std::vector<std::vector< typename Board3DTo2D<Space, KSpace>::const_iterator it = Board3DTo2D<Space, KSpace>::myCubesMap.begin();
+        it != Board3DTo2D<Space, KSpace>::myCubesMap.end();   it++)
     {
-        for (typename std::vector< typename Board3DTo2D<Space, KSpace>::CubeD3D>::iterator s_it = Board3DTo2D<Space, KSpace>::myCubeSetList.at(i).begin();
-             s_it != Board3DTo2D<Space, KSpace>::myCubeSetList.at(i).end();
-             ++s_it)
-        {
-            {
-                cairo_save (cr);
-
-                if (Board3DTo2D<Space, KSpace>::myModes["Board3DTo2D"]=="SolidMode")
-		  cairo_set_source_rgba (cr, (*s_it).color.red()/255.0, (*s_it).color.green()/255.0,
-					 (*s_it).color.blue()/255.0, (*s_it).color.alpha()/(255.0*1.75)); // *1.75 arbitraire
-                else
-		  cairo_set_source_rgba (cr, (*s_it).color.red()/255.0, (*s_it).color.green()/255.0,
-					 (*s_it).color.blue()/255.0, (*s_it).color.alpha()/(255.0*0.75)); // *0.75 arbitraire
-
-                cairo_set_line_width (cr, 1.); // arbitraire car non set
-
-                double x1, y1, x2, y2, x3, y3, x4, y4;
+       for (typename std::vector< typename Board3DTo2D<Space, KSpace>::CubeD3D>::const_iterator s_it = it->second.begin();
+           s_it != it->second.end(); ++s_it)
+         {
+           {
+             cairo_save (cr);
+             
+             if (Board3DTo2D<Space, KSpace>::myModes["Board3DTo2D"]=="SolidMode")
+               cairo_set_source_rgba (cr, (*s_it).color.red()/255.0, (*s_it).color.green()/255.0,
+                                      (*s_it).color.blue()/255.0, (*s_it).color.alpha()/(255.0*1.75)); // *1.75 arbitraire
+             else
+               cairo_set_source_rgba (cr, (*s_it).color.red()/255.0, (*s_it).color.green()/255.0,
+                                      (*s_it).color.blue()/255.0, (*s_it).color.alpha()/(255.0*0.75)); // *0.75 arbitraire
+             
+             cairo_set_line_width (cr, 1.); // arbitraire car non set
+             
+             double x1, y1, x2, y2, x3, y3, x4, y4;
                 double width=(*s_it).width;
 
                 //z+

--- a/src/DGtal/io/boards/Board3DTo2D.ih
+++ b/src/DGtal/io/boards/Board3DTo2D.ih
@@ -430,7 +430,7 @@ DGtal::Board3DTo2D<Space, KSpace>::saveCairo(const char *filename, CairoType typ
     }
 
     // myCubeSetList
-    for(typename std::vector<std::vector< typename Board3DTo2D<Space, KSpace>::const_iterator it = Board3DTo2D<Space, KSpace>::myCubesMap.begin();
+    for(typename  Board3DTo2D<Space, KSpace>::CubesMap::const_iterator it = Board3DTo2D<Space, KSpace>::myCubesMap.begin();
         it != Board3DTo2D<Space, KSpace>::myCubesMap.end();   it++)
     {
        for (typename std::vector< typename Board3DTo2D<Space, KSpace>::CubeD3D>::const_iterator s_it = it->second.begin();

--- a/src/DGtal/io/doc/moduleQGLInteraction.dox
+++ b/src/DGtal/io/doc/moduleQGLInteraction.dox
@@ -7,7 +7,7 @@ namespace DGtal {
 
 /**
  * @page moduleQGLInteraction Limited interaction when using selection with QGLViewer Viewer3D stream mechanism
- *
+ *  
  * This part of the manual describes how to select objects in 3D
  * scenes when using a Viewer3D object. The principle is to handle one
  * or several reactions or callback functions to the viewer. They are
@@ -16,17 +16,19 @@ namespace DGtal {
  * shift + left click on the object of interest. The "name" of the
  * clicked object is then given as parameter to the reaction/callback
  * function, so that further processing taking into account the
- * selected object is made possible.
- *
+ * selected object is made possible. By default the selected elements
+ * are highlighted in red color.
+ *  
  * @author Jacques-Olivier Lachaud
+ * @author Bertrand Kerautret
  *
  * Related examples: viewer3D-10-interaction.cpp
  *
  * [TOC]
  *
  * @note This functionality is not really useful for developing a full
- * interactive 3D application. It is for now limited to surfel
- * selection, without visual feedback. However, this functionality is
+ * interactive 3D application. It is for now limited to surfel and voxel
+ * selection, with simple visual feedback. However, this functionality is
  * rather easy to use, hence may be found useful when prototyping.
  * 
  * \section QGLInteraction_sec1 Giving names to graphical objects

--- a/src/DGtal/io/doc/moduleQGLInteraction.dox
+++ b/src/DGtal/io/doc/moduleQGLInteraction.dox
@@ -8,6 +8,7 @@ namespace DGtal {
 /**
  * @page moduleQGLInteraction Limited interaction when using selection with QGLViewer Viewer3D stream mechanism
  *  
+ *
  * This part of the manual describes how to select objects in 3D
  * scenes when using a Viewer3D object. The principle is to handle one
  * or several reactions or callback functions to the viewer. They are
@@ -17,7 +18,20 @@ namespace DGtal {
  * clicked object is then given as parameter to the reaction/callback
  * function, so that further processing taking into account the
  * selected object is made possible. By default the selected elements
- * are highlighted in red color.
+ * are highlighted (in dark or light color depending of the original
+ * color element).
+ *  
+ * Actually the elements which can be selected interactively are the following:
+ * 
+ * |   Element type         | list type   | can be selected |
+ * |:----------------------:|:----------: |:---------------:|
+ * | Surfel (Quad3D)        | std::map    |       YES       |
+ * | Voxel (Cube3D)         | std::map    |       YES       |
+ * | Line (LineD3D)         | std::vector |       NO        |
+ * | Point (BallD3D)        | std::vector |       NO        |
+ * | Triangles (TriangleD3D)| std::vector |       NO        |
+ * | Polygon (PolygonD3D)   | std::vector |       NO        |
+ *  
  *  
  * @author Jacques-Olivier Lachaud
  * @author Bertrand Kerautret

--- a/src/DGtal/io/doc/packageIO.dox
+++ b/src/DGtal/io/doc/packageIO.dox
@@ -48,7 +48,7 @@ In this package, we present DGtal tools and utilities to import/export images an
 
 - \ref moduleBoard2D (Jacques-Olivier Lachaud, Nicolas Normand, David Coeurjolly, Martial Tola)
 - \ref moduleDisplay3D (Bertrand Kerautret, Martial Tola, Aline Martin, David Coeurjolly)
-  - \ref moduleQGLInteraction (Jacques-Olivier Lachaud)
+  - \ref moduleQGLInteraction (Jacques-Olivier Lachaud, Bertrand Kerautret)
 - \ref moduleIO (David Coeurjolly, Bertrand Kerautret, Martial Tola, Pierre Gueth)
 
 @b Package @b Concepts @b Overview

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -1187,12 +1187,16 @@ namespace DGtal
 
 
     /**
-     * Creates an OpenGL list of type GL_QUADS from a vector of CubeD3D.
-     * @param[in] aVectCubes a vector of cubes (Cube3D) containing the cubes to be displayed.
+     * Creates an OpenGL list of type GL_QUADS from a CubeD3D.  Only
+     * one OpenGL list is created but each map compoment (CubeD3D
+     * vector) are marked by its identifier through the OpenGl
+     * glPushName() function.
+     * See @ref moduleQGLInteraction for more details.
+     * @param[in] aCubeMap  a map of cube (CubesMap) associating a name to a vector of CubeD3D.
      * @param[in] idList the Id of the list (should be given by glGenLists).
      **/
-    void glCreateListCubes( const VectorCubes & aVectCubes,
-                              unsigned int idList);
+    void glCreateListCubesMaps(const typename Display3D<Space, KSpace>::CubesMap &aCubeMap, unsigned int idList);
+
 
 
     /**
@@ -1354,9 +1358,6 @@ namespace DGtal
     /// lists of the list to draw
     //GLuint myListToAff;
 
-    GLuint myCubeSetListId;
-    GLuint myCubeSetListWiredId;
-
     GLuint myTriangleSetListId;
     GLuint myTriangleSetListWiredId;
 
@@ -1370,10 +1371,12 @@ namespace DGtal
     GLuint myQuadsMapId;
     GLuint myQuadsMapWiredId;
 
+    GLuint myCubeMapId;
+    GLuint myCubeSetListWiredId;
+
     /// number of lists in myListToAff
 
     unsigned int myNbListe;
-    unsigned int myNbCubeSetList;
     unsigned int myNbLineSetList;
     unsigned int myNbBallSetList;
     unsigned int myNbPrismSetList;

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -1381,7 +1381,10 @@ namespace DGtal
     unsigned int myNbBallSetList;
     unsigned int myNbPrismSetList;
 
-
+    /// used to displayed selected elements
+    int mySelectedElementId = -1;
+    Color mySelectionColor = Color::Red;
+    
     /// information linked to the navigation in the viewer
     qglviewer::Vec myOrig, myDir, myDirSelector, mySelectedPoint;
     /// a point selected with postSelection @see postSelection

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -1383,7 +1383,7 @@ namespace DGtal
 
     /// used to displayed selected elements
     int mySelectedElementId = -1;
-    Color mySelectionColor = Color::Red;
+    unsigned char mySelectionColorShift = 100;
     
     /// information linked to the navigation in the viewer
     qglviewer::Vec myOrig, myDir, myDirSelector, mySelectedPoint;

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -1371,7 +1371,7 @@ namespace DGtal
     GLuint myQuadsMapId;
     GLuint myQuadsMapWiredId;
 
-    GLuint myCubeMapId;
+    GLuint myCubesMapId;
     GLuint myCubeSetListWiredId;
 
     /// number of lists in myListToAff

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -1383,7 +1383,7 @@ namespace DGtal
 
     /// used to displayed selected elements
     int mySelectedElementId = -1;
-    unsigned char mySelectionColorShift = 100;
+    unsigned char mySelectionColorShift = 150;
     
     /// information linked to the navigation in the viewer
     qglviewer::Vec myOrig, myDir, myDirSelector, mySelectedPoint;

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -645,12 +645,10 @@ DGtal::Viewer3D<Space, KSpace>::drawWithNames()
   // quads. Seems to work well.
 
   glCallList ( myQuadsMapId );
-  // JOL: 2014/10/15. I leave the remaining code, but I am not
-  // confident that it works reliably.
-  for ( unsigned int i=0; i<Viewer3D<Space, KSpace>::myCubeSetList.size() ; i++ )
-    {
-      glCallList ( myCubeSetListId +i);
-    }
+
+  glCallList ( myCubesMapId );
+
+
   for ( unsigned int i=0; i<Viewer3D<Space, KSpace>::myLineSetList.size(); i++ )
     {
       glCallList ( myLineSetListId+i );
@@ -744,10 +742,10 @@ DGtal::Viewer3D<Space, KSpace>::draw()
     }
 
   glCallList(myPrismListId);
-  for ( unsigned int j=0; j< Viewer3D<Space, KSpace>::myCubeSetList.size() ; j++ )
-    {
-      glCallList( myCubeSetListId+j);
-    }
+  
+
+  glCallList( myCubesMapId );
+      
 
   for ( unsigned int j=0; j< Viewer3D<Space, KSpace>::myBallSetList.size(); j++ )
     {
@@ -914,15 +912,23 @@ DGtal::Viewer3D<Space, KSpace>::sortSurfelFromCamera()
 {
   CompFarthestVoxelFromCamera comp;
   comp.posCam= camera()->position();
-  for ( unsigned int i=0; i< Viewer3D<Space, KSpace>::myCubeSetList.size() ; i++ )
+
+  for (typename Viewer3D<Space, KSpace>::CubesMap::iterator it = Viewer3D<Space, KSpace>::myCubesMap.begin(), 
+         itE = Viewer3D<Space, KSpace>::myCubesMap.end();
+       it != itE; ++it )
     {
-      sort ( Viewer3D<Space, KSpace>::myCubeSetList.at ( i ).begin(), Viewer3D<Space, KSpace>::myCubeSetList.at ( i ).end(), comp );
+      DGtal::trace.info() << "sort quad size" << it->second.size() << std::endl;
+      sort ( it->second.begin(), it->second.end(), comp );
     }
+
   CompFarthestSurfelFromCamera compSurf;
   DGtal::trace.info() << "sort surfel size" << Viewer3D<Space, KSpace>::myPrismList.size() << std::endl;
   sort ( Viewer3D<Space, KSpace>::myPrismList.begin(), Viewer3D<Space, KSpace>::myPrismList.end(), compSurf );
-
 }
+
+
+
+
 
 template< typename Space, typename KSpace>
 void
@@ -990,26 +996,6 @@ DGtal::Viewer3D<Space, KSpace>::postSelection ( const QPoint& point )
       SelectCallbackFct fct = getSelectCallback3D( selectedName(), aData );
       if ( fct ) fct( this, selectedName(), aData );
       // I leave the remaining code.
-      else if ( selectedName() >= 0 )
-        {
-          unsigned int id = abs ( selectedName()-1 );
-          if ( id< Viewer3D<Space, KSpace>::myCubeSetList.size())
-            {
-              DGtal::trace.info() << "deleting list="<< id<<endl;
-              Viewer3D<Space, KSpace>::myCubeSetList.erase ( Viewer3D<Space, KSpace>::myCubeSetList.begin() +id );
-              updateList ( false );
-            }
-          else if ( id< Viewer3D<Space, KSpace>::myCubeSetList.size()+ Viewer3D<Space, KSpace>::myLineSetList.size() )
-            {
-              Viewer3D<Space, KSpace>::myLineSetList.erase ( Viewer3D<Space, KSpace>::myLineSetList.begin() + ( id- Viewer3D<Space, KSpace>::myCubeSetList.size()) );
-              updateList ( false );
-            }
-          else if ( id< Viewer3D<Space, KSpace>::myBallSetList.size() + Viewer3D<Space, KSpace>::myLineSetList.size() + Viewer3D<Space, KSpace>::myCubeSetList.size())
-            {
-              Viewer3D<Space, KSpace>::myBallSetList.erase ( Viewer3D<Space, KSpace>::myBallSetList.begin() + ( id- Viewer3D<Space, KSpace>::myCubeSetList.size() - Viewer3D<Space, KSpace>::myLineSetList.size() ) );
-              updateList ( false );
-            }
-        }
     }
 }
 
@@ -1021,21 +1007,20 @@ DGtal::Viewer3D<Space, KSpace>::updateList ( bool needToUpdateBoundingBox )
 {
 
   // glDeleteLists
-  glDeleteLists(myCubeSetListId, myNbCubeSetList);
+  glDeleteLists(myCubesMapId, 1);
   glDeleteLists(myLineSetListId, myNbLineSetList);
   glDeleteLists(myBallSetListId, myNbBallSetList);
   glDeleteLists(myTriangleSetListId, 1);
   glDeleteLists(myTriangleSetListWiredId, 1);
   glDeleteLists(myPrismListId, 1);
-  glDeleteLists(myCubeSetListWiredId, 1);
+  glDeleteLists(myCubesMapId, 1);
   glDeleteLists(myPolygonSetListId, 1);
   glDeleteLists(myPolygonSetListWiredId, 1);
   glDeleteLists(myQuadsMapId, 1);
   glDeleteLists(myQuadsMapWiredId, 1);
 
   // Storing ID for each list
-  myCubeSetListId = glGenLists(Viewer3D<Space, KSpace>::myCubeSetList.size());
-  myNbCubeSetList  = Viewer3D<Space, KSpace>::myCubeSetList.size();
+  myCubesMapId = glGenLists(1);
   myLineSetListId = glGenLists(Viewer3D<Space, KSpace>::myLineSetList.size());
   myNbLineSetList =  Viewer3D<Space, KSpace>::myLineSetList.size();
   myBallSetListId = glGenLists(Viewer3D<Space, KSpace>::myBallSetList.size());
@@ -1058,11 +1043,9 @@ DGtal::Viewer3D<Space, KSpace>::updateList ( bool needToUpdateBoundingBox )
   glBlendFunc ( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 
 
-  for( unsigned int i = 0; i <   Viewer3D<Space, KSpace>::myCubeSetList.size(); i++){
-    glCreateListCubes(Viewer3D<Space, KSpace>::myCubeSetList.at(i), myCubeSetListId+i);
-    myNbListe++;
-  }
-
+  
+  glCreateListCubeMaps(Viewer3D<Space, KSpace>::myCubesMap, myCubesMapIdi);
+  
 
   glCreateListQuadD3D(Viewer3D<Space, KSpace>::myPrismList, myPrismListId);
   myNbListe++;
@@ -1376,20 +1359,31 @@ DGtal::Viewer3D<Space, KSpace>::helpString() const
 
 
 
+template< typename Space, typename KSpace>
+void
+DGtal::Viewer3D<Space, KSpace>::glCreateListQuadMaps(const typename DGtal::Display3D<Space, KSpace>::QuadsMap &aQuadMap,
+                                                    unsigned int idList){
+  glNewList ( idList, GL_COMPILE );
+
+  for (typename DGtal::Display3D<Space, KSpace>::QuadsMap::const_iterator it = aQuadMap.begin(), itE = aQuadMap.end();
+       it != itE; ++it )
+    {
 
 template< typename Space, typename KSpace>
 void
-DGtal::Viewer3D<Space, KSpace>::glCreateListCubes( const VectorCubes & aVectCubes,
-                                                   unsigned int idList){
+  DGtal::Viewer3D<Space, KSpace>::glCreateListCubeMaps(const typename DGtal::Display3D<Space, KSpace>::CubesMap &aCubeMap,
+                                                       unsigned int idList){
   glNewList ( idList , GL_COMPILE );
   glPushName ( myNbListe );
   glEnable ( GL_DEPTH_TEST );
   glBegin ( GL_QUADS );
 
-  for (typename  VectorCubes::const_iterator c_it =  aVectCubes.begin();
-       c_it != aVectCubes.end(); ++c_it ){
+  for (typename DGtal::Display3D<Space, KSpace>::QuadsMap::const_iterator it = aCubeMap.begin(), itE = aCubeMap.end();
+       it != itE; ++it )
+    {
+      
 
-    typename Viewer3D<Space, KSpace>::CubeD3D cube = (*c_it);
+    typename Viewer3D<Space, KSpace>::CubeD3D cube = (*it);
     glColor4ub ( cube.color.red(), cube.color.green(), cube.color.blue(), cube.color.alpha() );
     double _width= cube.width;
     //z+

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -40,7 +40,7 @@
 
 #include "DGtal/io/viewers/Viewer3D.h"
 
-
+#include <algorithm> 
 #include <limits>
 #include <QColor>
 #include <QTextEdit>
@@ -993,6 +993,10 @@ DGtal::Viewer3D<Space, KSpace>::postSelection ( const QPoint& point )
       if ( fct ) fct( this, selectedName(), aData );
       // I leave the remaining code.      
       updateList(false);
+    }else if (mySelectedElementId != -1)
+    {
+      mySelectedElementId = -1;
+      updateList(false);
     }
 }
 
@@ -1373,9 +1377,26 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListCubesMaps(const typename DGtal::Disp
       for (auto   &cube: mapElem.second)
         {
           if(useColorSelection)
-            glColor4ub ( mySelectionColor.red(), mySelectionColor.green(), mySelectionColor.blue(), mySelectionColor.alpha() );
+            {
+              unsigned char m = std::max(std::max( cube.color.red(), cube.color.green()), cube.color.blue());
+              if(m>128)
+                {
+                  glColor4ub ( std::max(cube.color.red()-mySelectionColorShift, 0),
+                               std::max(cube.color.green()-mySelectionColorShift, 0),
+                               std::max(cube.color.blue()-mySelectionColorShift, 0),
+                               cube.color.alpha());              
+                }
+              else{
+                glColor4ub ( std::min(cube.color.red()+mySelectionColorShift, 255),
+                             std::min(cube.color.green()+mySelectionColorShift, 255),
+                             std::min(cube.color.blue()+mySelectionColorShift, 255),
+                             cube.color.alpha());              
+              } 
+            }
           else
-            glColor4ub ( cube.color.red(), cube.color.green(), cube.color.blue(), cube.color.alpha() );
+            { 
+              glColor4ub ( cube.color.red(), cube.color.green(), cube.color.blue(),cube.color.alpha());
+            }
           double _width= cube.width;
           //z+
           glNormal3f ( 0.0, 0.0, 1.0 );
@@ -1515,9 +1536,28 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListQuadMaps(const typename DGtal::Displ
       for (auto &q: mapElem.second)
         {
           if(useColorSelection)
-            glColor4ub ( mySelectionColor.red(), mySelectionColor.green(), mySelectionColor.blue(), mySelectionColor.alpha() );
+            {
+              unsigned char m = std::max(std::max( q.color.red(), q.color.green()), q.color.blue());
+              if(m>128)
+                {
+                  glColor4ub ( std::max(q.color.red()-mySelectionColorShift, 0),
+                               std::max(q.color.green()-mySelectionColorShift, 0),
+                               std::max(q.color.blue()-mySelectionColorShift, 0),
+                               q.color.alpha());              
+                }
+              else{
+                glColor4ub ( std::min(q.color.red()+mySelectionColorShift, 255),
+                             std::min(q.color.green()+mySelectionColorShift, 255),
+                             std::min(q.color.blue()+mySelectionColorShift, 255),
+                             q.color.alpha());              
+              } 
+            }
           else
-            glColor4ub ( q.color.red(), q.color.green(), q.color.blue(), q.color.alpha() );
+            {
+              glColor4ub ( q.color.red(), q.color.green(), q.color.blue(), q.color.alpha());              
+              
+            }
+
           glNormal3f ( q.nx, q.ny ,q.nz );
           glVertex3f ( q.point1[0], q.point1[1], q.point1[2] );
           glVertex3f ( q.point2[0], q.point2[1], q.point2[2] );

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -646,7 +646,7 @@ DGtal::Viewer3D<Space, KSpace>::drawWithNames()
 
   glCallList ( myQuadsMapId );
 
-  glCallList ( myCubesMapId );
+  glCallList ( myCubeMapId );
 
 
   for ( unsigned int i=0; i<Viewer3D<Space, KSpace>::myLineSetList.size(); i++ )
@@ -744,7 +744,7 @@ DGtal::Viewer3D<Space, KSpace>::draw()
   glCallList(myPrismListId);
   
 
-  glCallList( myCubesMapId );
+  glCallList( myCubeMapId );
       
 
   for ( unsigned int j=0; j< Viewer3D<Space, KSpace>::myBallSetList.size(); j++ )
@@ -1007,20 +1007,19 @@ DGtal::Viewer3D<Space, KSpace>::updateList ( bool needToUpdateBoundingBox )
 {
 
   // glDeleteLists
-  glDeleteLists(myCubesMapId, 1);
+  glDeleteLists(myCubeMapId, 1);
   glDeleteLists(myLineSetListId, myNbLineSetList);
   glDeleteLists(myBallSetListId, myNbBallSetList);
   glDeleteLists(myTriangleSetListId, 1);
   glDeleteLists(myTriangleSetListWiredId, 1);
   glDeleteLists(myPrismListId, 1);
-  glDeleteLists(myCubesMapId, 1);
   glDeleteLists(myPolygonSetListId, 1);
   glDeleteLists(myPolygonSetListWiredId, 1);
   glDeleteLists(myQuadsMapId, 1);
   glDeleteLists(myQuadsMapWiredId, 1);
 
   // Storing ID for each list
-  myCubesMapId = glGenLists(1);
+  myCubeMapId = glGenLists(1);
   myLineSetListId = glGenLists(Viewer3D<Space, KSpace>::myLineSetList.size());
   myNbLineSetList =  Viewer3D<Space, KSpace>::myLineSetList.size();
   myBallSetListId = glGenLists(Viewer3D<Space, KSpace>::myBallSetList.size());
@@ -1044,7 +1043,7 @@ DGtal::Viewer3D<Space, KSpace>::updateList ( bool needToUpdateBoundingBox )
 
 
   
-  glCreateListCubeMaps(Viewer3D<Space, KSpace>::myCubesMap, myCubesMapIdi);
+  glCreateListCubesMaps(Viewer3D<Space, KSpace>::myCubesMap, myCubeMapId);
   
 
   glCreateListQuadD3D(Viewer3D<Space, KSpace>::myPrismList, myPrismListId);
@@ -1361,29 +1360,23 @@ DGtal::Viewer3D<Space, KSpace>::helpString() const
 
 template< typename Space, typename KSpace>
 void
-DGtal::Viewer3D<Space, KSpace>::glCreateListQuadMaps(const typename DGtal::Display3D<Space, KSpace>::QuadsMap &aQuadMap,
-                                                    unsigned int idList){
-  glNewList ( idList, GL_COMPILE );
-
-  for (typename DGtal::Display3D<Space, KSpace>::QuadsMap::const_iterator it = aQuadMap.begin(), itE = aQuadMap.end();
-       it != itE; ++it )
-    {
-
-template< typename Space, typename KSpace>
-void
-  DGtal::Viewer3D<Space, KSpace>::glCreateListCubeMaps(const typename DGtal::Display3D<Space, KSpace>::CubesMap &aCubeMap,
-                                                       unsigned int idList){
+DGtal::Viewer3D<Space, KSpace>::glCreateListCubesMaps(const typename DGtal::Display3D<Space, KSpace>::CubesMap &aCubeMap,
+                                                     unsigned int idList){
   glNewList ( idList , GL_COMPILE );
-  glPushName ( myNbListe );
-  glEnable ( GL_DEPTH_TEST );
-  glBegin ( GL_QUADS );
-
-  for (typename DGtal::Display3D<Space, KSpace>::QuadsMap::const_iterator it = aCubeMap.begin(), itE = aCubeMap.end();
+  
+  for (typename DGtal::Display3D<Space, KSpace>::CubesMap::const_iterator it = aCubeMap.begin(), itE = aCubeMap.end();
        it != itE; ++it )
     {
+      glPushName ( it->first );
+      glEnable ( GL_LIGHTING );
+      glBegin ( GL_QUADS );
       
-
-    typename Viewer3D<Space, KSpace>::CubeD3D cube = (*it);
+      
+      for (typename std::vector<typename Viewer3D<Space, KSpace>::CubeD3D>::const_iterator  it_s = it->second.begin();
+           it_s != it->second.end(); it_s++)
+        {
+  
+          typename Viewer3D<Space, KSpace>::CubeD3D cube = (*it_s);
     glColor4ub ( cube.color.red(), cube.color.green(), cube.color.blue(), cube.color.alpha() );
     double _width= cube.width;
     //z+
@@ -1424,7 +1417,9 @@ void
     glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]+_width );
   }
   glEnd();
-  glEndList();
+  glPopName();
+    }
+glEndList();
 }
 
 

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -1378,12 +1378,12 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListCubesMaps(const typename DGtal::Disp
         {
           if(useColorSelection)
             {
-              unsigned char m = std::max(std::max( cube.color.red(), cube.color.green()), cube.color.blue());
+              unsigned char m =  (cube.color.red()+ cube.color.green()+ cube.color.blue())/3;
               if(m>128)
                 {
-                  glColor4ub ( std::max(cube.color.red()-mySelectionColorShift, 0),
-                               std::max(cube.color.green()-mySelectionColorShift, 0),
-                               std::max(cube.color.blue()-mySelectionColorShift, 0),
+                  glColor4ub ( std::max((int)(cube.color.red())-mySelectionColorShift, 0),
+                               std::max((int)(cube.color.green())-mySelectionColorShift, 0),
+                               std::max((int)(cube.color.blue())-mySelectionColorShift, 0),
                                cube.color.alpha());              
                 }
               else{
@@ -1537,12 +1537,12 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListQuadMaps(const typename DGtal::Displ
         {
           if(useColorSelection)
             {
-              unsigned char m = std::max(std::max( q.color.red(), q.color.green()), q.color.blue());
+              unsigned char m = (q.color.red()+ q.color.green()+ q.color.blue())/3;
               if(m>128)
                 {
-                  glColor4ub ( std::max(q.color.red()-mySelectionColorShift, 0),
-                               std::max(q.color.green()-mySelectionColorShift, 0),
-                               std::max(q.color.blue()-mySelectionColorShift, 0),
+                  glColor4ub ( std::max((int)(q.color.red())-mySelectionColorShift, 0),
+                               std::max((int)(q.color.green())-mySelectionColorShift, 0),
+                               std::max((int)(q.color.blue())-mySelectionColorShift, 0),
                                q.color.alpha());              
                 }
               else{

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -755,12 +755,12 @@ DGtal::Viewer3D<Space, KSpace>::draw()
         }
       glCallList(myBallSetListId+j);
     }
- for ( typename vector<vector< typename Viewer3D<Space, KSpace>::BallD3D> >::const_iterator itb= Viewer3D<Space, KSpace>::myBallSetList.begin();
-	itb != Viewer3D<Space, KSpace>::myBallSetList.end(); itb++ )
+
+  for ( auto const &bList: Viewer3D<Space, KSpace>::myBallSetList )
     {
-      for ( typename vector< typename Viewer3D<Space, KSpace>::BallD3D>::const_iterator it_s = itb->begin(); it_s !=itb->end() ; it_s ++)
+      for ( auto const & b: bList)
         {
-          glDrawGLBall ( *it_s );
+          glDrawGLBall ( b );
         }
     }
 
@@ -913,14 +913,12 @@ DGtal::Viewer3D<Space, KSpace>::sortSurfelFromCamera()
   CompFarthestVoxelFromCamera comp;
   comp.posCam= camera()->position();
 
-  for (typename Viewer3D<Space, KSpace>::CubesMap::iterator it = Viewer3D<Space, KSpace>::myCubesMap.begin(), 
-         itE = Viewer3D<Space, KSpace>::myCubesMap.end();
-       it != itE; ++it )
+  for (auto &mapElem: Viewer3D<Space, KSpace>::myCubesMap)
+    
     {
-      DGtal::trace.info() << "sort quad size" << it->second.size() << std::endl;
-      sort ( it->second.begin(), it->second.end(), comp );
+      DGtal::trace.info() << "sort quad size" << mapElem.second.size() << std::endl;
+      sort ( mapElem.second.begin(), mapElem.second.end(), comp );
     }
-
   CompFarthestSurfelFromCamera compSurf;
   DGtal::trace.info() << "sort surfel size" << Viewer3D<Space, KSpace>::myPrismList.size() << std::endl;
   sort ( Viewer3D<Space, KSpace>::myPrismList.begin(), Viewer3D<Space, KSpace>::myPrismList.end(), compSurf );
@@ -936,11 +934,10 @@ DGtal::Viewer3D<Space, KSpace>::sortTriangleFromCamera()
 {
   CompFarthestTriangleFromCamera comp;
   comp.posCam= camera()->position();
-  for (typename std::vector<std::vector< typename Viewer3D<Space, KSpace>::TriangleD3D> >::iterator it = Viewer3D<Space, KSpace>::myTriangleSetList.begin(); it != Viewer3D<Space, KSpace>::myTriangleSetList.end(); it++)
+  for (auto &listElem: Viewer3D<Space, KSpace>::myTriangleSetList)
     {
-      sort ( it->begin(), it->end(), comp );
+      sort ( listElem.begin(), listElem.end(), comp );
     }
-
 }
 
 
@@ -952,13 +949,11 @@ DGtal::Viewer3D<Space, KSpace>::sortQuadFromCamera()
   CompFarthestSurfelFromCamera comp;
   comp.posCam= camera()->position();
 
-  for (typename Viewer3D<Space, KSpace>::QuadsMap::iterator it = Viewer3D<Space, KSpace>::myQuadsMap.begin(), itE = Viewer3D<Space, KSpace>::myQuadsMap.end();
-       it != itE; ++it )
+  for (auto &listElem: Viewer3D<Space, KSpace>::myQuadsMap)
     {
-      DGtal::trace.info() << "sort quad size" << it->second.size() << std::endl;
-      sort ( it->second.begin(), it->second.end(), comp );
+      DGtal::trace.info() << "sort quad size" << listElem.second.size() << std::endl;
+      sort ( listElem.second.begin(), listElem.second.end(), comp );
     }
-
 }
 
 
@@ -969,10 +964,10 @@ DGtal::Viewer3D<Space, KSpace>::sortPolygonFromCamera()
   CompFarthestPolygonFromCamera comp;
   comp.posCam= camera()->position();
 
-  for (typename std::vector<std::vector< typename Viewer3D<Space, KSpace>::PolygonD3D> >::iterator it = Viewer3D<Space, KSpace>::myPolygonSetList.begin(); it != Viewer3D<Space, KSpace>:: myPolygonSetList.end(); it++)
+  for (auto &listElem: Viewer3D<Space, KSpace>::myPolygonSetList)
     {
-      DGtal::trace.info() << "sort polygon size" << it->size() << std::endl;
-      sort ( it->begin(), it->end(), comp );
+      DGtal::trace.info() << "sort polygon size" << listElem.size() << std::endl;
+      sort ( listElem.begin(), listElem.end(), comp );
     }
 
 }
@@ -1361,65 +1356,60 @@ DGtal::Viewer3D<Space, KSpace>::helpString() const
 template< typename Space, typename KSpace>
 void
 DGtal::Viewer3D<Space, KSpace>::glCreateListCubesMaps(const typename DGtal::Display3D<Space, KSpace>::CubesMap &aCubeMap,
-                                                     unsigned int idList){
+                                                      unsigned int idList){
   glNewList ( idList , GL_COMPILE );
   
-  for (typename DGtal::Display3D<Space, KSpace>::CubesMap::const_iterator it = aCubeMap.begin(), itE = aCubeMap.end();
-       it != itE; ++it )
+  for (auto &mapElem: aCubeMap)
     {
-      glPushName ( it->first );
+      glPushName ( mapElem.first );
       glEnable ( GL_LIGHTING );
-      glBegin ( GL_QUADS );
+      glBegin ( GL_QUADS );      
       
-      
-      for (typename std::vector<typename Viewer3D<Space, KSpace>::CubeD3D>::const_iterator  it_s = it->second.begin();
-           it_s != it->second.end(); it_s++)
+      for (auto   &cube: mapElem.second)
         {
-  
-          typename Viewer3D<Space, KSpace>::CubeD3D cube = (*it_s);
-    glColor4ub ( cube.color.red(), cube.color.green(), cube.color.blue(), cube.color.alpha() );
-    double _width= cube.width;
-    //z+
-    glNormal3f ( 0.0, 0.0, 1.0 );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]+_width );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]+_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]+_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]+_width );
-    //z-
-    glNormal3f ( 0.0, 0.0, -1.0 );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]-_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]-_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]-_width );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]-_width );
-    //x+
-    glNormal3f ( 1.0, 0.0, 0.0 );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]+_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]-_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]-_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]+_width );
-    //x-
-    glNormal3f ( -1.0, 0.0, 0.0 );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]+_width );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]+_width );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]-_width );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]-_width );
-    //y+
-    glNormal3f ( 0.0, 1.0, 0.0 );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]+_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]+_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]-_width );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]-_width );
-    //y-
-    glNormal3f ( 0.0, -1.0, 0.0 );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]+_width );
-    glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]-_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]-_width );
-    glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]+_width );
-  }
-  glEnd();
-  glPopName();
+          glColor4ub ( cube.color.red(), cube.color.green(), cube.color.blue(), cube.color.alpha() );
+          double _width= cube.width;
+          //z+
+          glNormal3f ( 0.0, 0.0, 1.0 );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]+_width );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]+_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]+_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]+_width );
+          //z-
+          glNormal3f ( 0.0, 0.0, -1.0 );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]-_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]-_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]-_width );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]-_width );
+          //x+
+          glNormal3f ( 1.0, 0.0, 0.0 );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]+_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]-_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]-_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]+_width );
+          //x-
+          glNormal3f ( -1.0, 0.0, 0.0 );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]+_width );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]+_width );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]-_width );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]-_width );
+          //y+
+          glNormal3f ( 0.0, 1.0, 0.0 );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]+_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]+_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]+_width, cube.center[2]-_width );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]+_width, cube.center[2]-_width );
+          //y-
+          glNormal3f ( 0.0, -1.0, 0.0 );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]+_width );
+          glVertex3f ( cube.center[0]-_width, cube.center[1]-_width, cube.center[2]-_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]-_width );
+          glVertex3f ( cube.center[0]+_width, cube.center[1]-_width, cube.center[2]+_width );
+        }
+      glEnd();
+      glPopName();
     }
-glEndList();
+  glEndList();
 }
 
 
@@ -1437,16 +1427,15 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListQuadD3D(const VectorQuad &aVectQuad,
   glBlendFunc ( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 
   glBegin ( GL_QUADS );
-  for ( typename  VectorQuad::const_iterator s_it = aVectQuad.begin();
-        s_it != aVectQuad.end(); ++s_it )
+  for ( auto const &q: aVectQuad )
     {
-      glColor4ub ( ( *s_it ).color.red(), ( *s_it ).color.green(),
-                   ( *s_it ).color.blue(), ( *s_it ).color.alpha() );
-      glNormal3f ( ( *s_it ).nx, ( *s_it ).ny, ( *s_it ).nz );
-      glVertex3f ( ( *s_it ).point1[0], ( *s_it ).point1[1] , ( *s_it ).point1[2] );
-      glVertex3f ( ( *s_it ).point2[0], ( *s_it ).point2[1] , ( *s_it ).point2[2] );
-      glVertex3f ( ( *s_it ).point3[0], ( *s_it ).point3[1] , ( *s_it ).point3[2] );
-      glVertex3f ( ( *s_it ).point4[0], ( *s_it ).point4[1] , ( *s_it ).point4[2] );
+      glColor4ub ( q.color.red(), q.color.green(),
+                   q.color.blue(), q.color.alpha() );
+      glNormal3f ( q.nx, q.ny, q.nz );
+      glVertex3f ( q.point1[0], q.point1[1] , q.point1[2] );
+      glVertex3f ( q.point2[0], q.point2[1] , q.point2[2] );
+      glVertex3f ( q.point3[0], q.point3[1] , q.point3[2] );
+      glVertex3f ( q.point4[0], q.point4[1] , q.point4[2] );
     }
   glEnd();
   glEndList();
@@ -1462,13 +1451,12 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListLines(const VectorLine &aVectLine,
   glDisable ( GL_LIGHTING );
   glPushName ( myNbListe );
   glBegin ( GL_LINES );
-  for (typename  VectorLine::const_iterator s_it =  aVectLine.begin();
-       s_it != aVectLine.end(); ++s_it )
+  for (auto const &l: aVectLine )
     {
-      glColor4ub ( ( *s_it ).color.red(), ( *s_it ).color.green(),
-                   ( *s_it ).color.blue(), ( *s_it ).color.alpha() );
-      glVertex3f ( ( *s_it ).point1[0], ( *s_it ).point1[1], ( *s_it ).point1[2] );
-      glVertex3f ( ( *s_it ).point2[0], ( *s_it ).point2[1], ( *s_it ).point2[2] );
+      glColor4ub ( l.color.red(), l.color.green(),
+                   l.color.blue(), l.color.alpha() );
+      glVertex3f ( l.point1[0], l.point1[1], l.point1[2] );
+      glVertex3f ( l.point2[0], l.point2[1], l.point2[2] );
     }
   glEnd();
   glEnable ( GL_LIGHTING );
@@ -1489,10 +1477,10 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListBalls(const VectorBall &aVectBall,
 
   glPushName ( myNbListe );
   glBegin ( GL_POINTS );
-  for ( typename VectorBall::const_iterator s_it = aVectBall.begin(); s_it != aVectBall.end(); ++s_it )
+  for ( auto const &ball: aVectBall )
     {
-      glColor4ub ( ( *s_it ).color.red(), ( *s_it ).color.green(), ( *s_it ).color.blue(), ( *s_it ).color.alpha() );
-      glVertex3f ( ( *s_it ).center[0], ( *s_it ).center[1], ( *s_it ).center[2] );
+      glColor4ub ( ball.color.red(), ball.color.green(), ball.color.blue(), ball.color.alpha() );
+      glVertex3f ( ball.center[0], ball.center[1], ball.center[2] );
     }
   glEnd();
   glEnable ( GL_LIGHTING );
@@ -1507,29 +1495,25 @@ void
 DGtal::Viewer3D<Space, KSpace>::glCreateListQuadMaps(const typename DGtal::Display3D<Space, KSpace>::QuadsMap &aQuadMap,
                                                     unsigned int idList){
   glNewList ( idList, GL_COMPILE );
-
-  for (typename DGtal::Display3D<Space, KSpace>::QuadsMap::const_iterator it = aQuadMap.begin(), itE = aQuadMap.end();
-       it != itE; ++it )
+  for (auto & mapElem: aQuadMap)
     {
-      glPushName ( it->first );
+      glPushName ( mapElem.first );
       glEnable ( GL_LIGHTING );
       glBegin ( GL_QUADS );
-
-      for (typename std::vector<typename Viewer3D<Space, KSpace>::QuadD3D>::const_iterator  it_s = it->second.begin();
-           it_s != it->second.end(); it_s++)
+      
+      for (auto &q: mapElem.second)
         {
-          glColor4ub ( it_s->color.red(), it_s->color.green(), it_s->color.blue(), it_s->color.alpha() );
-          glNormal3f ( it_s->nx, it_s->ny ,it_s->nz );
-          glVertex3f ( it_s->point1[0], it_s->point1[1], it_s->point1[2] );
-          glVertex3f ( it_s->point2[0], it_s->point2[1], it_s->point2[2] );
-          glVertex3f ( it_s->point3[0], it_s->point3[1], it_s->point3[2] );
-          glVertex3f ( it_s->point4[0], it_s->point4[1], it_s->point4[2] );
+          glColor4ub ( q.color.red(), q.color.green(), q.color.blue(), q.color.alpha() );
+          glNormal3f ( q.nx, q.ny ,q.nz );
+          glVertex3f ( q.point1[0], q.point1[1], q.point1[2] );
+          glVertex3f ( q.point2[0], q.point2[1], q.point2[2] );
+          glVertex3f ( q.point3[0], q.point3[1], q.point3[2] );
+          glVertex3f ( q.point4[0], q.point4[1], q.point4[2] );
         }
       glEnd();
       glPopName();
     }
   glEndList();
-
 }
 
 
@@ -1543,34 +1527,32 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListQuadMapsWired(const typename DGtal::
   glPushName ( myNbListe );
   glDisable ( GL_LIGHTING );
   glBegin ( GL_LINES );
-
-  for (typename DGtal::Display3D<Space, KSpace>::QuadsMap::const_iterator it = aQuadMap.begin(), itE = aQuadMap.end();
-       it != itE; ++it )
+  
+  for (auto const &mapElem: aQuadMap)
     {
-      for (typename std::vector<typename Viewer3D<Space, KSpace>::QuadD3D>::const_iterator  it_s = it->second.begin();
-           it_s != it->second.end(); it_s++)
+      for(auto const &q: mapElem.second)
         {
           glColor4ub ( 150.0,150.0,150.0,255.0 );
           glColor4ub ( Viewer3D<Space, KSpace>::myCurrentLineColor.red(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.green(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.blue(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.alpha() );
-          glVertex3f ( it_s->point1[0], it_s->point1[1], it_s->point1[2] );
-          glVertex3f ( it_s->point2[0], it_s->point2[1], it_s->point2[2] );
-          glVertex3f ( it_s->point2[0], it_s->point2[1], it_s->point2[2] );
+          glVertex3f ( q.point1[0], q.point1[1], q.point1[2] );
+          glVertex3f ( q.point2[0], q.point2[1], q.point2[2] );
+          glVertex3f ( q.point2[0], q.point2[1], q.point2[2] );
           glColor4ub ( Viewer3D<Space, KSpace>::myCurrentLineColor.red(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.green(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.blue(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.alpha() );
-          glVertex3f ( it_s->point3[0], it_s->point3[1], it_s->point3[2] );
-          glVertex3f ( it_s->point3[0], it_s->point3[1], it_s->point3[2] );
-          glVertex3f ( it_s->point4[0], it_s->point4[1], it_s->point4[2] );
+          glVertex3f ( q.point3[0], q.point3[1], q.point3[2] );
+          glVertex3f ( q.point3[0], q.point3[1], q.point3[2] );
+          glVertex3f ( q.point4[0], q.point4[1], q.point4[2] );
           glColor4ub ( Viewer3D<Space, KSpace>::myCurrentLineColor.red(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.green(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.blue(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.alpha() );
-          glVertex3f ( it_s->point4[0], it_s->point4[1], it_s->point4[2] );
-          glVertex3f ( it_s->point1[0], it_s->point1[1], it_s->point1[2] );
+          glVertex3f ( q.point4[0], q.point4[1], q.point4[2] );
+          glVertex3f ( q.point1[0], q.point1[1], q.point1[2] );
         }
     }
   glEnd();
@@ -1587,15 +1569,15 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListTriangles(const std::vector<VectorTr
   glPushName ( myNbListe );
   glEnable ( GL_LIGHTING );
   glBegin ( GL_TRIANGLES );
-  for (typename std::vector<VectorTriangle>::const_iterator it = aVectTriangle.begin(); it != aVectTriangle.end(); it++)
+  for(auto const &tList: aVectTriangle)
     {
-      for (typename VectorTriangle::const_iterator it_s = it->begin(); it_s != it->end(); it_s++)
+      for (auto const &t: tList)
         {
-          glColor4ub (it_s->color.red(),it_s->color.green(),it_s->color.blue(),it_s->color.alpha() );
-          glNormal3f (it_s->nx,it_s->ny ,it_s->nz );
-          glVertex3f (it_s->point1[0],it_s->point1[1],it_s->point1[2] );
-          glVertex3f (it_s->point2[0],it_s->point2[1],it_s->point2[2] );
-          glVertex3f (it_s->point3[0],it_s->point3[1],it_s->point3[2] );
+          glColor4ub (t.color.red(),t.color.green(),t.color.blue(),t.color.alpha() );
+          glNormal3f (t.nx,t.ny ,t.nz );
+          glVertex3f (t.point1[0],t.point1[1],t.point1[2] );
+          glVertex3f (t.point2[0],t.point2[1],t.point2[2] );
+          glVertex3f (t.point3[0],t.point3[1],t.point3[2] );
         }
     }
   glEnd();
@@ -1611,21 +1593,20 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListTrianglesWired(const std::vector<Vec
   glPushName ( myNbListe );
   glDisable ( GL_LIGHTING );
   glBegin ( GL_LINES );
-  for (typename std::vector<VectorTriangle >::const_iterator it = aVectTriangle.begin();
-       it != aVectTriangle.end(); it++)
+  for (auto const &tList: aVectTriangle)
     {
-      for (typename VectorTriangle::const_iterator it_s = it->begin(); it_s != it->end(); it_s++)
+      for (auto const &t: tList)
         {
           glColor4ub ( Viewer3D<Space, KSpace>::myCurrentLineColor.red(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.green(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.blue(),
                        Viewer3D<Space, KSpace>::myCurrentLineColor.alpha() );
-          glVertex3f (it_s->point1[0],it_s->point1[1],it_s->point1[2] );
-          glVertex3f (it_s->point2[0],it_s->point2[1],it_s->point2[2] );
-          glVertex3f (it_s->point2[0],it_s->point2[1],it_s->point2[2] );
-          glVertex3f (it_s->point3[0],it_s->point3[1],it_s->point3[2] );
-          glVertex3f (it_s->point3[0],it_s->point3[1],it_s->point3[2] );
-          glVertex3f (it_s->point1[0],it_s->point1[1],it_s->point1[2] );
+          glVertex3f (t.point1[0],t.point1[1],t.point1[2] );
+          glVertex3f (t.point2[0],t.point2[1],t.point2[2] );
+          glVertex3f (t.point2[0],t.point2[1],t.point2[2] );
+          glVertex3f (t.point3[0],t.point3[1],t.point3[2] );
+          glVertex3f (t.point3[0],t.point3[1],t.point3[2] );
+          glVertex3f (t.point1[0],t.point1[1],t.point1[2] );
         }
     }
   glEnd();
@@ -1638,21 +1619,21 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListTrianglesWired(const std::vector<Vec
 template< typename Space, typename KSpace>
 void
 DGtal::Viewer3D<Space, KSpace>::glCreateListPolygons(const std::vector<VectorPolygon>  &aVectPolygon,
-                                                    unsigned int idList){
+                                                     unsigned int idList){
   glNewList ( idList, GL_COMPILE );
   glPushName ( myNbListe );
   glEnable ( GL_LIGHTING );
-  for (typename std::vector<VectorPolygon >::const_iterator it = aVectPolygon.begin();
-       it != aVectPolygon.end(); it++)
+  
+  for(auto const &pList: aVectPolygon)
     {
-      for (typename VectorPolygon::const_iterator it_s = it->begin(); it_s != it->end(); it_s++)
+      for (auto const &p: pList)
         {
           glBegin ( GL_POLYGON );
-          glColor4ub ( it_s->color.red(), it_s->color.green(), it_s->color.blue(), it_s->color.alpha() );
-          glNormal3f ( it_s->nx, it_s->ny ,it_s->nz );
-          for(unsigned int j=0;j < (it_s->vertices).size();j++)
+          glColor4ub ( p.color.red(), p.color.green(), p.color.blue(), p.color.alpha() );
+          glNormal3f ( p.nx, p.ny ,p.nz );
+          for(unsigned int j=0;j < (p.vertices).size();j++)
             {
-              glVertex3f ( (it_s->vertices).at(j)[0], (it_s->vertices).at(j)[1], (it_s->vertices).at ( j )[2] );
+              glVertex3f ( (p.vertices).at(j)[0], (p.vertices).at(j)[1], (p.vertices).at ( j )[2] );
             }
           glEnd();
         }
@@ -1665,31 +1646,30 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListPolygons(const std::vector<VectorPol
 template< typename Space, typename KSpace>
 void
 DGtal::Viewer3D<Space, KSpace>::glCreateListPolygonsWired(const std::vector<VectorPolygon>  &aVectPolygon,
-                                                         unsigned int idList){
+                                                          unsigned int idList){
   glNewList ( idList, GL_COMPILE );
   glPushName ( myNbListe );
   glDisable ( GL_LIGHTING );
   glBegin ( GL_LINES );
-   for (typename std::vector<VectorPolygon >::const_iterator it = aVectPolygon.begin();
-        it != aVectPolygon.end(); it++)
-     {
-       for (typename VectorPolygon::const_iterator it_s = it->begin(); it_s != it->end(); it_s++)
-         {
-           glColor4ub ( Viewer3D<Space, KSpace>::myCurrentLineColor.red(),
-                        Viewer3D<Space, KSpace>::myCurrentLineColor.green(),
-                        Viewer3D<Space, KSpace>::myCurrentLineColor.blue() ,
-                        Viewer3D<Space, KSpace>::myCurrentLineColor.alpha() );
-           for(unsigned int j=0;j < (it_s->vertices).size();j++)
-             {
-               glVertex3f ( (it_s->vertices).at(j)[0], (it_s->vertices).at(j)[1], (it_s->vertices).at ( j )[2] );
-               glVertex3f ( (it_s->vertices).at((j+1)%(it_s->vertices).size())[0],
-                            (it_s->vertices).at((j+1)%(it_s->vertices).size())[1],
-                            (it_s->vertices).at ( (j+1)%(it_s->vertices).size() )[2] );
+  for(auto const &pList: aVectPolygon)
+    { 
+      for (auto const &p: pList)
+        {
+          glColor4ub ( Viewer3D<Space, KSpace>::myCurrentLineColor.red(),
+                       Viewer3D<Space, KSpace>::myCurrentLineColor.green(),
+                       Viewer3D<Space, KSpace>::myCurrentLineColor.blue() ,
+                       Viewer3D<Space, KSpace>::myCurrentLineColor.alpha() );
+          for(unsigned int j=0;j < (p.vertices).size();j++)
+            {
+              glVertex3f ( (p.vertices).at(j)[0], (p.vertices).at(j)[1], (p.vertices).at ( j )[2] );
+              glVertex3f ( (p.vertices).at((j+1)%(p.vertices).size())[0],
+                           (p.vertices).at((j+1)%(p.vertices).size())[1],
+                           (p.vertices).at ( (j+1)%(p.vertices).size() )[2] );
             }
-         }
-     }
-   glEnd();
-   glEndList();
+        }
+    }
+  glEnd();
+  glEndList();
 }
 
 

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -987,10 +987,12 @@ DGtal::Viewer3D<Space, KSpace>::postSelection ( const QPoint& point )
     {
       DGtal::trace.info() << "Element of liste= " << selectedName() << "selected" << endl;
       // JOL: 2014/10/15
+      mySelectedElementId = selectedName();
       void* aData = 0;
       SelectCallbackFct fct = getSelectCallback3D( selectedName(), aData );
       if ( fct ) fct( this, selectedName(), aData );
-      // I leave the remaining code.
+      // I leave the remaining code.      
+      updateList(false);
     }
 }
 
@@ -1364,10 +1366,16 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListCubesMaps(const typename DGtal::Disp
       glPushName ( mapElem.first );
       glEnable ( GL_LIGHTING );
       glBegin ( GL_QUADS );      
+      bool useColorSelection = false;
+      if(mySelectedElementId == mapElem.first)
+        useColorSelection = true;
       
       for (auto   &cube: mapElem.second)
         {
-          glColor4ub ( cube.color.red(), cube.color.green(), cube.color.blue(), cube.color.alpha() );
+          if(useColorSelection)
+            glColor4ub ( mySelectionColor.red(), mySelectionColor.green(), mySelectionColor.blue(), mySelectionColor.alpha() );
+          else
+            glColor4ub ( cube.color.red(), cube.color.green(), cube.color.blue(), cube.color.alpha() );
           double _width= cube.width;
           //z+
           glNormal3f ( 0.0, 0.0, 1.0 );
@@ -1500,10 +1508,16 @@ DGtal::Viewer3D<Space, KSpace>::glCreateListQuadMaps(const typename DGtal::Displ
       glPushName ( mapElem.first );
       glEnable ( GL_LIGHTING );
       glBegin ( GL_QUADS );
+      bool useColorSelection = false;
+      if(mySelectedElementId == mapElem.first)
+        useColorSelection = true;
       
       for (auto &q: mapElem.second)
         {
-          glColor4ub ( q.color.red(), q.color.green(), q.color.blue(), q.color.alpha() );
+          if(useColorSelection)
+            glColor4ub ( mySelectionColor.red(), mySelectionColor.green(), mySelectionColor.blue(), mySelectionColor.alpha() );
+          else
+            glColor4ub ( q.color.red(), q.color.green(), q.color.blue(), q.color.alpha() );
           glNormal3f ( q.nx, q.ny ,q.nz );
           glVertex3f ( q.point1[0], q.point1[1], q.point1[2] );
           glVertex3f ( q.point2[0], q.point2[1], q.point2[2] );

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -646,7 +646,7 @@ DGtal::Viewer3D<Space, KSpace>::drawWithNames()
 
   glCallList ( myQuadsMapId );
 
-  glCallList ( myCubeMapId );
+  glCallList ( myCubesMapId );
 
 
   for ( unsigned int i=0; i<Viewer3D<Space, KSpace>::myLineSetList.size(); i++ )
@@ -744,7 +744,7 @@ DGtal::Viewer3D<Space, KSpace>::draw()
   glCallList(myPrismListId);
   
 
-  glCallList( myCubeMapId );
+  glCallList( myCubesMapId );
       
 
   for ( unsigned int j=0; j< Viewer3D<Space, KSpace>::myBallSetList.size(); j++ )
@@ -1002,7 +1002,7 @@ DGtal::Viewer3D<Space, KSpace>::updateList ( bool needToUpdateBoundingBox )
 {
 
   // glDeleteLists
-  glDeleteLists(myCubeMapId, 1);
+  glDeleteLists(myCubesMapId, 1);
   glDeleteLists(myLineSetListId, myNbLineSetList);
   glDeleteLists(myBallSetListId, myNbBallSetList);
   glDeleteLists(myTriangleSetListId, 1);
@@ -1014,7 +1014,7 @@ DGtal::Viewer3D<Space, KSpace>::updateList ( bool needToUpdateBoundingBox )
   glDeleteLists(myQuadsMapWiredId, 1);
 
   // Storing ID for each list
-  myCubeMapId = glGenLists(1);
+  myCubesMapId = glGenLists(1);
   myLineSetListId = glGenLists(Viewer3D<Space, KSpace>::myLineSetList.size());
   myNbLineSetList =  Viewer3D<Space, KSpace>::myLineSetList.size();
   myBallSetListId = glGenLists(Viewer3D<Space, KSpace>::myBallSetList.size());
@@ -1038,7 +1038,7 @@ DGtal::Viewer3D<Space, KSpace>::updateList ( bool needToUpdateBoundingBox )
 
 
   
-  glCreateListCubesMaps(Viewer3D<Space, KSpace>::myCubesMap, myCubeMapId);
+  glCreateListCubesMaps(Viewer3D<Space, KSpace>::myCubesMap, myCubesMapId);
   
 
   glCreateListQuadD3D(Viewer3D<Space, KSpace>::myPrismList, myPrismListId);

--- a/src/DGtal/io/viewers/Viewer3DFactory.ih
+++ b/src/DGtal/io/viewers/Viewer3DFactory.ih
@@ -366,12 +366,12 @@ DGtal::Viewer3DFactory<Space,KSpace>::draw( Viewer3D<Space, KSpace> & viewer,
       }
     else if ( mode == "Paving" )
       {
-	viewer.createNewCubeList( aDomain.className());
+	viewer.createNewCubeList( );
 	drawAsPaving( viewer, aDomain );
       }else if ( mode == "PavingGrids" )
       {
 	viewer.createNewLineList(aDomain.className());
-	viewer.createNewCubeList( aDomain.className());
+	viewer.createNewCubeList( );
 	drawAsGrid( viewer, aDomain );
 	drawAsPaving( viewer, aDomain );
       }


### PR DESCRIPTION
# PR Description

For now the Viewer3D interaction was limited to surfel, with this PR, the voxel can also be used with interaction.  The transform was mainly to replace the list of CubeD3D with with a std::map<DGtal::int32_t, std::vector< CubeD3D > > as done initially by @JacquesOlivierLachaud.
The example tool was updated with this new possibility (with the doc)

# Checklist

- [n.a.] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)