### PR TITLE
Fixing issue #779

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -36,12 +36,17 @@
    some improvements on bounding box computation with orientation check.
    (B. Kerautret, [#1123](https://github.com/DGtal-team/DGtal/pull/1123))
 
+- *Image Package*
+ - Fixing issue [#779](https://github.com/DGtal-team/DGtal/issues/779) by
+   storing domain with smart pointer in ImageContainerBySTLMap.
+   (Roland Denis [#1151](https://github.com/DGtal-team/DGtal/pull/1151))
+
 - *IO Package*
  - Display3D: Fix embedder usage when using default constructor in Debug mode.
-   (Roland Denis [##1143](https://github.com/DGtal-team/DGtal/pull/1143))
+   (Roland Denis [#1143](https://github.com/DGtal-team/DGtal/pull/1143))
  - Viewer3D: Fix a problem when the show() method was called at the end of the
    main program (the list creation was not called).
-   (Bertrand Kerautret [##1138](https://github.com/DGtal-team/DGtal/pull/1138))
+   (Bertrand Kerautret [#1138](https://github.com/DGtal-team/DGtal/pull/1138))
  - Viewer3D: add three new modes for shape rendering (default, metallic and
    plastic). The rendering can be changed by using the key M. The user can
    also choose its own rendering with some setter/getter on the opengl

--- a/src/DGtal/base/CowPtr.h
+++ b/src/DGtal/base/CowPtr.h
@@ -90,6 +90,25 @@ public:
     const T* operator->()   const throw()   {return myPtr.get();}
     const T* get()          const throw()   {return myPtr.get();}
 
+    /* The following non-const methods are deactivated if T is a const type.
+     * The goal here is to avoid unecessary copies when it is known that
+     *   the T object will not be modified.
+     *
+     * The problem is that C++ uses the non-const methods whenever it's possible
+     *   (ie when CowPtr<T> is non-const), even if the full expression doesn't 
+     *   modify the object. A solution is to const_cast the CowPtr<T> before
+     *   using one of these methods to force the usage of the const versions above.
+     *
+     * However, in the trivial case when T is a const type, we can simplify this
+     *   by deactivating those methods.
+     *
+     * To do that, we use std::enable_if (see http://en.cppreference.com/w/cpp/types/enable_if )
+     *   in the template parameters (it is also possible in the return type or
+     *   as a parameter but it will change the signature). It depends on
+     *   the constness of T returned by the type trait std::is_const.
+     * The `typename U = T` is necessary in order that the SFINAE rule works at the overload
+     * resolution step.
+     */
     template < typename U = T, typename std::enable_if< ! std::is_const<U>::value >::type* = nullptr >
     T& operator*()                          {copy(); return *myPtr;}
 

--- a/src/DGtal/base/CowPtr.h
+++ b/src/DGtal/base/CowPtr.h
@@ -43,6 +43,7 @@
 //////////////////////////////////////////////////////////////////////////////
 // Inclusions
 #include <iostream>
+#include <type_traits>
 #include "DGtal/base/Common.h"
 #include "DGtal/base/CountedPtr.h"
 //////////////////////////////////////////////////////////////////////////////
@@ -89,8 +90,13 @@ public:
     const T* operator->()   const throw()   {return myPtr.get();}
     const T* get()          const throw()   {return myPtr.get();}
     
+    template < typename U = T, typename std::enable_if< ! std::is_const<U>::value >::type* = nullptr >
     T& operator*()                          {copy(); return *myPtr;}
+
+    template < typename U = T, typename std::enable_if< ! std::is_const<U>::value >::type* = nullptr >
     T* operator->()                         {copy(); return myPtr.get();}
+
+    template < typename U = T, typename std::enable_if< ! std::is_const<U>::value >::type* = nullptr >
     T* get()                                {copy(); return myPtr.get();}
 
     /**

--- a/src/DGtal/base/CowPtr.h
+++ b/src/DGtal/base/CowPtr.h
@@ -89,7 +89,7 @@ public:
     const T& operator*()    const throw()   {return *myPtr;}
     const T* operator->()   const throw()   {return myPtr.get();}
     const T* get()          const throw()   {return myPtr.get();}
-    
+
     template < typename U = T, typename std::enable_if< ! std::is_const<U>::value >::type* = nullptr >
     T& operator*()                          {copy(); return *myPtr;}
 
@@ -101,7 +101,7 @@ public:
 
     /**
        Equality operator ==
-       
+
        @param other any other pointer.
        @return 'true' if pointed address is equal to \a other.
     */
@@ -112,7 +112,7 @@ public:
 
     /**
        Inequality operator !=
-       
+
        @param other any other pointer.
        @return 'true' if pointed address is different from \a other.
     */

--- a/src/DGtal/images/ImageContainerBySTLMap.h
+++ b/src/DGtal/images/ImageContainerBySTLMap.h
@@ -112,6 +112,10 @@ namespace DGtal
     typedef typename Domain::Dimension Dimension;
     typedef Point Vertex;
 
+    // Pointer to the (const) Domain given at construction.
+    typedef const Domain * DomainPtr;
+
+
     /// static constants
     static const typename Domain::Dimension dimension;
 
@@ -127,8 +131,10 @@ namespace DGtal
     /////////////////// Data members //////////////////
   private:
 
-    /// Image domain
-    Domain myDomain;
+    /// Counted pointer on the image domain,
+    /// Since the domain is not mutable, not assignable,
+    /// it is shared by all the copies of *this
+    DomainPtr myDomainPtr;
 
     /// Default value
     Value myDefaultValue;
@@ -144,7 +150,7 @@ namespace DGtal
      * @param aValue a default value associated to the domain points
      * that are not contained in the underlying map.
      */
-    ImageContainerBySTLMap( const Domain& aDomain, const Value& aValue = 0);
+    ImageContainerBySTLMap( ConstAlias<Domain> aDomain, const Value& aValue = 0);
 
     /**
      * Copy operator

--- a/src/DGtal/images/ImageContainerBySTLMap.h
+++ b/src/DGtal/images/ImageContainerBySTLMap.h
@@ -112,10 +112,6 @@ namespace DGtal
     typedef typename Domain::Dimension Dimension;
     typedef Point Vertex;
 
-    // Pointer to the (const) Domain given at construction.
-    typedef const Domain * DomainPtr;
-
-
     /// static constants
     static const typename Domain::Dimension dimension;
 
@@ -131,10 +127,8 @@ namespace DGtal
     /////////////////// Data members //////////////////
   private: 
 
-    /// Counted pointer on the image domain,
-    /// Since the domain is not mutable, not assignable,
-    /// it is shared by all the copies of *this
-    DomainPtr myDomainPtr;
+    /// Image domain
+    Domain myDomain;
 
     /// Default value
     Value myDefaultValue;
@@ -150,7 +144,7 @@ namespace DGtal
      * @param aValue a default value associated to the domain points
      * that are not contained in the underlying map.
      */
-    ImageContainerBySTLMap( ConstAlias<Domain> aDomain, const Value& aValue = 0);
+    ImageContainerBySTLMap( const Domain& aDomain, const Value& aValue = 0);
 
     /** 
      * Copy operator

--- a/src/DGtal/images/ImageContainerBySTLMap.h
+++ b/src/DGtal/images/ImageContainerBySTLMap.h
@@ -78,33 +78,33 @@ namespace DGtal
    * Once constructed, the image is valid, i.e. every point of the
    * image domain has a value, which can be read and overwritten.
    * Note that the default value (returned for points that are not
-   * stored in the underlying STL map) can be chosen by the user. 
+   * stored in the underlying STL map) can be chosen by the user.
    *
-   * As a model of concepts::CImage, this class provides two ways of accessing values: 
-   * - through the range of points returned by the domain() method 
-   * combined with the operator() that takes a point and returns its associated value. 
-   * - through the range of values returned by the range() method, 
+   * As a model of concepts::CImage, this class provides two ways of accessing values:
+   * - through the range of points returned by the domain() method
+   * combined with the operator() that takes a point and returns its associated value.
+   * - through the range of values returned by the range() method,
    * which can be used to directly iterate over the values of the image
    *
-   * This class also provides a setValue() method and an output iterator, 
-   * which is returned by the outputIterator() method for writting purposes. 
+   * This class also provides a setValue() method and an output iterator,
+   * which is returned by the outputIterator() method for writting purposes.
    *
    * @see testImage.cpp
    */
 
   template <typename TDomain, typename TValue>
-  class ImageContainerBySTLMap: 
+  class ImageContainerBySTLMap:
     public std::map<typename TDomain::Point, TValue >
   {
 
   public:
 
-    typedef ImageContainerBySTLMap<TDomain,TValue> Self; 
-    typedef std::map<typename TDomain::Point, TValue > Parent; 
+    typedef ImageContainerBySTLMap<TDomain,TValue> Self;
+    typedef std::map<typename TDomain::Point, TValue > Parent;
 
     /// domain
     BOOST_CONCEPT_ASSERT(( concepts::CDomain<TDomain> ));
-    typedef TDomain Domain;    
+    typedef TDomain Domain;
     typedef typename Domain::Point Point;
     typedef typename Domain::Vector Vector;
     typedef typename Domain::Integer Integer;
@@ -118,14 +118,14 @@ namespace DGtal
     /// range of values
     BOOST_CONCEPT_ASSERT(( CLabel<TValue> ));
     typedef TValue Value;
-    typedef DefaultConstImageRange<Self> ConstRange; 
-    typedef DefaultImageRange<Self> Range; 
+    typedef DefaultConstImageRange<Self> ConstRange;
+    typedef DefaultImageRange<Self> Range;
 
     /// output iterator
-    typedef SetValueIterator<Self> OutputIterator; 
+    typedef SetValueIterator<Self> OutputIterator;
 
     /////////////////// Data members //////////////////
-  private: 
+  private:
 
     /// Image domain
     Domain myDomain;
@@ -135,39 +135,39 @@ namespace DGtal
 
     /////////////////// standard services //////////////////
 
-  public: 
+  public:
 
-    /** 
+    /**
      * Constructor from a Domain
-     * 
+     *
      * @param aDomain the image domain.
      * @param aValue a default value associated to the domain points
      * that are not contained in the underlying map.
      */
     ImageContainerBySTLMap( const Domain& aDomain, const Value& aValue = 0);
 
-    /** 
+    /**
      * Copy operator
-     * 
+     *
      * @param other the object to copy.
      */
     ImageContainerBySTLMap(const ImageContainerBySTLMap& other);
 
-    /** 
+    /**
      * Assignement operator
-     * 
+     *
      * @param other the object to copy.
      * @return this
      */
     ImageContainerBySTLMap& operator=(const ImageContainerBySTLMap& other);
 
-    /** 
+    /**
      * Destructor.
      *
     */
     ~ImageContainerBySTLMap();
 
-  
+
     /////////////////// Interface //////////////////
 
       /**
@@ -190,12 +190,12 @@ namespace DGtal
      * @param aValue the value.
      */
     void setValue(const Point &aPoint, const Value &aValue);
-    
+
 
     /**
      * @return the domain associated to the image.
      */
-    const Domain &domain() const; 
+    const Domain &domain() const;
 
     /**
      * @return the const range providing constant
@@ -232,15 +232,15 @@ namespace DGtal
     typedef typename std::map<Point,Value>::const_iterator ConstIterator;
     typedef typename std::map<Point,Value>::reverse_iterator ReverseIterator;
     typedef typename std::map<Point,Value>::const_reverse_iterator ConstReverseIterator;
-    
+
     /**
-     * Construct a Iterator on the image 
+     * Construct a Iterator on the image
      *
-     * 
+     *
      * @return a Iterator      */
     OutputIterator outputIterator();
 
-        
+
   };
 
   /**
@@ -252,7 +252,7 @@ namespace DGtal
   template <typename TDomain, typename TValue>
   inline
   std::ostream&
-  operator<< ( std::ostream & out, 
+  operator<< ( std::ostream & out,
                const ImageContainerBySTLMap<TDomain,TValue> & object )
   {
     object.selfDisplay ( out );

--- a/src/DGtal/images/ImageContainerBySTLMap.h
+++ b/src/DGtal/images/ImageContainerBySTLMap.h
@@ -48,12 +48,11 @@
 // Inclusions
 #include <iostream>
 #include <map>
-#include <memory>
 
 #include "DGtal/base/Common.h"
-#include "DGtal/base/ConstAlias.h"
-#include "DGtal/base/CountedPtr.h"
 #include "DGtal/base/BasicFunctors.h"
+#include "DGtal/base/CowPtr.h"
+#include "DGtal/base/Clone.h"
 #include "DGtal/images/DefaultConstImageRange.h"
 #include "DGtal/images/DefaultImageRange.h"
 #include "DGtal/images/SetValueIterator.h"
@@ -113,6 +112,9 @@ namespace DGtal
     typedef typename Domain::Dimension Dimension;
     typedef Point Vertex;
 
+    // Pointer to the (const) Domain given at construction.
+    typedef CowPtr< const Domain >  DomainPtr;
+
     /// static constants
     static const typename Domain::Dimension dimension;
 
@@ -131,7 +133,7 @@ namespace DGtal
     /// Shared pointer on the image domain,
     /// Since the domain is not mutable, not assignable,
     /// it is shared by all the copies of *this
-    std::shared_ptr<const Domain> myDomainPtr;
+    DomainPtr myDomainPtr;
 
     /// Default value
     Value myDefaultValue;
@@ -141,24 +143,15 @@ namespace DGtal
   public:
 
     /**
-     * Constructor from a Domain.
+     * Constructor from a pointer to a domain.
      *
-     * If Domain is a heavy type, prefer giving a smart pointer on the domain.
+     * If Domain is a heavy type, consider giving instead a smart pointer on the domain (like CountedPtr).
      *
      * @param aDomain the image domain.
      * @param aValue a default value associated to the domain points
      * that are not contained in the underlying map.
      */
-    ImageContainerBySTLMap( const Domain & aDomain, const Value& aValue = 0);
-
-    /**
-     * Constructor from a pointer to a domain.
-     *
-     * @param aDomainPtr a pointer to the image domain.
-     * @param aValue a default value associated to the domain points
-     * that are not contained in the underlying map.
-     */
-    ImageContainerBySTLMap( const std::shared_ptr<const Domain> & aDomainPtr, const Value& aValue = 0);
+    ImageContainerBySTLMap( Clone<const Domain> aDomain, const Value& aValue = 0);
 
     /**
      * Copy operator

--- a/src/DGtal/images/ImageContainerBySTLMap.h
+++ b/src/DGtal/images/ImageContainerBySTLMap.h
@@ -48,6 +48,7 @@
 // Inclusions
 #include <iostream>
 #include <map>
+#include <memory>
 
 #include "DGtal/base/Common.h"
 #include "DGtal/base/ConstAlias.h"
@@ -112,10 +113,6 @@ namespace DGtal
     typedef typename Domain::Dimension Dimension;
     typedef Point Vertex;
 
-    // Pointer to the (const) Domain given at construction.
-    typedef const Domain * DomainPtr;
-
-
     /// static constants
     static const typename Domain::Dimension dimension;
 
@@ -131,10 +128,10 @@ namespace DGtal
     /////////////////// Data members //////////////////
   private:
 
-    /// Counted pointer on the image domain,
+    /// Shared pointer on the image domain,
     /// Since the domain is not mutable, not assignable,
     /// it is shared by all the copies of *this
-    DomainPtr myDomainPtr;
+    std::shared_ptr<const Domain> myDomainPtr;
 
     /// Default value
     Value myDefaultValue;
@@ -144,13 +141,24 @@ namespace DGtal
   public:
 
     /**
-     * Constructor from a Domain
+     * Constructor from a Domain.
+     *
+     * If Domain is a heavy type, prefer giving a smart pointer on the domain.
      *
      * @param aDomain the image domain.
      * @param aValue a default value associated to the domain points
      * that are not contained in the underlying map.
      */
-    ImageContainerBySTLMap( ConstAlias<Domain> aDomain, const Value& aValue = 0);
+    ImageContainerBySTLMap( const Domain & aDomain, const Value& aValue = 0);
+
+    /**
+     * Constructor from a pointer to a domain.
+     *
+     * @param aDomainPtr a pointer to the image domain.
+     * @param aValue a default value associated to the domain points
+     * that are not contained in the underlying map.
+     */
+    ImageContainerBySTLMap( const std::shared_ptr<const Domain> & aDomainPtr, const Value& aValue = 0);
 
     /**
      * Copy operator

--- a/src/DGtal/images/ImageContainerBySTLMap.ih
+++ b/src/DGtal/images/ImageContainerBySTLMap.ih
@@ -47,8 +47,8 @@ const typename TDomain::Dimension DGtal::ImageContainerBySTLMap<TDomain,
 template <typename TDomain, typename TValue>
 inline
 DGtal::ImageContainerBySTLMap<TDomain,TValue>
-::ImageContainerBySTLMap( ConstAlias<Domain> aDomain, const Value& aValue)
-  : myDomainPtr( &aDomain ), myDefaultValue( aValue )
+::ImageContainerBySTLMap( const Domain& aDomain, const Value& aValue)
+  : myDomain( aDomain ), myDefaultValue( aValue )
 {
 }
 
@@ -58,7 +58,7 @@ inline
 DGtal::ImageContainerBySTLMap<TDomain,TValue>
 ::ImageContainerBySTLMap(const ImageContainerBySTLMap& other)
   : Parent(other), 
-    myDomainPtr(other.myDomainPtr), myDefaultValue(other.myDefaultValue)
+    myDomain(other.myDomain), myDefaultValue(other.myDefaultValue)
 {
 }
 //------------------------------------------------------------------------------
@@ -71,7 +71,7 @@ DGtal::ImageContainerBySTLMap<TDomain,TValue>
   if (this != &other)
     {
       Parent::operator=(other); 
-      myDomainPtr = other.myDomainPtr; 
+      myDomain = other.myDomain; 
       myDefaultValue = other.myDefaultValue; 
     }
   return *this; 
@@ -116,7 +116,7 @@ inline
 const typename DGtal::ImageContainerBySTLMap<TDomain,TValue>::Domain&
 DGtal::ImageContainerBySTLMap<TDomain,TValue>::domain() const
 {
-  return *myDomainPtr;
+  return myDomain;
 }
 
 //------------------------------------------------------------------------------
@@ -162,7 +162,7 @@ void
 DGtal::ImageContainerBySTLMap<TDomain,TValue>::selfDisplay ( std::ostream & out ) const
 {
   out << "[Image - STLMap] size=" << this->size() << " valuetype=" 
-      << sizeof(TValue) << "bytes Domain=" << *myDomainPtr;
+      << sizeof(TValue) << "bytes Domain=" << myDomain;
 }
 
 //------------------------------------------------------------------------------

--- a/src/DGtal/images/ImageContainerBySTLMap.ih
+++ b/src/DGtal/images/ImageContainerBySTLMap.ih
@@ -47,8 +47,8 @@ const typename TDomain::Dimension DGtal::ImageContainerBySTLMap<TDomain,
 template <typename TDomain, typename TValue>
 inline
 DGtal::ImageContainerBySTLMap<TDomain,TValue>
-::ImageContainerBySTLMap( const Domain& aDomain, const Value& aValue)
-  : myDomain( aDomain ), myDefaultValue( aValue )
+::ImageContainerBySTLMap( ConstAlias<Domain> aDomain, const Value& aValue)
+  : myDomainPtr( &aDomain ), myDefaultValue( aValue )
 {
 }
 
@@ -58,7 +58,7 @@ inline
 DGtal::ImageContainerBySTLMap<TDomain,TValue>
 ::ImageContainerBySTLMap(const ImageContainerBySTLMap& other)
   : Parent(other),
-    myDomain(other.myDomain), myDefaultValue(other.myDefaultValue)
+    myDomainPtr(other.myDomainPtr), myDefaultValue(other.myDefaultValue)
 {
 }
 //------------------------------------------------------------------------------
@@ -71,7 +71,7 @@ DGtal::ImageContainerBySTLMap<TDomain,TValue>
   if (this != &other)
     {
       Parent::operator=(other);
-      myDomain = other.myDomain;
+      myDomainPtr = other.myDomainPtr;
       myDefaultValue = other.myDefaultValue;
     }
   return *this;
@@ -116,7 +116,7 @@ inline
 const typename DGtal::ImageContainerBySTLMap<TDomain,TValue>::Domain&
 DGtal::ImageContainerBySTLMap<TDomain,TValue>::domain() const
 {
-  return myDomain;
+  return *myDomainPtr;
 }
 
 //------------------------------------------------------------------------------
@@ -162,7 +162,7 @@ void
 DGtal::ImageContainerBySTLMap<TDomain,TValue>::selfDisplay ( std::ostream & out ) const
 {
   out << "[Image - STLMap] size=" << this->size() << " valuetype="
-      << sizeof(TValue) << "bytes Domain=" << myDomain;
+      << sizeof(TValue) << "bytes Domain=" << *myDomainPtr;
 }
 
 //------------------------------------------------------------------------------

--- a/src/DGtal/images/ImageContainerBySTLMap.ih
+++ b/src/DGtal/images/ImageContainerBySTLMap.ih
@@ -43,22 +43,13 @@ template <typename TDomain, typename TValue>
 const typename TDomain::Dimension DGtal::ImageContainerBySTLMap<TDomain,
 								TValue>::dimension = TDomain::Space::dimension;
 
-
-template <typename TDomain, typename TValue>
-inline
-DGtal::ImageContainerBySTLMap<TDomain,TValue>
-::ImageContainerBySTLMap( const Domain & aDomain, const Value& aValue)
-  : myDomainPtr( std::make_shared<const Domain>(aDomain) ), myDefaultValue( aValue )
-{
-}
-
 //------------------------------------------------------------------------------
 
 template <typename TDomain, typename TValue>
 inline
 DGtal::ImageContainerBySTLMap<TDomain,TValue>
-::ImageContainerBySTLMap( const std::shared_ptr<const Domain> & aDomainPtr, const Value& aValue)
-  : myDomainPtr( aDomainPtr ), myDefaultValue( aValue )
+::ImageContainerBySTLMap( Clone<const Domain> aDomain, const Value& aValue)
+  : myDomainPtr( aDomain ), myDefaultValue( aValue )
 {
 }
 

--- a/src/DGtal/images/ImageContainerBySTLMap.ih
+++ b/src/DGtal/images/ImageContainerBySTLMap.ih
@@ -57,7 +57,7 @@ template <typename TDomain, typename TValue>
 inline
 DGtal::ImageContainerBySTLMap<TDomain,TValue>
 ::ImageContainerBySTLMap(const ImageContainerBySTLMap& other)
-  : Parent(other), 
+  : Parent(other),
     myDomain(other.myDomain), myDefaultValue(other.myDefaultValue)
 {
 }
@@ -70,11 +70,11 @@ DGtal::ImageContainerBySTLMap<TDomain,TValue>
 {
   if (this != &other)
     {
-      Parent::operator=(other); 
-      myDomain = other.myDomain; 
-      myDefaultValue = other.myDefaultValue; 
+      Parent::operator=(other);
+      myDomain = other.myDomain;
+      myDefaultValue = other.myDefaultValue;
     }
-  return *this; 
+  return *this;
 }
 //------------------------------------------------------------------------------
 template <typename TDomain, typename TValue>
@@ -87,9 +87,9 @@ DGtal::ImageContainerBySTLMap<TDomain,TValue>::~ImageContainerBySTLMap( )
 template <typename TDomain, typename TValue>
 inline
 typename DGtal::ImageContainerBySTLMap<TDomain,TValue>::Value
-DGtal::ImageContainerBySTLMap<TDomain,TValue>::operator()(const Point &aPoint) const 
+DGtal::ImageContainerBySTLMap<TDomain,TValue>::operator()(const Point &aPoint) const
 {
-  ASSERT( this->domain().isInside( aPoint ) ); 
+  ASSERT( this->domain().isInside( aPoint ) );
   ConstIterator it = this->find( aPoint );
   if ( it == this->end() )
     return myDefaultValue;
@@ -103,11 +103,11 @@ inline
 void
 DGtal::ImageContainerBySTLMap<TDomain,TValue>::setValue(const Point &aPoint, const Value &aValue)
 {
-  ASSERT( this->domain().isInside( aPoint ) ); 
-  std::pair<typename std::map<Point,Value>::iterator, bool> 
-    res = this->insert( std::pair<Point,Value>(aPoint, aValue) ); 
+  ASSERT( this->domain().isInside( aPoint ) );
+  std::pair<typename std::map<Point,Value>::iterator, bool>
+    res = this->insert( std::pair<Point,Value>(aPoint, aValue) );
   if (res.second == false)
-    res.first->second = aValue; 
+    res.first->second = aValue;
 }
 
 //------------------------------------------------------------------------------
@@ -161,7 +161,7 @@ inline
 void
 DGtal::ImageContainerBySTLMap<TDomain,TValue>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[Image - STLMap] size=" << this->size() << " valuetype=" 
+  out << "[Image - STLMap] size=" << this->size() << " valuetype="
       << sizeof(TValue) << "bytes Domain=" << myDomain;
 }
 

--- a/src/DGtal/images/ImageContainerBySTLMap.ih
+++ b/src/DGtal/images/ImageContainerBySTLMap.ih
@@ -47,8 +47,18 @@ const typename TDomain::Dimension DGtal::ImageContainerBySTLMap<TDomain,
 template <typename TDomain, typename TValue>
 inline
 DGtal::ImageContainerBySTLMap<TDomain,TValue>
-::ImageContainerBySTLMap( ConstAlias<Domain> aDomain, const Value& aValue)
-  : myDomainPtr( &aDomain ), myDefaultValue( aValue )
+::ImageContainerBySTLMap( const Domain & aDomain, const Value& aValue)
+  : myDomainPtr( std::make_shared<const Domain>(aDomain) ), myDefaultValue( aValue )
+{
+}
+
+//------------------------------------------------------------------------------
+
+template <typename TDomain, typename TValue>
+inline
+DGtal::ImageContainerBySTLMap<TDomain,TValue>
+::ImageContainerBySTLMap( const std::shared_ptr<const Domain> & aDomainPtr, const Value& aValue)
+  : myDomainPtr( aDomainPtr ), myDefaultValue( aValue )
 {
 }
 

--- a/tests/geometry/volumes/distance/testPowerMap.cpp
+++ b/tests/geometry/volumes/distance/testPowerMap.cpp
@@ -30,7 +30,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include <iostream>
 #include "DGtal/base/Common.h"
-#include "DGtal/base/CountedPtr.h"
 #include "DGtal/helpers/StdDefs.h"
 #include "DGtal/geometry/volumes/distance/PowerMap.h"
 #include "DGtal/geometry/volumes/distance/ExactPredicateLpPowerSeparableMetric.h"
@@ -68,7 +67,7 @@ bool testPowerMap()
   using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >;
   using Image = ImageContainerBySTLMap< SetDomain , DGtal::int64_t>;
 
-  Image image( CountedPtr<const SetDomain> ( new SetDomain( set ) ) );
+  Image image( new SetDomain( set ) );
 
   //Setting some values
   image.setValue(Z2i::Point(3,3), 9);

--- a/tests/geometry/volumes/distance/testPowerMap.cpp
+++ b/tests/geometry/volumes/distance/testPowerMap.cpp
@@ -66,7 +66,9 @@ bool testPowerMap()
 
   using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >;
   using Image = ImageContainerBySTLMap< SetDomain , DGtal::int64_t>;
-  Image image( std::make_shared<SetDomain>( set ) );
+
+  SetDomain setDomain( set );
+  Image image( setDomain );
   
   //Setting some values
   image.setValue(Z2i::Point(3,3), 9); 

--- a/tests/geometry/volumes/distance/testPowerMap.cpp
+++ b/tests/geometry/volumes/distance/testPowerMap.cpp
@@ -67,7 +67,7 @@ bool testPowerMap()
   using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >;
   using Image = ImageContainerBySTLMap< SetDomain , DGtal::int64_t>;
 
-  SetDomain setDomain( set );
+  const SetDomain setDomain( set );
   Image image( setDomain );
   
   //Setting some values

--- a/tests/geometry/volumes/distance/testPowerMap.cpp
+++ b/tests/geometry/volumes/distance/testPowerMap.cpp
@@ -30,6 +30,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include <iostream>
 #include "DGtal/base/Common.h"
+#include "DGtal/base/CountedPtr.h"
 #include "DGtal/helpers/StdDefs.h"
 #include "DGtal/geometry/volumes/distance/PowerMap.h"
 #include "DGtal/geometry/volumes/distance/ExactPredicateLpPowerSeparableMetric.h"
@@ -53,37 +54,36 @@ bool testPowerMap()
 {
   unsigned int nbok = 0;
   unsigned int nb = 0;
-  
+
   trace.beginBlock ( "Testing PowerMap2D ..." );
 
   Z2i::Domain domain(Z2i::Point(0,0),Z2i::Point(10,10));
   Z2i::Domain domainLarge(Z2i::Point(0,0),Z2i::Point(10,10));
 
   DigitalSetBySTLSet<Z2i::Domain > set(domain);
-  set.insertNew(Z2i::Point(3,3)); 
-  //set.insertNew(Z2i::Point(3,7)); 
+  set.insertNew(Z2i::Point(3,3));
+  //set.insertNew(Z2i::Point(3,7));
   set.insertNew(Z2i::Point(7,7));
 
   using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >;
   using Image = ImageContainerBySTLMap< SetDomain , DGtal::int64_t>;
 
-  const SetDomain setDomain( set );
-  Image image( setDomain );
-  
+  Image image( CountedPtr<const SetDomain> ( new SetDomain( set ) ) );
+
   //Setting some values
-  image.setValue(Z2i::Point(3,3), 9); 
-  //  image.setValue(Z2i::Point(3,7), 0); 
+  image.setValue(Z2i::Point(3,3), 9);
+  //  image.setValue(Z2i::Point(3,7), 0);
   image.setValue(Z2i::Point(7,7), 16);
-  
+
   Z2i::L2PowerMetric l2power;
   PowerMap<Image, Z2i::L2PowerMetric> power(&domainLarge, &image, &l2power);
   for(unsigned int i=0; i<11; i++)
     {
       for(unsigned int j=0; j<11; j++)
-	if (image.domain().isInside(Z2i::Point(i,j)))
-	  trace.info()<< image(Z2i::Point(i,j))<<" ";
-	else
-	  trace.info()<< "0 ";
+        if (image.domain().isInside(Z2i::Point(i,j)))
+          trace.info()<< image(Z2i::Point(i,j))<<" ";
+        else
+          trace.info()<< "0 ";
       trace.info()<<std::endl;
     }
   trace.info()<<std::endl;
@@ -101,38 +101,38 @@ bool testPowerMap()
   for(unsigned int i=0; i<11; i++)
     {
       for(unsigned int j=0; j<11; j++)
-	{
-	  Z2i::Point p(i,j);
-	  DGtal::int64_t dist = (i-power(p)[0])*(i-power(p)[0]) +
-	    ( j-power(p)[1])*(j-power(p)[1])  - image(power(p));
-	  trace.info()<< dist;
-	}
+        {
+          Z2i::Point p(i,j);
+          DGtal::int64_t dist = (i-power(p)[0])*(i-power(p)[0]) +
+            ( j-power(p)[1])*(j-power(p)[1])  - image(power(p));
+          trace.info()<< dist;
+        }
       std::cerr<<std::endl;
     }
   trace.info()<<std::endl;
- 
+
   //Reconstruction
   for(unsigned int i=0; i<11; i++)
     {
       for(unsigned int j=0; j<11; j++)
-	{
-	  Z2i::Point p(i,j);
-	  DGtal::int32_t dist = (i-power(p)[0])*(i-power(p)[0]) +
-	    ( j-power(p)[1])*(j-power(p)[1])  - image(power(p));
-	  if (dist>=0)
-	    std::cerr<< "0 ";
-	   else
-	     std::cerr<< "X ";
-	}
+        {
+          Z2i::Point p(i,j);
+          DGtal::int32_t dist = (i-power(p)[0])*(i-power(p)[0]) +
+            ( j-power(p)[1])*(j-power(p)[1])  - image(power(p));
+          if (dist>=0)
+            std::cerr<< "0 ";
+          else
+            std::cerr<< "X ";
+        }
       std::cerr<<std::endl;
     }
-  
-  nbok += true ? 1 : 0; 
+
+  nbok += true ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
-	       << "true == true" << std::endl;
+    << "true == true" << std::endl;
   trace.endBlock();
-  
+
   return nbok == nb;
 }
 

--- a/tests/geometry/volumes/distance/testPowerMap.cpp
+++ b/tests/geometry/volumes/distance/testPowerMap.cpp
@@ -63,10 +63,10 @@ bool testPowerMap()
   set.insertNew(Z2i::Point(3,3)); 
   //set.insertNew(Z2i::Point(3,7)); 
   set.insertNew(Z2i::Point(7,7));
-  DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > > setDomain(set); 
-  
-  typedef ImageContainerBySTLMap< DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > > , DGtal::int64_t> Image;
-  Image image(setDomain);
+
+  using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >;
+  using Image = ImageContainerBySTLMap< SetDomain , DGtal::int64_t>;
+  Image image( std::make_shared<SetDomain>( set ) );
   
   //Setting some values
   image.setValue(Z2i::Point(3,3), 9); 

--- a/tests/geometry/volumes/distance/testReducedMedialAxis.cpp
+++ b/tests/geometry/volumes/distance/testReducedMedialAxis.cpp
@@ -62,10 +62,10 @@ bool testReducedMedialAxis()
   set.insertNew(Z2i::Point(3,3)); 
   //set.insertNew(Z2i::Point(3,7)); 
   set.insertNew(Z2i::Point(7,7));
-  DigitalSetDomain<DigitalSetBySTLSet<Z2i::Domain > > setDomain(set); 
   
-  typedef ImageContainerBySTLMap<DigitalSetDomain<DigitalSetBySTLSet<Z2i::Domain > > , DGtal::int64_t> Image;
-  Image image(setDomain);
+  using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >; 
+  using Image = ImageContainerBySTLMap< SetDomain , DGtal::int64_t>;
+  Image image( std::make_shared<SetDomain>( set ) );
   
   //Setting some values
   image.setValue(Z2i::Point(3,3), 9); 

--- a/tests/geometry/volumes/distance/testReducedMedialAxis.cpp
+++ b/tests/geometry/volumes/distance/testReducedMedialAxis.cpp
@@ -65,7 +65,8 @@ bool testReducedMedialAxis()
   
   using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >; 
   using Image = ImageContainerBySTLMap< SetDomain , DGtal::int64_t>;
-  Image image( std::make_shared<SetDomain>( set ) );
+  const SetDomain setDomain( set );
+  Image image( setDomain );
   
   //Setting some values
   image.setValue(Z2i::Point(3,3), 9); 

--- a/tests/geometry/volumes/distance/testReducedMedialAxis.cpp
+++ b/tests/geometry/volumes/distance/testReducedMedialAxis.cpp
@@ -30,6 +30,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include <iostream>
 #include "DGtal/base/Common.h"
+#include "DGtal/base/CountedPtr.h"
 #include "DGtal/helpers/StdDefs.h"
 #include "DGtal/geometry/volumes/distance/PowerMap.h"
 #include "DGtal/geometry/volumes/distance/ReducedMedialAxis.h"
@@ -52,27 +53,26 @@ bool testReducedMedialAxis()
 {
   unsigned int nbok = 0;
   unsigned int nb = 0;
-  
+
   trace.beginBlock ( "Testing PowerMap2D ..." );
 
   Z2i::Domain domain(Z2i::Point(0,0),Z2i::Point(10,10));
   Z2i::Domain domainLarge(Z2i::Point(0,0),Z2i::Point(10,10));
 
   DigitalSetBySTLSet<Z2i::Domain > set(domain);
-  set.insertNew(Z2i::Point(3,3)); 
-  //set.insertNew(Z2i::Point(3,7)); 
+  set.insertNew(Z2i::Point(3,3));
+  //set.insertNew(Z2i::Point(3,7));
   set.insertNew(Z2i::Point(7,7));
-  
-  using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >; 
+
+  using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >;
   using Image = ImageContainerBySTLMap< SetDomain , DGtal::int64_t>;
-  const SetDomain setDomain( set );
-  Image image( setDomain );
-  
+  Image image( CountedPtr<const SetDomain>( new SetDomain( set ) ) );
+
   //Setting some values
-  image.setValue(Z2i::Point(3,3), 9); 
-  //  image.setValue(Z2i::Point(3,7), 0); 
+  image.setValue(Z2i::Point(3,3), 9);
+  //  image.setValue(Z2i::Point(3,7), 0);
   image.setValue(Z2i::Point(7,7), 16);
-  
+
   Z2i::L2PowerMetric l2power;
   PowerMap<Image, Z2i::L2PowerMetric> power(&domainLarge, &image, &l2power);
   for(unsigned int i=0; i<11; i++)
@@ -108,10 +108,10 @@ bool testReducedMedialAxis()
       std::cerr<<std::endl;
     }
   trace.info()<<std::endl;
- 
+
   //Medial Axis extraction
   ReducedMedialAxis<PowerMap<Image, Z2i::L2PowerMetric> >::Type  rdma = ReducedMedialAxis< PowerMap<Image, Z2i::L2PowerMetric> >::getReducedMedialAxisFromPowerMap(power);
-  
+
   //Reconstruction
   for(unsigned int i=0; i<11; i++)
     {
@@ -122,19 +122,19 @@ bool testReducedMedialAxis()
             trace.info()<< rdma(p);
           else
             trace.info()<< " - ";
-            
+
 	}
       std::cerr<<std::endl;
     }
   trace.info()<<std::endl;
- 
-  
-  nbok += true ? 1 : 0; 
+
+
+  nbok += true ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
 	       << "true == true" << std::endl;
   trace.endBlock();
-  
+
   return nbok == nb;
 }
 

--- a/tests/geometry/volumes/distance/testReducedMedialAxis.cpp
+++ b/tests/geometry/volumes/distance/testReducedMedialAxis.cpp
@@ -30,7 +30,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include <iostream>
 #include "DGtal/base/Common.h"
-#include "DGtal/base/CountedPtr.h"
 #include "DGtal/helpers/StdDefs.h"
 #include "DGtal/geometry/volumes/distance/PowerMap.h"
 #include "DGtal/geometry/volumes/distance/ReducedMedialAxis.h"
@@ -66,7 +65,7 @@ bool testReducedMedialAxis()
 
   using SetDomain = DigitalSetDomain< DigitalSetBySTLSet<Z2i::Domain > >;
   using Image = ImageContainerBySTLMap< SetDomain , DGtal::int64_t>;
-  Image image( CountedPtr<const SetDomain>( new SetDomain( set ) ) );
+  Image image( new SetDomain( set ) );
 
   //Setting some values
   image.setValue(Z2i::Point(3,3), 9);


### PR DESCRIPTION
# PR Description

The issue #779 comes from the fact that `ImageContainerBySTLMap` stores his domain by pointer.
But readers create domain on the stack before constructing images so that the pointer is invalid as soon as the reader ends. 

Therefore, a solution is to store the domain by value, like other image containers.
But, doing so (like in this PR), leads to compilation errors when the domain is not assignable. It is the case when using a `DigitalSetDomain`, like in `tests/geometry/volumes/distance/testPowerMap`.

In fact, this problem arises for all `CTrivialConstImage` models that store the domain by value, since it is a refinement of `boost::Assignable`.

Any suggestion ?

# Checklist

- [N/A] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [N/A] Doxygen documentation of the code completed (classes, methods, types, members...)
- [N/A] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
