### PR TITLE
fixing extension removal

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -55,9 +55,11 @@
  - Fixing issue [#899](https://github.com/DGtal-team/DGtal/issues/899) in
    all color maps, (David Coeurjolly, Bertrand Kerautret
    [#1134](https://github.com/DGtal-team/DGtal/pull/1134))
--  GenericReader: include longvol reader in GenericReader for 64 bit images.
+ -  GenericReader: include longvol reader in GenericReader for 64 bit images.
    Update the test for 64 bit longvol. (Bertrand Kerautret
    [#1135](https://github.com/DGtal-team/DGtal/pull/1135))
+ - Fix the extension removal in Obj filename export in Board3D. (David 
+   Coeurjolly,[#XXXX](https://github.com/DGtal-team/DGtal/pull/XXXX)))
 
 - *Topology Package*
   - Fix wrong starting point for surface tracking in example code

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -58,8 +58,8 @@
  -  GenericReader: include longvol reader in GenericReader for 64 bit images.
    Update the test for 64 bit longvol. (Bertrand Kerautret
    [#1135](https://github.com/DGtal-team/DGtal/pull/1135))
- - Fix the extension removal in Obj filename export in Board3D. (David 
-   Coeurjolly,[#XXXX](https://github.com/DGtal-team/DGtal/pull/XXXX)))
+ - Fix the extension removal in Obj filename export in Board3D. (David
+   Coeurjolly,[#1154](https://github.com/DGtal-team/DGtal/pull/1154)))
 
 - *Topology Package*
   - Fix wrong starting point for surface tracking in example code

--- a/src/DGtal/io/boards/Board3D.ih
+++ b/src/DGtal/io/boards/Board3D.ih
@@ -147,13 +147,13 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
   
   outOBJ.open(nameOBJ.str().c_str());
   outOBJ << "#  OBJ format"<< std::endl;
-  outOBJ << "# generated from Board3D from the DGTal library"<< std::endl;
+  outOBJ << "# generated from Board3D from the DGtal library"<< std::endl;
   outOBJ << "mtllib " <<  nameMTL.str() << std::endl;
   outOBJ << std::endl;
   
   outMTL.open(nameMTL.str().c_str());
   outMTL << "#  MTL format"<< std::endl;
-  outMTL << "# generated from Board3D from the DGTal library"<< std::endl;
+  outMTL << "# generated from Board3D from the DGtal library"<< std::endl;
   
   
   //myClippingPlaneList++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/DGtal/io/boards/Board3D.ih
+++ b/src/DGtal/io/boards/Board3D.ih
@@ -131,9 +131,15 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
   size_t k, j; //id of each elements and sub elements of a list for the .OBJ identification
   std::ofstream outOBJ; //OBJ file where to write
   std::ofstream outMTL; //MTL file where to write
+
+  //the filename without OBJ any extention
+  std::string noExt;
+  size_t lastdot = filename.find_last_of(".");
+  if (lastdot != std::string::npos)
+    noExt = filename.substr(0, lastdot);
+  else
+  noExt = filename;
   
-  
-  std::string noExt(filename.substr(0, filename.find_first_of("."))); //the filename withoutOBJ any extention
   std::stringstream nameOBJ;
   std::stringstream nameMTL;
   nameOBJ << noExt << ".obj";

--- a/src/DGtal/io/boards/Board3D.ih
+++ b/src/DGtal/io/boards/Board3D.ih
@@ -138,8 +138,8 @@ void DGtal::Board3D<Space, KSpace>::saveOBJ(const std::string & filename, const 
   if (lastdot != std::string::npos)
     noExt = filename.substr(0, lastdot);
   else
-  noExt = filename;
-  
+    noExt = filename;
+    
   std::stringstream nameOBJ;
   std::stringstream nameMTL;
   nameOBJ << noExt << ".obj";

--- a/tests/io/boards/testBoard3D.cpp
+++ b/tests/io/boards/testBoard3D.cpp
@@ -124,7 +124,7 @@ bool testQuadNorm()
   Cell surfel = k.uCell( Point( 2,3,3) );
   Display3DFactory<Space,KSpace>::drawUnorientedSurfelWithNormal( board, surfel, n2.getNormalized());
 
-  board.saveOBJ("dgtalBoard3D-quad.obj");
+  board.saveOBJ("dgtalBoard3D.quad.obj");
 
 
   nbok += true ? 1 : 0;


### PR DESCRIPTION
# PR Description

Fixes filename extension removal when exporting to OBJ in Board3D. Now the extension is given after the last dot and not the first one (exports to ```aSuper.Obj.FileName.obj``` is now possible).

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [n.a.] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
