### PR TITLE
Fix fill interior exterior 3d

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -65,7 +65,9 @@
   - Fix wrong starting point for surface tracking in example code
     frontierAndBoundary.cpp.
     (Roland Denis, [#1144](https://github.com/DGtal-team/DGtal/pull/1144))
-
+  - Fix interior/exterior fill methods of topology/helpers/Surfaces class which
+    was wrong on 3d and on closed Khalimsky space.
+    (Bertrand Kerautret, [#1156](https://github.com/DGtal-team/DGtal/pull/1156))
 
 # DGtal 0.9.1
 

--- a/src/DGtal/topology/helpers/Surfaces.ih
+++ b/src/DGtal/topology/helpers/Surfaces.ih
@@ -991,7 +991,10 @@ DGtal::Surfaces<TKSpace>::uFillInterior( const KSpace & aKSpace,
 {
   unsigned int numberCellFilled = 0;
   std::deque<Cell> pixels;      
-  Cell p =  aKSpace.uFirst(aKSpace.uCell(Point(1,1)));  
+  Cell p =  aKSpace.uFirst(aKSpace.uCell(Point::diagonal(1)));  
+  Cell lowerCell = aKSpace.uFirst(p);
+  Cell upperCell = aKSpace.uLast(p);
+ 
   bool in_mode = empty_is_inside;   
   do 
     {
@@ -1034,7 +1037,7 @@ DGtal::Surfaces<TKSpace>::uFillInterior( const KSpace & aKSpace,
 	    pixels.clear();
 	  in_mode = empty_is_inside;
 	}
-    }  while ( aKSpace.uNext(p, aKSpace.lowerCell(), aKSpace.upperCell())  );
+    }  while ( aKSpace.uNext(p, lowerCell, upperCell)  );
 
   return numberCellFilled;
 }
@@ -1054,7 +1057,10 @@ DGtal::Surfaces<TKSpace>::uFillExterior( const KSpace & aKSpace,
 {
   unsigned int numberCellFilled=0;
   std::deque<Cell> pixels;      
-  Cell p =  aKSpace.uFirst(aKSpace.uCell(Point(1,1)));  
+  Cell p =  aKSpace.uFirst(aKSpace.uCell(Point::diagonal(1)));  
+  Cell lowerCell = aKSpace.uFirst(p);
+  Cell upperCell = aKSpace.uLast(p);
+  
   bool in_mode = empty_is_outside;   
   do 
     {
@@ -1096,7 +1102,7 @@ DGtal::Surfaces<TKSpace>::uFillExterior( const KSpace & aKSpace,
 	    pixels.clear();
 	  in_mode = empty_is_outside;
 	}
-    }  while ( aKSpace.uNext(p, aKSpace.lowerCell(), aKSpace.upperCell())  );
+    }  while ( aKSpace.uNext(p, lowerCell, upperCell)  );
   return numberCellFilled;
 }
 

--- a/tests/topology/testSurfaceHelper.cpp
+++ b/tests/topology/testSurfaceHelper.cpp
@@ -192,27 +192,59 @@ test3dSurfaceHelper()
           aSet.insert(p);
         } 
      }
-  Z3i::KSpace K;
-  K.init(image.domain().lowerBound(),
-         image.domain().upperBound(), true);
-  SurfelAdjacency<3> SAdj( false );
-  std::vector<std::vector<DGtal::Z3i::SCell> > vectConnectedSCell;
-  Surfaces<DGtal::Z3i::KSpace>::extractAllConnectedSCell(vectConnectedSCell,K, SAdj, aSet, false);
-  nb++;
-  nbok += vectConnectedSCell.size()==1;
-  trace.info() << "Connected component :" << vectConnectedSCell.size() << " (should be 1) "  << std::endl;
-  trace.endBlock();
+   Z3i::KSpace Kc;
+   Kc.init(image.domain().lowerBound(),
+          image.domain().upperBound(), true);
+   SurfelAdjacency<3> SAdj( false );
+   std::vector<std::vector<DGtal::Z3i::SCell> > vectConnectedSCell;
+   Surfaces<DGtal::Z3i::KSpace>::extractAllConnectedSCell(vectConnectedSCell,Kc, SAdj, aSet, false);
+   nb++;
+   nbok += vectConnectedSCell.size()==1;
+   trace.info() << "Connected component :" << vectConnectedSCell.size() << " (should be 1) "  << std::endl;
+   trace.endBlock();
+   
+   trace.beginBlock("Test filling interior of surface (in an closed KhalimskySpaceND ) ...");
+   Image3dChar imageFilled(image.domain());
+   std::set<Z3i::SCell> setSCell; for (auto const &s: vectConnectedSCell[0]) setSCell.insert(s);
+   functors::SurfelSetPredicate<std::set<Z3i::SCell>,Z3i::SCell> surfacePred (setSCell);
   
-  trace.beginBlock("Test filling of surface ...");
-  Image3dChar imageFilled(image.domain());
-  std::set<Z3i::SCell> setSCell; for (auto const &s: vectConnectedSCell[0]) setSCell.insert(s);
-  functors::SurfelSetPredicate<std::set<Z3i::SCell>,Z3i::SCell> surfacePred (setSCell);
-  
-  unsigned int nbFilled = DGtal::Surfaces<DGtal::Z3i::KSpace>::uFillInterior(K, surfacePred, imageFilled, 1);
-  trace.info() << "Nb voxel filled:" << nbFilled << " (should be " << aSet.size() << " )"  << std::endl;
-  nb++;
-  nbok += nbFilled == aSet.size();
-  trace.endBlock();
+   unsigned int nbFilled = DGtal::Surfaces<DGtal::Z3i::KSpace>::uFillInterior(Kc, surfacePred, imageFilled, 1);
+   trace.info() << "Nb voxel filled:" << nbFilled << " (should be " << aSet.size() << " )"  << std::endl;
+   nb++;
+   nbok += nbFilled == aSet.size();
+   trace.endBlock();
+
+
+   trace.beginBlock("Test filling interior of surface (in an open  KhalimskySpaceND ) ...");
+   Z3i::KSpace ko;
+   ko.init(image.domain().lowerBound(),
+           image.domain().upperBound(), false);
+   unsigned int nbFilled2 = DGtal::Surfaces<DGtal::Z3i::KSpace>::uFillInterior(ko, surfacePred, imageFilled, 1);
+   trace.info() << "Nb voxel filled:" << nbFilled2 << " (should be " << aSet.size() << " )"  << std::endl;
+   nb++;
+   nbok += nbFilled2 == aSet.size();
+   trace.endBlock();
+
+   
+   trace.beginBlock("Test filling exterior of surface (in an closed KhalimskySpaceND ) ...");  
+   unsigned int nbFilled3 = DGtal::Surfaces<DGtal::Z3i::KSpace>::uFillExterior(Kc, surfacePred, imageFilled, 1);
+   trace.info() << "Nb voxel filled:" << nbFilled3 << " (should be " << aSet.size() << " )"  << std::endl;
+   nb++;
+   nbok += nbFilled3 == imageFilled.size()-aSet.size();
+   trace.endBlock();
+
+
+
+   trace.beginBlock("Test filling exterior of surface (in an open  KhalimskySpaceND ) ...");
+   unsigned int nbFilled4 = DGtal::Surfaces<DGtal::Z3i::KSpace>::uFillExterior(ko, surfacePred, imageFilled, 1);
+   trace.info() << "Nb voxel filled:" << nbFilled4 << " (should be " << aSet.size() << " )"  << std::endl;
+   nb++;
+   nbok += nbFilled4 == imageFilled.size()-aSet.size();
+   trace.endBlock();
+
+
+   
+   
   return nb == nbok;
 }
 


### PR DESCRIPTION
# PR Description
The method  to fill the interior/exterior was wrong with error on 3D surface when using an closes KhalimskySpaceND.  New tests with 3D surface and open/close space were added to ensure that all is fine in all cases.

# Checklist
- [n.a] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [n.a] Doxygen documentation of the code completed (classes, methods, types, members...)
- [n.a] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)