### PR TITLE
Fix tubular mesh

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -71,8 +71,8 @@
 
 - *Shape Package*
   - Fix a tubular mesh construction problem (missing faces) which appears
-    when the center line is oriented in an main axis direction (in
-    createTubularMesh()). Also improve the face construction.
+    when the center line is oriented in a main axis direction (in
+    createTubularMesh()). Also improves and fixes the face construction.
     (Bertrand Kerautret, [#1157](https://github.com/DGtal-team/DGtal/pull/1157))
 
 # DGtal 0.9.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -69,6 +69,12 @@
     was wrong on 3d and on closed Khalimsky space.
     (Bertrand Kerautret, [#1156](https://github.com/DGtal-team/DGtal/pull/1156))
 
+- *Shape Package*
+  - Fix a tubular mesh construction problem (missing faces) which appears
+    when the center line is oriented in an main axis direction (in
+    createTubularMesh()). Also improve the face construction.
+    (Bertrand Kerautret, [#1157](https://github.com/DGtal-team/DGtal/pull/1157))
+
 # DGtal 0.9.1
 
 ## New Features / Critical Changes

--- a/src/DGtal/shapes/Mesh.ih
+++ b/src/DGtal/shapes/Mesh.ih
@@ -598,24 +598,28 @@ DGtal::Mesh<TPoint>::createTubularMesh(DGtal::Mesh<TPoint> &aMesh, const std::ve
           vectDir = aSkeleton.at(i) - aSkeleton.at(i-1);
         }
       
-      double d = -vectDir[0]* aSkeleton.at(i)[0] - vectDir[1]*aSkeleton.at(i)[1] - vectDir[2]*aSkeleton.at(i)[2];
+      double d = -vectDir[0]* aSkeleton.at(i)[0] - vectDir[1]*aSkeleton.at(i)[1]
+                 - vectDir[2]*aSkeleton.at(i)[2];
       TPoint pRefOrigin;
         if(vectDir[0]!=0)
           {
             pRefOrigin [0]= -d/vectDir[0];
             pRefOrigin [1]= 0.0;
             pRefOrigin [2]= 0.0;
-            if(pRefOrigin==aSkeleton.at(i))
+            if(aSkeleton.at(i) ==  pRefOrigin ||
+               (vectDir[1]==0 && vectDir[2]==0))
               {
                 pRefOrigin[1]=-1.0;
               }
+            
           }
         else if (vectDir[1]!=0)
           {
             pRefOrigin [0]= 0.0;
             pRefOrigin [1]= -d/vectDir[1];
             pRefOrigin [2]= 0.0;
-            if(pRefOrigin==aSkeleton.at(i))
+            if(aSkeleton.at(i) ==  pRefOrigin ||
+               (vectDir[0]==0 && vectDir[2]==0))
               {
                 pRefOrigin[0]=-1.0;
               }
@@ -624,7 +628,8 @@ DGtal::Mesh<TPoint>::createTubularMesh(DGtal::Mesh<TPoint> &aMesh, const std::ve
             pRefOrigin [0]= 0.0;
             pRefOrigin [1]= 0.0;
             pRefOrigin [2]= -d/vectDir[2];
-            if(pRefOrigin==aSkeleton.at(i))
+            if(aSkeleton.at(i) ==  pRefOrigin ||
+               (vectDir[0]==0 && vectDir[1]==0))
               {
                 pRefOrigin[0]=-1.0;
               }
@@ -649,43 +654,57 @@ DGtal::Mesh<TPoint>::createTubularMesh(DGtal::Mesh<TPoint> &aMesh, const std::ve
   
   // Generating faces...
   for(unsigned int i = 0; i< aSkeleton.size()-1; i++)
-    {    
-      // Looking nearest point to obtain potential shift in face construction
-      if (aSkeleton.at(i)==aSkeleton.at(i+1)){
-        continue;
+  {
+    if (aSkeleton.at(i)==aSkeleton.at(i+1)){
+      trace.warning() << "Two skeleton points are identical, ignoring one point." << std::endl;
+      continue;
+    }
+    // Computing best shift between two consecutive ring points to generate tube face.
+    // (criteria defined by the minimal distance between 4 sampling points)
+    double minDistance = std::numeric_limits<double>::max();
+    TPoint ptRefRing1 = aMesh.getVertex(nbVertexInitial+i*nbPtPerFaces);
+    TPoint ptRefRing2 = aMesh.getVertex(nbVertexInitial+i*nbPtPerFaces+nbPtPerFaces/4);
+    TPoint ptRefRing3 = aMesh.getVertex(nbVertexInitial+i*nbPtPerFaces+2*(nbPtPerFaces/4));
+    TPoint ptRefRing4 = aMesh.getVertex(nbVertexInitial+i*nbPtPerFaces+3*(nbPtPerFaces/4));
+
+    unsigned int shift = 0;
+    TPoint vectDir;
+    if(i != aSkeleton.size()-1)
+    {
+      vectDir = aSkeleton.at(i+1) - aSkeleton.at(i);
+    }
+    else
+    {
+      vectDir = aSkeleton.at(i) - aSkeleton.at(i-1);
+    }
+    
+    for(unsigned int k=0; k<nbPtPerFaces; k++)
+    {
+      TPoint pScan1 = aMesh.getVertex(nbVertexInitial+(i+1)*nbPtPerFaces+k);
+      TPoint pScan2 = aMesh.getVertex(nbVertexInitial+(i+1)*nbPtPerFaces+
+                                        (nbPtPerFaces/4+k)%nbPtPerFaces);
+      TPoint pScan3 = aMesh.getVertex(nbVertexInitial+(i+1)*nbPtPerFaces+
+                                        (2*(nbPtPerFaces/4)+k)%nbPtPerFaces);
+      TPoint pScan4 = aMesh.getVertex(nbVertexInitial+(i+1)*nbPtPerFaces+
+                                        (3*(nbPtPerFaces/4)+k)%nbPtPerFaces);
+      double distance = (ptRefRing1 - pScan1).norm()+(ptRefRing2 - pScan2).norm()+
+                        (ptRefRing3 - pScan3).norm()+(ptRefRing4 - pScan4).norm();
+      if(distance<minDistance){
+        shift = k;
+        minDistance = distance;
       }
-      double minNormVecto = std::numeric_limits<double>::max();
-      TPoint ptRefRing = aMesh.getVertex(nbVertexInitial+i*nbPtPerFaces);
-      unsigned int shift = 0;
-      for(unsigned int k=0; k<nbPtPerFaces; k++)
-        {
-          TPoint vectDir;
-          if(i != aSkeleton.size()-1)
-            { 
-              vectDir = aSkeleton.at(i+1) - aSkeleton.at(i);
-          }
-          else
-            {
-          vectDir = aSkeleton.at(i) - aSkeleton.at(i-1);
-            }
-      TPoint dirComp = aMesh.getVertex(nbVertexInitial+k+(i+1)*nbPtPerFaces)-ptRefRing;
-      double normVecto = (dirComp/dirComp.norm()).crossProduct(vectDir/vectDir.norm()).norm();
-      if(normVecto < minNormVecto)
-        {
-          minNormVecto = normVecto;
-          shift = k;
-        }
+
     }
     for(unsigned int k=0; k<nbPtPerFaces; k++)
-      {
-        Mesh<TPoint>::MeshFace aFace;
-        aMesh.addQuadFace(nbVertexInitial+k+i*nbPtPerFaces, 
-                          nbVertexInitial+(shift+k)%nbPtPerFaces+nbPtPerFaces*(i+1), 
-                          nbVertexInitial+(shift+k+1)%nbPtPerFaces+nbPtPerFaces*(i+1),
-                          nbVertexInitial+(k+1)%nbPtPerFaces+i*nbPtPerFaces,
-                          aMeshColor);
-      }
+    {
+      Mesh<TPoint>::MeshFace aFace;
+      aMesh.addQuadFace(nbVertexInitial+k+i*nbPtPerFaces,
+                        nbVertexInitial+(shift+k)%nbPtPerFaces+nbPtPerFaces*(i+1),
+                        nbVertexInitial+(shift+k+1)%nbPtPerFaces+nbPtPerFaces*(i+1),
+                        nbVertexInitial+(k+1)%nbPtPerFaces+i*nbPtPerFaces,
+                        aMeshColor);
     }
+  }
 }
 
 
@@ -695,8 +714,8 @@ DGtal::Mesh<TPoint>::createTubularMesh(DGtal::Mesh<TPoint> &aMesh, const std::ve
 template <typename TPoint>
 template <typename TValue>
 inline
-void 
-DGtal::Mesh<TPoint>::createMeshFromHeightSequence(Mesh<TPoint> &aMesh,  const std::vector<TValue> & anValueSequence, 
+void
+DGtal::Mesh<TPoint>::createMeshFromHeightSequence(Mesh<TPoint> &aMesh,  const std::vector<TValue> & anValueSequence,
                                                   const unsigned int lengthSequence,
                                                   double stepX, double stepY, double stepZ, 
                                                   const DGtal::Color &aMeshColor ){

--- a/tests/shapes/testMesh.cpp
+++ b/tests/shapes/testMesh.cpp
@@ -312,11 +312,12 @@ bool testVisualTubularMesh()
   double radiusSpirale = 13.0;
   double radiusTube = 15.0;
   double alphaMax = 32.0;
-  for (double alpha = 0; alpha< alphaMax; alpha+= 0.1, z = z+0.5-0.05)
+  double reduc = 0.05;
+  for (double alpha = 0; alpha< alphaMax; alpha += 0.1, z += 0.5-reduc)
     {
       centerline.push_back(Z3i::RealPoint(radiusSpirale*cos(alpha), radiusSpirale*sin(alpha), z  ));
       nbPoints++;
-      radiusSpirale -=0.05;
+      radiusSpirale -=reduc;
       radiusSpirale = std::max(radiusSpirale, 0.0);
     }    
   // Generate radius:
@@ -324,7 +325,7 @@ bool testVisualTubularMesh()
   for(unsigned int i=0; i<nbPoints; i++)
     {
       vectRadius.push_back(radiusTube);
-      radiusTube -=0.05;
+      radiusTube -=reduc;
       radiusTube = std::max(radiusTube, 0.0);
     }  
 

--- a/tests/shapes/testMesh.cpp
+++ b/tests/shapes/testMesh.cpp
@@ -329,11 +329,12 @@ bool testVisualTubularMesh()
     }  
 
   DGtal::Mesh<Z3i::RealPoint> theMeshShell(true);
-  DGtal::Mesh<Z3i::RealPoint>::createTubularMesh(theMeshShell, centerline, vectRadius, 0.01);
+  DGtal::Mesh<Z3i::RealPoint>::createTubularMesh(theMeshShell, centerline, vectRadius, 0.1);
   
-  trace.info() << "Mesh generated with " << theMeshShell.nbFaces() << " faces (should be 200651)" << std::endl;
+  trace.info() << "Mesh generated with " << theMeshShell.nbFaces()
+               << " faces (should be " << (centerline.size()-1)*63 << " )" << std::endl;
   nb++;
-  nbok +=  theMeshShell.nbFaces() == 200651;
+  nbok +=  theMeshShell.nbFaces() == (centerline.size()-1)*63;
   theMeshShell >> "spiraleGeneratedFromTestMesh.off";  
   trace.info() << " [done]" << std::endl;
   trace.endBlock();
@@ -375,14 +376,15 @@ bool testVisualTubularMesh()
   DGtal::Mesh<DGtal::Z3i::RealPoint>::createTubularMesh(theMeshTube, centerLine2,
                                                         5.0, 0.2, DGtal::Color::Blue);
   
-  trace.info() << "Mesh generated with " << theMeshTube.nbFaces() << " faces (should be 10208)" << std::endl; 
+  trace.info() << "Mesh generated with " << theMeshTube.nbFaces() << " faces (should be "
+               << (centerLine2.size()-1)*32 << " )" << std::endl; 
   nb++;
-  nbok +=  theMeshTube.nbFaces() == 10208;
+  nbok +=  theMeshTube.nbFaces() == (centerLine2.size()-1)*32;
 
   theMeshTube >> "tubeGeneratedFromTestMesh.off";  
   trace.endBlock();
   
-  return nb = nbok;
+  return nb == nbok;
 
 }
 

--- a/tests/shapes/testMesh.cpp
+++ b/tests/shapes/testMesh.cpp
@@ -301,7 +301,10 @@ bool testMeshGeneration()
  */
 bool testVisualTubularMesh()
 {
-  trace.beginBlock("Testing visual tubular mesh generation:");
+  unsigned int nbok = 0;
+  unsigned int nb = 0;
+
+  trace.beginBlock("Testing visual tubular mesh generation (shell mesh):");
   // Generate the center line:
   std::vector<Z3i::RealPoint> centerline;
   unsigned int nbPoints = 0;
@@ -325,13 +328,62 @@ bool testVisualTubularMesh()
       radiusTube = std::max(radiusTube, 0.0);
     }  
 
-  DGtal::Mesh<Z3i::RealPoint> theMesh(true);
-  DGtal::Mesh<Z3i::RealPoint>::createTubularMesh(theMesh, centerline, vectRadius, 0.01);
+  DGtal::Mesh<Z3i::RealPoint> theMeshShell(true);
+  DGtal::Mesh<Z3i::RealPoint>::createTubularMesh(theMeshShell, centerline, vectRadius, 0.01);
   
-  trace.info()<< "generating done .. saving ";
-  theMesh >> "spiraleGeneratedFromTestMesh.off";  
+  trace.info() << "Mesh generated with " << theMeshShell.nbFaces() << " faces (should be 200651)" << std::endl;
+  nb++;
+  nbok +=  theMeshShell.nbFaces() == 200651;
+  theMeshShell >> "spiraleGeneratedFromTestMesh.off";  
+  trace.info() << " [done]" << std::endl;
   trace.endBlock();
-  return true;
+
+
+
+  trace.beginBlock("Testing visual tubular mesh generation (tube mesh):");
+  std::vector<Z3i::RealPoint> centerLine2;
+  centerLine2.push_back(Z3i::RealPoint(0.0,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(3.3,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(6.6,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(10.0,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(13.3,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(16.6,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(20.0,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(60.0,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(63.3,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(66.6,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(70.0,0.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(71.7,0.1,0.0));
+  centerLine2.push_back(Z3i::RealPoint(73.4,0.6,0.0));
+  centerLine2.push_back(Z3i::RealPoint(75.0,1.3,0.0));
+  centerLine2.push_back(Z3i::RealPoint(76.4,2.3,0.0));
+  centerLine2.push_back(Z3i::RealPoint(77.6,3.5,0.0));
+  centerLine2.push_back(Z3i::RealPoint(78.6,5.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(79.3,6.5,0.0));
+  centerLine2.push_back(Z3i::RealPoint(79.8,8.2,0.0));
+  centerLine2.push_back(Z3i::RealPoint(80.0,10.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(80.0,13.8,0.0));
+  centerLine2.push_back(Z3i::RealPoint(80.0,86.1,0.0));
+  centerLine2.push_back(Z3i::RealPoint(80.0,90.0,0.0));
+  centerLine2.push_back(Z3i::RealPoint(80.1,91.7,-0.1));
+  centerLine2.push_back(Z3i::RealPoint(80.6,93.4,0.1));
+  centerLine2.push_back(Z3i::RealPoint(81.3,95.0,0.1));
+  centerLine2.push_back(Z3i::RealPoint(82.3,96.4,-0.1));
+  centerLine2.push_back(Z3i::RealPoint(83.5,97.6,-0.1));
+
+  DGtal::Mesh<Z3i::RealPoint> theMeshTube(true);
+  DGtal::Mesh<DGtal::Z3i::RealPoint>::createTubularMesh(theMeshTube, centerLine2,
+                                                        5.0, 0.2, DGtal::Color::Blue);
+  
+  trace.info() << "Mesh generated with " << theMeshTube.nbFaces() << " faces (should be 10208)" << std::endl; 
+  nb++;
+  nbok +=  theMeshTube.nbFaces() == 10208;
+
+  theMeshTube >> "tubeGeneratedFromTestMesh.off";  
+  trace.endBlock();
+  
+  return nb = nbok;
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/shapes/testMesh.cpp
+++ b/tests/shapes/testMesh.cpp
@@ -294,6 +294,46 @@ bool testMeshGeneration()
   return ok;
 }
 
+
+
+/**
+ * Test the mesh object construction.
+ */
+bool testVisualTubularMesh()
+{
+  trace.beginBlock("Testing visual tubular mesh generation:");
+  // Generate the center line:
+  std::vector<Z3i::RealPoint> centerline;
+  unsigned int nbPoints = 0;
+  double z = 0.0;
+  double radiusSpirale = 13.0;
+  double radiusTube = 15.0;
+  double alphaMax = 32.0;
+  for (double alpha = 0; alpha< alphaMax; alpha+= 0.1, z = z+0.5-0.05)
+    {
+      centerline.push_back(Z3i::RealPoint(radiusSpirale*cos(alpha), radiusSpirale*sin(alpha), z  ));
+      nbPoints++;
+      radiusSpirale -=0.05;
+      radiusSpirale = std::max(radiusSpirale, 0.0);
+    }    
+  // Generate radius:
+  std::vector<double> vectRadius;
+  for(unsigned int i=0; i<nbPoints; i++)
+    {
+      vectRadius.push_back(radiusTube);
+      radiusTube -=0.05;
+      radiusTube = std::max(radiusTube, 0.0);
+    }  
+
+  DGtal::Mesh<Z3i::RealPoint> theMesh(true);
+  DGtal::Mesh<Z3i::RealPoint>::createTubularMesh(theMesh, centerline, vectRadius, 0.01);
+  
+  trace.info()<< "generating done .. saving ";
+  theMesh >> "spiraleGeneratedFromTestMesh.off";  
+  trace.endBlock();
+  return true;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Standard services - public :
 
@@ -305,7 +345,7 @@ int main( int argc, char** argv )
     trace.info() << " " << argv[ i ];
   trace.info() << endl;
 
-  bool res = testMesh() && testMeshGeneration(); // && ... other tests
+  bool res = testMesh() && testMeshGeneration() && testVisualTubularMesh(); 
   trace.emphase() << ( res ? "Passed." : "Error." ) << endl;
   trace.endBlock();
   return res ? 0 : 1;


### PR DESCRIPTION
# PR Description
Fix tubular mesh construction which could appear when a tube was oriented in an axis direction (thanks @naubry for the sequence bug). 
The face mesh generation of tubular mesh was also improved  by using distance measure instead direction.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [n.a] Doxygen documentation of the code completed (classes, methods, types, members...)
- [n.a] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)