### PR TITLE
fix an ITK reader warning

### DIFF
--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -37,8 +37,7 @@ namespace DGtal {
   throw(DGtal::IOException)
   {
     typedef typename Image::Domain Domain;
-    typedef typename Domain::Point Point;
-
+    
     typedef ImageContainerByITKImage<Domain, ValueOut> DGtalITKImage;
     typedef typename DGtalITKImage::ITKImagePointer ITKImagePointer;
     ITKImagePointer itk_image = DGtalITKImage::ITKImage::New();


### PR DESCRIPTION
# PR Description
Small PR just to remove a warning.

# Checklist

- [n.a.] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [n.a.] Doxygen documentation of the code completed (classes, methods, types, members...)
- [n.a.] Documentation module page added or updated.
- [n.a.] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
