### PR TITLE
Fixing arithmetic ring issue

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,8 +4,8 @@
 
 - *Geometry Package*
  - New robust normal vector estimator using spherical accumulators and statistical
-   voting (Boulc'h & Marlet, SGP 2012). 
-   (David Coeurjolly, [#1149](https://github.com/DGtal-team/DGtal/pull/1149)) 
+   voting (Boulc'h & Marlet, SGP 2012).
+   (David Coeurjolly, [#1149](https://github.com/DGtal-team/DGtal/pull/1149))
 
 ## Changes
 - *Configuration/General*
@@ -38,6 +38,8 @@
 - *Configuration/General*
  - Simplification of the windows build instructions. (David
    Coeurjolly, [#1160](https://github.com/DGtal-team/DGtal/pull/1160))
+ - Fixing issues raised on some algorithms when changing Euclidean ring
+   for SpaceND and KhalimskySpaceND. (Jérémy Levallois, [#1163](https://github.com/DGtal-team/DGtal/pull/1163))
 
 - *DEC Package*
  - Fixing warnings in DiscreteExteriorCalculus and DiscreteExteriorCalculusFactory.

--- a/src/DGtal/geometry/curves/AlphaThickSegmentComputer.h
+++ b/src/DGtal/geometry/curves/AlphaThickSegmentComputer.h
@@ -21,7 +21,7 @@
  * @author Bertrand Kerautret (\c kerautre@loria.fr )
  * LORIA (CNRS, UMR 7503), University of Nancy, France
  * @author Alexandre Faure
- * @author Fabien Feschet 
+ * @author Fabien Feschet
  * @author Mohammad Said
  * @author Jacques-Olivier Lachaud
  *
@@ -91,7 +91,7 @@ namespace DGtal
  * TInputPoint > .
  *
  *
- * This class is a model of boost::ForwardContainer and  CForwardSegmentComputer.  
+ * This class is a model of boost::ForwardContainer and  CForwardSegmentComputer.
  * It is also default constructible, copy  constructible, assignable and equality comparable.
  *
  *
@@ -100,21 +100,21 @@ namespace DGtal
  *  @snippet examples/geometry/curves/exampleAlphaThickSegmentNoisy.cpp exampleAlphaThickSegementNoisyTypedef
  *
  * - Then import possibly a vector containing the input points by using the PointListReader class:
- *  @snippet examples/geometry/curves/exampleAlphaThickSegmentNoisy.cpp exampleAlphaThickSegementNoisyReadFile 
- * 
- * - Finally apply the segment recognition (here of maximal thickness 15)  by adding the sequence (forward) of contour points: 
- *  @snippet examples/geometry/curves/exampleAlphaThickSegmentNoisy.cpp exampleAlphaThickSegementNoisInitAndReco 
+ *  @snippet examples/geometry/curves/exampleAlphaThickSegmentNoisy.cpp exampleAlphaThickSegementNoisyReadFile
+ *
+ * - Finally apply the segment recognition (here of maximal thickness 15)  by adding the sequence (forward) of contour points:
+ *  @snippet examples/geometry/curves/exampleAlphaThickSegmentNoisy.cpp exampleAlphaThickSegementNoisInitAndReco
  *  @note The maximal thickness given in initialization is the same than
  *  the width given by the method width() of the ParallelStrip primitive
  *  (not the vertical/horizontal width of the convex hull).
  *
- *  
+ *
  * - If you use a Board2D display, you can draw the resulting segment like other 2D objects:
- *  @snippet examples/geometry/curves/exampleAlphaThickSegmentNoisy.cpp exampleAlphaThickSegementDisplay 
- * 
+ *  @snippet examples/geometry/curves/exampleAlphaThickSegmentNoisy.cpp exampleAlphaThickSegementDisplay
+ *
  * The complete example of segment recognition is given in exampleAlphaThickSegmentNoisy.cpp
  *
- * @note You can also construct the segment by using an input point iterator in initialisation (see @ref moduleAlphaThickSegmentReco for more details) 
+ * @note You can also construct the segment by using an input point iterator in initialisation (see @ref moduleAlphaThickSegmentReco for more details)
  *
  * The proposed implementation is mainly a backport from
  * [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene) with some
@@ -130,14 +130,14 @@ class AlphaThickSegmentComputer
 
   // ----------------------- public types --------------------------------------
   BOOST_STATIC_ASSERT(( TInputPoint::dimension == 2 ));
-  BOOST_CONCEPT_ASSERT((boost_concepts::ReadableIterator<TConstIterator>)); 
- 
+  BOOST_CONCEPT_ASSERT((boost_concepts::ReadableIterator<TConstIterator>));
+
 public:
   /**
    * Type of input point.
    **/
   typedef TInputPoint InputPoint;
-  
+
   /**
    * The container type of Input Point
    **/
@@ -145,66 +145,66 @@ public:
   typedef typename InputPointContainer::size_type Size;
   typedef typename InputPointContainer::const_iterator ContainerConstIterator;
   typedef typename DGtal::functions::Hull2D::ThicknessDefinition ThicknessDef;
-  
+
   typedef typename InputPointContainer::iterator Iterator;
   typedef TConstIterator ConstIterator;
-  typedef ParallelStrip< SpaceND< 2,  DGtal::int32_t > ,true,true> Primitive;  
-  
+  typedef ParallelStrip< SpaceND< 2 > ,true,true> Primitive;  
+
   /**
-   * Type of embedded points 
+   * Type of embedded points
    * @see getBoundingBox, getBoundingBoxFromExtremPoints
    */
-  typedef DGtal::PointVector<2, double> PointD; 
+  typedef DGtal::PointVector<2, double> PointD;
 
-  typedef AlphaThickSegmentComputer<InputPoint, ConstIterator> Self; 
-  typedef AlphaThickSegmentComputer<InputPoint, ReverseIterator<ConstIterator> > Reverse; 
-  typedef DGtal::InHalfPlaneBySimple3x3Matrix<InputPoint, typename InputPoint::Component> Functor;  
+  typedef AlphaThickSegmentComputer<InputPoint, ConstIterator> Self;
+  typedef AlphaThickSegmentComputer<InputPoint, ReverseIterator<ConstIterator> > Reverse;
+  typedef DGtal::InHalfPlaneBySimple3x3Matrix<InputPoint, typename InputPoint::Component> Functor;
   typedef typename  DGtal::MelkmanConvexHull<InputPoint, Functor>::ConstIterator ConvexhullConstIterator;
-  
+
   // ----------------------- internal types --------------------------------------
 
-private: 
+private:
   struct State{
-    DGtal::MelkmanConvexHull<InputPoint, Functor> melkmanCH;  
+    DGtal::MelkmanConvexHull<InputPoint, Functor> melkmanCH;
     /** the last point added at the front of the alpha thick segment */
     InputPoint lastFront;
     /** the last point added at the back of the alpha thick segment */
     InputPoint lastBack;
-    /** one the convexhull edge point of the (edge, vertex) pair used to compute the convexhull height */ 
+    /** one the convexhull edge point of the (edge, vertex) pair used to compute the convexhull height */
     InputPoint edgePh;
-    /** one the convexhull edge point of the (edge, vertex) pair used to compute the convexhull height */ 
+    /** one the convexhull edge point of the (edge, vertex) pair used to compute the convexhull height */
     InputPoint edgeQh;
     /** one the convexhull vertex of the (edge, vertex) pair used to compute the convexhull height */
-    InputPoint vertexSh; 
+    InputPoint vertexSh;
     /*the actual thickness of the current segment*/
-    double actualThickness; 
+    double actualThickness;
   };
-    
-  
+
+
   // ----------------------- Standard services ------------------------------
 public:
-  
+
 
 
   /**
    * Constructor.
    * @param[in] maximalThickness the maximal thickness of the segment (default 1).
-   * @param[in] thicknessDefinition the definition of the thickness used in the segment extension (can be DGtal::functions::Hull2D::HorizontalVerticalThickness (default) or DGtal::functions::Hull2D::EuclideanThickness). 
+   * @param[in] thicknessDefinition the definition of the thickness used in the segment extension (can be DGtal::functions::Hull2D::HorizontalVerticalThickness (default) or DGtal::functions::Hull2D::EuclideanThickness).
    * @param[in] thickCompPrecision to adjust the precision of the
    * thickness estimation used in the comparison during the segment
    * extension (default set to 1e-6).
    */
-  AlphaThickSegmentComputer(const double maximalThickness = 1.0, 
-                            const ThicknessDef &thicknessDefinition = functions::Hull2D::HorizontalVerticalThickness, 
+  AlphaThickSegmentComputer(const double maximalThickness = 1.0,
+                            const ThicknessDef &thicknessDefinition = functions::Hull2D::HorizontalVerticalThickness,
                             const double thickCompPrecision=1e-6);
-  
-  
-  
+
+
+
   /**
    * Destructor.
    */
   ~AlphaThickSegmentComputer();
-  
+
 
   /**
    * Copy constructor.
@@ -212,7 +212,7 @@ public:
    * @param[in] other the object to clone.
    */
   AlphaThickSegmentComputer ( const AlphaThickSegmentComputer & other );
-  
+
 
   /**
    * Assignment.
@@ -221,19 +221,19 @@ public:
    * @return a reference on 'this'.
    */
   AlphaThickSegmentComputer & operator= ( const AlphaThickSegmentComputer & other );
-  
 
-  /** 
-   * @return a default-constructed instance of Self 
+
+  /**
+   * @return a default-constructed instance of Self
    */
   Self getSelf() const;
 
-  
+
   /**
    * @return a default-constructed instance of Reverse
    */
   Reverse getReverse() const;
-  
+
   /**
    * Equality operator.
    * @param other the object to compare with.
@@ -242,7 +242,7 @@ public:
    * 'false' otherwise
    */
   bool operator==( const AlphaThickSegmentComputer & other ) const;
-  
+
   /**
    * Difference operator.
    * @param other the object to compare with.
@@ -250,7 +250,7 @@ public:
    * 'true' otherwise
    */
   bool operator!=( const AlphaThickSegmentComputer & other ) const;
-    
+
 
 
   //-------------------- model of ForwardContainer -----------------------------
@@ -262,16 +262,16 @@ public:
    * iterator without the option of saving samples).
    */
   Size size() const;
-  
-  
+
+
   /**
-   * @return 'true' if and only if the container contains no point. 
+   * @return 'true' if and only if the container contains no point.
    * @note: returns always 'true' if the segment computer is initialized with a curve
    * const iterator without the option of saving samples).
    */
   bool empty() const;
-  
-  
+
+
   /**
    * @return a const iterator pointing on the first point given in the
    * container associated to the current alpha thick segment (is empty
@@ -293,7 +293,7 @@ public:
    */
   ConvexhullConstIterator convexhullBegin() const;
 
-  
+
   /**
    * @return a const iterator pointing after the last point of the
    * convex hull associated to the current alpha thick segment.
@@ -321,7 +321,7 @@ public:
    * @return the maximal allowed number of points in the current alpha thick segment.
    */
   Size max_size() const;
-  
+
 
 
 
@@ -335,10 +335,10 @@ public:
    * the width of the ParallelStrip primitive (set to 1 by default).
    *
    * @param[in] it an iterator on input points.
-   */  
-  void init(const ConstIterator &it);    
-  
-  
+   */
+  void init(const ConstIterator &it);
+
+
   /**
    * Tries to extend front the current alpha thick segment with the
    * next contour point and checks if we have still an alpha thick
@@ -359,18 +359,18 @@ public:
    *  still an alpha thick segment of width alpha_max after adding the
    *  given point \aPoint. The segment parameters are keep in its
    *  original state.
-   *  
+   *
    * @return 'true' if the segment can be extended with the given point, 'false' otherwise.
    */
   bool isExtendableFront();
 
-  
+
   /**
    *  Tests whether the current alpha thick segment can be extended, i.e
    *  checks if we have still an alpha thick segment of width alpha_max after
    *  adding the given point \aPoint. The segment parameters are keep
    *  in its original state.
-   *  
+   *
    * @param[in] aPoint the point to be tested for the segment extension.
    * @return 'true' if the segment can be extended with the given point, 'false' otherwise.
    */
@@ -389,40 +389,40 @@ public:
    * otherwise (the object is then in its original state).
    */
   bool extendFront(const InputPoint &aPoint);
-  
- 
+
+
 
   //-------------------- Primitive services -----------------------------
-  
-  
+
+
   /**
      Returns the current primitive recognized by this computer,
      which is a ParallelStrip of axis width smaller than the one
      specified at instanciation.
   */
   Primitive primitive() const;
-  
 
 
-  
+
+
     // ----------------------- Interface --------------------------------------
 public:
-  
-  
+
+
   /**
    * Checks the validity/consistency of the object.
    * @return 'true' if the object is valid, 'false' otherwise.
    */
   bool isValid() const;
-  
- 
+
+
   /**
    * Get the extremity points of the segment. These points are not
    * necessary the last point of the segment.
    *
    **/
   std::pair<InputPoint, InputPoint>  getExtremityPoints() const;
-  
+
 
   /**
    * @return the antipodal leaning points of the segment (given in the
@@ -434,30 +434,30 @@ public:
    **/
   std::pair<std::pair<InputPoint, InputPoint>, InputPoint>
   getAntipodalLeaningPoints() const;
-  
-  
+
+
   /**
    * Computes the paralell strip params from the current state of the segment.
    * @param[out] mu the minimal value of N.X (with N is the normal vector of the segment).
    * @param[out] N the normal of the vector (not normalized).
-   * @param[out] nu the width of the strip. 
+   * @param[out] nu the width of the strip.
    *
    **/
   void computeParallelStripParams(double &mu, PointD &N, double &nu) const;
-  
-  
+
+
   /**
    * @return the two values of the normal vector given as a Point(a,b)
    * (the normal is oriented toward the segment by considering the
    * edge PQ of the convexhull antipodal pair).
    **/
- 
+
   PointD getNormal() const;
 
 
   /**
    * @return the thickness of the current segment.
-   **/  
+   **/
   double getThickness() const;
 
 
@@ -465,19 +465,19 @@ public:
    * @return the mu parameter of the current segment (given from the segment ParalellStrip primitive).
    **/
   double getMu() const;
- 
- 
+
+
   /**
    * @return the nu parameter the of the current segment (given from the segment ParalellStrip primitive).
    **/
   double getNu() const;
-   
-  
+
+
    /**
    * @return the segment length defined from the bouding box (@see getBoundingBox).
    **/
   double getSegmentLength() const;
-  
+
 
   /**
    * @return 'true' if the points of the segment computer are stored in the main container.
@@ -487,7 +487,7 @@ public:
 
   /**
    * @return the total number of points beeing recognized through in the segment construction.
-   **/  
+   **/
   unsigned int getNumberSegmentPoints() const;
 
 
@@ -501,11 +501,11 @@ public:
   std::vector<InputPoint> getConvexHull() const;
 
 
-  
+
   /**
    * Computes the segment bounding box according to two extremity points (\a aFirstPt, \a aLastPt).
    * @param[in] aFirstPt the first extrem point.
-   * @param[in] aLastPt the last extrem point. 
+   * @param[in] aLastPt the last extrem point.
    * @param[out] pt1LongestSegment1 the first point of one of the longest segment.
    * @param[out] pt2LongestSegment1 the second point of one of the longest segment.
    * @param[out] pt3LongestSegment2 the first point of one of the second longest segment.
@@ -518,7 +518,7 @@ public:
    * @note the segment bounding box can be drawn with the sequence of
    * out parameters pt1LongestSegment1, pt2LongestSegment1,
    * pt3LongestSegment1, pt4LongestSegment1.
-   **/  
+   **/
   void getBoundingBoxFromExtremPoints(const InputPoint &aFirstPt,
                                       const InputPoint &aLastPt,
                                       PointD &pt1LongestSegment1,
@@ -526,8 +526,8 @@ public:
                                       PointD &pt3LongestSegment2,
                                       PointD &pt4LongestSegment2,
                                       double minVisibleWidthBounds = 0.2) const;
-  
-  
+
+
   /**
    * Computes the segment bounding box defined from the extremity
    * points computed after a scan of the current convexhull. Note that
@@ -550,10 +550,10 @@ public:
                       PointD &pt2LongestSegment1,
                       PointD &pt3LongestSegment2,
                       PointD &pt4LongestSegment2) const;
-  
-    
-  
-  
+
+
+
+
 
   /**
    * @return the style name used for drawing this object.
@@ -567,22 +567,22 @@ public:
    * @param[out] out the output stream where the object is written.
    */
   void selfDisplay ( std::ostream & out ) const;
-  
+
     // ------------------------- Protected Datas ------------------------------
 protected:
-  
- 
+
+
   /**
    * begin iterator (associated to input data)
    **/
   ConstIterator myBegin;
-  
+
   /**
    * begin iterator (associated to input data)
    **/
   ConstIterator myEnd;
-  
-    
+
+
 
 
     // ------------------------- Private Datas --------------------------------
@@ -591,15 +591,15 @@ private:
   /**
    * The set of points contained in the alpha thick segment which can be changed during computations.
    **/
-  mutable InputPointContainer myPointContainer; 
+  mutable InputPointContainer myPointContainer;
 
   /**
    * The maximal thickness of the segment.
    */
-  double myMaximalThickness;  
+  double myMaximalThickness;
 
   /**
-   * To adjust the precision of the thickness estimation used in the comparison during the segment extension. 
+   * To adjust the precision of the thickness estimation used in the comparison during the segment extension.
    */
   double myThicknessCompPrecision;
 
@@ -609,54 +609,54 @@ private:
    */
   ThicknessDef myThicknessDefinition;
 
-  
+
   /**
    * State of the actual computer
-   **/ 
+   **/
   State myState;
 
   /**
    * Previous saved computer state
-   **/   
+   **/
   mutable State myPreviousState;
-  
+
   bool myIsStoringPoints;
-  
+
   /**
    * Used by the size method.
    **/
   unsigned int myNbPointsAddedFromIterators;
 
-  
-  
+
+
 
     // ------------------------- Hidden services ------------------------------
 protected:
 
-  
+
 
   /**
    * Depending on connexity, return true if a convex is valid.
    */
   bool melkmanIsConvexValid() ;
-  
+
 
   /**
    *  Updates the main height of the melkman convex hull
    *   and update the antipodal pairs.
-   * 
+   *
    * @return the thickness of the segment (thickness defined by
    * default as the vertical/horizontal width (see @ref
    * moduleAlphaThickSegmentReco for more details).
    **/
-  double updateMainHeightAndAntiPodal();   
-  
- 
-  
+  double updateMainHeightAndAntiPodal();
+
+
+
   /**
    * Computes the projection of a Point \a ptC on the real line defined by the two points (\a ptA, \a ptB), and
    * return true if the projected point is inside the segment closed interval [A,B].
-   * 
+   *
    * @param[in] ptA one of the two points defining the straight line.
    * @param[in] ptB one of the two points defining the straight line.
    * @param[in] ptC the point to be projected.
@@ -666,7 +666,7 @@ protected:
   template<typename TPointD>
   bool projectOnStraightLine(const TPointD & ptA, const TPointD & ptB,
                              const TPointD & ptC, PointD & ptProjected) const;
-  
+
 
   /**
    * From an point iterator (\a itBegin and \a itEnd) it computes the
@@ -677,13 +677,13 @@ protected:
    * @param[in] itEnd the end iterator of the input points.
    * @param[out] aFirstExtrPt the first extrem point.
    * @param[out] aLastExtrPt the last extrem point.
-   * 
+   *
    **/
   template<typename TConstIteratorG>
   void computeExtremaPoints(const TConstIteratorG & itBegin, const TConstIteratorG & itEnd,
                             InputPoint & aFirstExtrPt, InputPoint & aLastExtrPt) const;
-  
-  
+
+
     // ------------------------- Internals ------------------------------------
 private:
 

--- a/src/DGtal/geometry/curves/AlphaThickSegmentComputer.h
+++ b/src/DGtal/geometry/curves/AlphaThickSegmentComputer.h
@@ -148,7 +148,7 @@ public:
 
   typedef typename InputPointContainer::iterator Iterator;
   typedef TConstIterator ConstIterator;
-  typedef ParallelStrip< SpaceND< 2 > ,true,true> Primitive;  
+  typedef ParallelStrip< SpaceND< 2, DGtal::int32_t > ,true,true> Primitive;  
 
   /**
    * Type of embedded points

--- a/src/DGtal/geometry/volumes/distance/PowerMap.h
+++ b/src/DGtal/geometry/volumes/distance/PowerMap.h
@@ -92,7 +92,7 @@ namespace DGtal
     */
   template < typename TWeightImage,
              typename TPowerSeparableMetric,
-             typename TImageContainer = 
+             typename TImageContainer =
              ImageContainerBySTLVector<HyperRectDomain<typename TWeightImage::Domain::Space>,
                                        typename TWeightImage::Domain::Space::Vector> >
   class PowerMap
@@ -102,7 +102,7 @@ namespace DGtal
 
     BOOST_CONCEPT_ASSERT(( concepts::CConstImage< TWeightImage > ));
     BOOST_CONCEPT_ASSERT(( concepts::CPowerSeparableMetric<TPowerSeparableMetric> ));
-    
+
     ///Copy of the distance image types
     typedef TWeightImage WeightImage;
     typedef typename TWeightImage::Value Weight;
@@ -115,46 +115,46 @@ namespace DGtal
 
     //ImageContainer::Domain::Space must match with TSpace
     BOOST_STATIC_ASSERT ((boost::is_same< typename TWeightImage::Domain::Space,
-                          typename TImageContainer::Domain::Space >::value )); 
-    
+                          typename TImageContainer::Domain::Space >::value ));
+
     //ImageContainer value type must be  TSpace::Vector
     BOOST_STATIC_ASSERT ((boost::is_same< typename TWeightImage::Domain::Space::Vector,
-                          typename TImageContainer::Value >::value )); 
-    
+                          typename TImageContainer::Value >::value ));
+
     //ImageContainer domain type must be  HyperRectangular
     BOOST_STATIC_ASSERT ((boost::is_same< HyperRectDomain<typename TWeightImage::Domain::Space>,
-					  typename TImageContainer::Domain >::value )); 
- 
+					  typename TImageContainer::Domain >::value ));
+
     ///Definition of the underlying domain type.
     typedef typename TImageContainer::Domain Domain;
-   
-    ///We construct the type associated to the separable metric 
+
+    ///We construct the type associated to the separable metric
     typedef TPowerSeparableMetric PowerSeparableMetric;
-    
+
     ///Type of resulting image
     typedef TImageContainer OutputImage;
-    
+
     ///Definition of the image model value type.
     typedef Vector Value;
     ///Definition of the image value type.
     typedef typename OutputImage::ConstRange  ConstRange;
-  
+
     ///Self type
   typedef PowerMap<TWeightImage, TPowerSeparableMetric, TImageContainer> Self;
-    
+
 
     /**
      * Constructor.
-     * 
+     *
      * This constructor computes the Power Map of a set of point
      * sites using a SeparableMetric metric.  The method associates to
      * each point satisfying the foreground predicate, the closest
-     * site for which the predicate is false. 
+     * site for which the predicate is false.
      *
      * All parameters are aliased in this class.
      *
      * @param aDomain defines the (hyper-rectangular) domain on which
-     * the computation is performed.  
+     * the computation is performed.
      * @param aWeightImage an image
      * returning the weight for some points
      * @param aMetric a power
@@ -179,7 +179,7 @@ namespace DGtal
      *  @return a reference to Self
      */
     Self &  operator=(const Self &aOtherPowerMap );
-    
+
     /**
      * Returns a reference (const) to the Power map domain.
      *  @return a domain
@@ -189,7 +189,7 @@ namespace DGtal
       return *myDomainPtr;
     }
 
-    
+
     /**
      * Returns a const range on the Power map values.
      *  @return a const range
@@ -198,7 +198,7 @@ namespace DGtal
     {
       return myImagePtr->constRange();
     }
-        
+
     /**
      * Access to a Power value (a.k.a. vector to the closest site) at a point.
      *
@@ -207,9 +207,9 @@ namespace DGtal
     Value operator()(const Point &aPoint) const
     {
       return myImagePtr->operator()(aPoint);
-    }    
- 
-    /** 
+    }
+
+    /**
      * @return  Returns the underlying metric.
      */
     const PowerSeparableMetric* metricPtr() const
@@ -217,7 +217,7 @@ namespace DGtal
       return myMetricPtr;
     }
 
-    /** 
+    /**
      * @return  Returns the underlying weight image.
      */
     const WeightImage* weightImagePtr() const
@@ -227,14 +227,14 @@ namespace DGtal
 
     /**
      * Self Display method.
-     * 
+     *
      * @param out output stream
      */
-    void selfDisplay ( std::ostream & out ) const;    
-       
+    void selfDisplay ( std::ostream & out ) const;
+
     // ------------------- Private functions ------------------------
-  private:    
-    
+  private:
+
     /**
      * Compute the Power Map of a set of point sites using a
      * SeparableMetric metric.  The method associates to each point
@@ -244,60 +244,60 @@ namespace DGtal
     void compute ( ) ;
 
 
-    /** 
+    /**
      *  Compute the other steps of the separable Power map.
-     * 
+     *
      * @param dim the dimension to process
-     */    
+     */
     void computeOtherSteps(const Dimension dim) const;
-    /** 
+    /**
      * Given  a voronoi map valid at dimension @a dim-1, this method
      * updates the map to make it consistent at dimension @a dim along
      * the 1D span starting at @a row along the dimension @a
      * dim.
-     * 
+     *
      * @param row starting point of the 1D process.
      * @param dim dimension of the update.
      */
-    void computeOtherStep1D (const Point &row, 
-			     const Size dim) const;
-    
+    void computeOtherStep1D (const Point &row,
+			     const Dimension dim) const;
+
     // ------------------- protected methods ------------------------
   protected:
 
-    /** 
+    /**
      * Default Constructor.
-     * 
+     *
      */
     PowerMap();
-   
-    
+
+
     // ------------------- Private members ------------------------
   private:
 
     ///Pointer to the computation domain
     const Domain * myDomainPtr;
-    
+
     ///Copy of the image lower bound
     Point myLowerBoundCopy;
-    
+
     ///Copy of the image lower bound
     Point myUpperBoundCopy;
-    
+
     ///Value to act as a +infinity value
     Point myInfinity;
 
   protected:
     ///Pointer to the separable metric instance
     const PowerSeparableMetric * myMetricPtr;
-    
+
     ///Power map image
     CountedPtr<OutputImage> myImagePtr;
- 
+
     ///Pointer to the point predicate
     const WeightImage * myWeightImagePtr;
-    
- 
+
+
   }; // end of class PowerMap
 
  /**

--- a/src/DGtal/geometry/volumes/distance/PowerMap.ih
+++ b/src/DGtal/geometry/volumes/distance/PowerMap.ih
@@ -50,16 +50,16 @@ template < typename W, typename Sep, typename Im>
 inline
 DGtal::PowerMap< W,Sep,Im>::~PowerMap()
 {
-} 
+}
 
 
 template < typename W, typename Sep, typename Im>
 inline
-typename DGtal::PowerMap<W, Sep,Im>::Self &  
-DGtal::PowerMap<W, Sep,Im>::operator=(const Self &aOtherPowerMap ) 
+typename DGtal::PowerMap<W, Sep,Im>::Self &
+DGtal::PowerMap<W, Sep,Im>::operator=(const Self &aOtherPowerMap )
 {
   if (this != &aOtherPowerMap)
-    { 
+    {
       myMetricPtr = aOtherPowerMap.myMetricPtr;
       myImagePtr = aOtherPowerMap.myImagePtr;
       myWeightImagePtr = aOtherPowerMap.myWeightImagePtr;
@@ -79,10 +79,10 @@ DGtal::PowerMap<W, Sep,Im>::compute( )
   //We copy the image extent
   myLowerBoundCopy = myDomainPtr->lowerBound();
   myUpperBoundCopy = myDomainPtr->upperBound();
- 
-  //Point outside the domain 
+
+  //Point outside the domain
   myInfinity = myDomainPtr->upperBound() + Point::diagonal(1);
-  
+
   //Init the map: the power map at point p is:
   //  - p if p is an input weighted point (with weight > 0);
   //  - myInfinity otherwise.
@@ -112,21 +112,21 @@ DGtal::PowerMap<W, Sep,Im>::computeOtherSteps ( const Dimension dim ) const
 #endif
 
   typedef typename Domain::ConstSubRange::ConstIterator ConstDomIt;
-  
+
   //We setup the subdomain iterator
   //the iterator will scan dimension using the order:
   // {n-1, n-2, ... 1} (we skip the '0' dimension).
-  std::vector<Size> subdomain;
+  std::vector<Dimension> subdomain;
   subdomain.reserve(W::Domain::Space::dimension - 1);
   for (unsigned int k = 0; k < W::Domain::Space::dimension ; k++)
     if ( ((int)W::Domain::Space::dimension - 1 - k) != dim)
       subdomain.push_back( (int)W::Domain::Space::dimension - 1 - k );
-  
+
   Domain localDomain(myLowerBoundCopy, myUpperBoundCopy);
-  
-  
+
+
 #ifdef WITH_OPENMP
-  //Parallel loop 
+  //Parallel loop
   std::vector<Point> subRangePoints;
   //Starting point precomputation
   for (ConstDomIt it = localDomain.subRange( subdomain ).begin(),
@@ -138,7 +138,7 @@ DGtal::PowerMap<W, Sep,Im>::computeOtherSteps ( const Dimension dim ) const
   for (size_t i = 0; i < subRangePoints.size(); ++i)
     computeOtherStep1D ( subRangePoints[i], dim);
 
-#else  
+#else
   //We solve the 1D problems sequentially
   for (ConstDomIt it = localDomain.subRange( subdomain ).begin(),
 	 itend = localDomain.subRange( subdomain ).end();
@@ -156,20 +156,20 @@ DGtal::PowerMap<W, Sep,Im>::computeOtherSteps ( const Dimension dim ) const
 template <typename W, typename Sep, typename Im>
 void
 DGtal::PowerMap<W,Sep,Im>::computeOtherStep1D ( const Point &startingPoint,
-                                                const Size dim) const
+                                                const Dimension dim) const
 {
   Point point = startingPoint;
   Point endpoint = startingPoint;
   Point psite;
   int nbSites = -1;
   std::vector<Point> Sites;
-  
-  //Reserve 
+
+  //Reserve
   Sites.reserve( myUpperBoundCopy[dim] - myLowerBoundCopy[dim] +1);
 
   //endpoint of the 1D row
   endpoint[dim] = myUpperBoundCopy[dim];
-  
+
   //Pruning the list of sites (dim=0 implies no hidden sites)
   if (dim==0)
     {
@@ -191,14 +191,14 @@ DGtal::PowerMap<W,Sep,Im>::computeOtherStep1D ( const Point &startingPoint,
 	{
 	  psite = myImagePtr->operator()(point);
 	  if ( psite != myInfinity )
-	    {        
-	      while ((nbSites >= 1) && 
+	    {
+	      while ((nbSites >= 1) &&
 		     ( myMetricPtr->hiddenByPower(Sites[nbSites-1], myWeightImagePtr->operator()(Sites[nbSites-1]),
 						  Sites[nbSites] ,  myWeightImagePtr->operator()(Sites[nbSites]),
 						  psite,  myWeightImagePtr->operator()(psite),
 						  startingPoint, endpoint, dim) ))
 		{
-		  nbSites --; 
+		  nbSites --;
                   Sites.pop_back();
 		}
 	      nbSites++;
@@ -218,15 +218,15 @@ DGtal::PowerMap<W,Sep,Im>::computeOtherStep1D ( const Point &startingPoint,
   point[dim] = myLowerBoundCopy[dim];
   for(Abscissa i = myLowerBoundCopy[dim] ;  i <= myUpperBoundCopy[dim] ;  i++)
     {
-      while ( (k < nbSites) && 
-	      ( myMetricPtr->closestPower(point, 
+      while ( (k < nbSites) &&
+	      ( myMetricPtr->closestPower(point,
 					  Sites[k], myWeightImagePtr->operator()(Sites[k]),
 					  Sites[k+1],myWeightImagePtr->operator()(Sites[k+1]))
 		!= DGtal::ClosestFIRST ))
         k++;
       myImagePtr->setValue(point, Sites[k]);
       point[dim]++;
-    } 
+    }
 }
 
 
@@ -238,10 +238,10 @@ inline
 DGtal::PowerMap<W,TSep,Im>::PowerMap( ConstAlias<Domain> aDomain,
                                       ConstAlias<WeightImage> aWeightImage,
                                       ConstAlias<PowerSeparableMetric> aMetric):
-  myDomainPtr(&aDomain), 
+  myDomainPtr(&aDomain),
   myMetricPtr(&aMetric),
   myWeightImagePtr(&aWeightImage)
-  
+
 {
   myImagePtr = CountedPtr<OutputImage>(new OutputImage(aDomain));
   compute();
@@ -252,7 +252,7 @@ inline
 void
 DGtal::PowerMap<W,TSep,Im>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[PowerMap] power separable metric=" << *myMetricPtr ; 
+  out << "[PowerMap] power separable metric=" << *myMetricPtr ;
 }
 
 
@@ -262,7 +262,7 @@ DGtal::PowerMap<W,TSep,Im>::selfDisplay ( std::ostream & out ) const
 template <typename W,typename TSep,typename Im>
 inline
 std::ostream&
-DGtal::operator<< ( std::ostream & out, 
+DGtal::operator<< ( std::ostream & out,
 		    const PowerMap<W,TSep,Im> & object )
 {
   object.selfDisplay( out );
@@ -271,5 +271,3 @@ DGtal::operator<< ( std::ostream & out,
 
 // //                                                                           //
 // ///////////////////////////////////////////////////////////////////////////////
-
-

--- a/src/DGtal/geometry/volumes/distance/VoronoiMap.h
+++ b/src/DGtal/geometry/volumes/distance/VoronoiMap.h
@@ -106,7 +106,7 @@ namespace DGtal
   template < typename TSpace,
              typename TPointPredicate,
              typename TSeparableMetric,
-             typename TImageContainer = 
+             typename TImageContainer =
              ImageContainerBySTLVector<HyperRectDomain<TSpace>,
                                        typename TSpace::Vector>
              >
@@ -120,20 +120,20 @@ namespace DGtal
 
     ///Both Space points and PointPredicate points must be the same.
     BOOST_STATIC_ASSERT ((boost::is_same< typename TSpace::Point,
-                          typename TPointPredicate::Point >::value )); 
- 
+                          typename TPointPredicate::Point >::value ));
+
     //ImageContainer::Domain::Space must match with TSpace
     BOOST_STATIC_ASSERT ((boost::is_same< TSpace,
-                          typename TImageContainer::Domain::Space >::value )); 
-   
+                          typename TImageContainer::Domain::Space >::value ));
+
     //ImageContainer value type must be  TSpace::Vector
     BOOST_STATIC_ASSERT ((boost::is_same< typename TSpace::Vector,
-                          typename TImageContainer::Value >::value )); 
- 
+                          typename TImageContainer::Value >::value ));
+
     //ImageContainer domain type must be  HyperRectangular
     BOOST_STATIC_ASSERT ((boost::is_same< HyperRectDomain<TSpace>,
-					  typename TImageContainer::Domain >::value )); 
-    
+					  typename TImageContainer::Domain >::value ));
+
     ///Copy of the space type.
     typedef TSpace Space;
 
@@ -154,23 +154,23 @@ namespace DGtal
     typedef typename Space::Dimension Dimension;
     typedef typename Space::Size Size;
     typedef typename Space::Point::Coordinate Abscissa;
- 
+
     ///Type of resulting image
     typedef TImageContainer OutputImage;
      ///Definition of the image value type.
     typedef Vector Value;
-    
+
     ///Definition of the image value type.
     typedef typename OutputImage::ConstRange  ConstRange;
 
     ///Self type
-    typedef VoronoiMap<TSpace, TPointPredicate, 
+    typedef VoronoiMap<TSpace, TPointPredicate,
 		       TSeparableMetric,TImageContainer> Self;
-    
+
 
     /**
      * Constructor.
-     * 
+     *
      * This constructor computes the Voronoi Map of a set of point
      * sites using a SeparableMetric metric.  The method associates to
      * each point satisfying the foreground predicate, the closest
@@ -183,7 +183,7 @@ namespace DGtal
      *
      * @param predicate a pointer to the point predicate to define the
      * Voronoi sites (false points).
-     * 
+     *
      *@param aMetric a pointer to the separable metric instance.
      */
     VoronoiMap(ConstAlias<Domain> aDomain,
@@ -205,7 +205,7 @@ namespace DGtal
      *  @return a reference to Self
      */
     Self &  operator=(const Self &aOtherVoronoiMap );
-    
+
     /**
      * Returns a reference (const) to the Voronoi map domain.
      * @return a domain
@@ -215,7 +215,7 @@ namespace DGtal
       return *myDomainPtr;
     }
 
-    
+
     /**
      * Returns a const range on the Voronoi map values.
      *  @return a const range
@@ -224,7 +224,7 @@ namespace DGtal
     {
       return myImagePtr->constRange();
     }
-        
+
     /**
      * Access to a Voronoi value (a.k.a. vector to the closest site)
      * at a point.
@@ -234,9 +234,9 @@ namespace DGtal
     Value operator()(const Point &aPoint) const
     {
       return myImagePtr->operator()(aPoint);
-    }    
-     
-    /** 
+    }
+
+    /**
      * @return Returns an alias to the underlying metric.
      */
     const SeparableMetric* metric() const
@@ -246,14 +246,14 @@ namespace DGtal
 
     /**
      * Self Display method.
-     * 
+     *
      * @param out output stream
      */
-    void selfDisplay ( std::ostream & out ) const;    
-   
+    void selfDisplay ( std::ostream & out ) const;
+
     // ------------------- Private functions ------------------------
-  private:    
-    
+  private:
+
     /**
      * Compute the Voronoi Map of a set of point sites using a
      * SeparableMetric metric.  The method associates to each point
@@ -263,49 +263,49 @@ namespace DGtal
     void compute ( ) ;
 
 
-    /** 
+    /**
      *  Compute the other steps of the separable Voronoi map.
-     * 
+     *
      * @param [in] dim the dimension to process
-     */    
+     */
     void computeOtherSteps(const Dimension dim) const;
-    /** 
+    /**
      * Given  a voronoi map valid at dimension @a dim-1, this method
      * updates the map to make it consistent at dimension @a dim along
      * the 1D span starting at @a row along the dimension @a
      * dim.
-     * 
+     *
      * @param [in] row starting point of the 1D process.
      * @param [in] dim dimension of the update.
      */
-    void computeOtherStep1D (const Point &row, 
-			     const Size dim) const;
-    
+    void computeOtherStep1D (const Point &row,
+			     const Dimension dim) const;
+
     // ------------------- protected methods ------------------------
   protected:
 
-    /** 
+    /**
      * Default Constructor.
-     * 
+     *
      */
     VoronoiMap();
-   
-    
+
+
     // ------------------- Private members ------------------------
   private:
 
     ///Pointer to the computation domain
     const Domain * myDomainPtr;
-    
+
     ///Pointer to the point predicate
     const PointPredicate * myPointPredicatePtr;
-    
+
     ///Copy of the image lower bound
     Point myLowerBoundCopy;
-    
+
     ///Copy of the image lower bound
     Point myUpperBoundCopy;
-    
+
     ///Value to act as a +infinity value
     Point myInfinity;
 

--- a/src/DGtal/geometry/volumes/distance/VoronoiMap.ih
+++ b/src/DGtal/geometry/volumes/distance/VoronoiMap.ih
@@ -112,7 +112,7 @@ DGtal::VoronoiMap<S,P, TSep, TImage>::computeOtherSteps ( const Dimension dim ) 
   //We setup the subdomain iterator
   //the iterator will scan dimension using the order:
   // {n-1, n-2, ... 1} (we skip the '0' dimension).
-  std::vector<Size> subdomain;
+  std::vector<Dimension> subdomain;
   subdomain.reserve(S::dimension - 1);
   for ( int k = 0; k < (int)S::dimension ; k++)
     if ( static_cast<Dimension>(((int)S::dimension - 1 - k)) != dim)
@@ -151,7 +151,7 @@ DGtal::VoronoiMap<S,P, TSep, TImage>::computeOtherSteps ( const Dimension dim ) 
 template <typename S,typename P, typename TSep, typename TImage>
 void
 DGtal::VoronoiMap<S,P,TSep, TImage>::computeOtherStep1D ( const Point &startingPoint,
-                                                  const Size dim) const
+                                                  const Dimension dim) const
 {
   Point point = startingPoint;
   Point endpoint = startingPoint;

--- a/src/DGtal/images/RigidTransformation3D.h
+++ b/src/DGtal/images/RigidTransformation3D.h
@@ -264,7 +264,9 @@ public:
         points[6] = transform ( Point ( aInput.lowerBound()[0], aInput.lowerBound()[1], aInput.upperBound()[2] ) );
         points[7] = transform ( Point ( aInput.upperBound()[0], aInput.upperBound()[1], aInput.lowerBound()[2] ) );
 
-        Point t_min ( INT_MAX, INT_MAX, INT_MAX ), t_max ( INT_MIN, INT_MIN, INT_MIN );
+        typename Point::Component cmax = std::numeric_limits<typename Point::Component>::max();
+        typename Point::Component cmin = std::numeric_limits<typename Point::Component>::min();
+        Point t_min ( cmax, cmax, cmax ), t_max ( cmin, cmin, cmin );
         for ( int i = 0; i < 8; i++ )
         {
             if ( points[i][0] < t_min[0] )

--- a/src/DGtal/io/Display2DFactory.ih
+++ b/src/DGtal/io/Display2DFactory.ih
@@ -44,10 +44,11 @@ DGtal::Display2DFactory::drawDECSignedKhalimskyCell(DGtal::Board2D& board, const
     FATAL_ERROR( dim == 2 );
     //FIXME: as for Display3D models, embedder should be factorized
     //and not instantiated at each call.
-    typedef DGtal::CanonicSCellEmbedder<DGtal::Z2i::KSpace> Embedder;
-    const DGtal::Z2i::KSpace K{};
+    typedef DGtal::KhalimskySpaceND<dim, TInteger> KSpace;
+    typedef DGtal::CanonicSCellEmbedder<KSpace> Embedder;
+    const KSpace K{};
     const Embedder embedder( K );
-    const Embedder::RealPoint coords = embedder(sk);
+    const typename Embedder::RealPoint coords = embedder(sk);
     const float x = coords[0];
     const float y = coords[1];
     const float retract = 0.1f;
@@ -435,7 +436,7 @@ void DGtal::Display2DFactory::draw( DGtal::Board2D & board,
 
 // AlphaThickSegmentComputer
 template <typename TInputPoint,  typename TConstIterator>
-void DGtal::Display2DFactory::drawAsBoundingBox( DGtal::Board2D & aBoard, 
+void DGtal::Display2DFactory::drawAsBoundingBox( DGtal::Board2D & aBoard,
                                                  const DGtal::AlphaThickSegmentComputer< TInputPoint, TConstIterator>  & anAlphaThickSegment){
   typedef DGtal::PointVector<2,double> PointD;
 
@@ -450,7 +451,7 @@ void DGtal::Display2DFactory::drawAsBoundingBox( DGtal::Board2D & aBoard,
 
 
 template < typename TInputPoint, typename TConstIterator>
-void DGtal::Display2DFactory::drawAsDigitalPoints( DGtal::Board2D & aBoard, 
+void DGtal::Display2DFactory::drawAsDigitalPoints( DGtal::Board2D & aBoard,
                                                    const DGtal::AlphaThickSegmentComputer< TInputPoint, TConstIterator> & anAlphaThickSegment){
   typedef typename DGtal::AlphaThickSegmentComputer< TInputPoint, TConstIterator>::ContainerConstIterator ContConstIterator;
   typedef TConstIterator ConstIterator;
@@ -460,7 +461,7 @@ void DGtal::Display2DFactory::drawAsDigitalPoints( DGtal::Board2D & aBoard,
     {
       std::vector<LibBoard::Point> contour;
       if (anAlphaThickSegment.isStoringSegmentPoints()){
-        for (ContConstIterator it = anAlphaThickSegment.containerBegin(); 
+        for (ContConstIterator it = anAlphaThickSegment.containerBegin();
              it != anAlphaThickSegment.containerEnd(); it++) {
           Point p = *it;
           double xp = NumberTraits<typename TInputPoint::Component>::castToDouble(p[0]);
@@ -482,21 +483,21 @@ void DGtal::Display2DFactory::drawAsDigitalPoints( DGtal::Board2D & aBoard,
     }
   // Draw points
   if (anAlphaThickSegment.isStoringSegmentPoints()){
-    for (ContConstIterator it = anAlphaThickSegment.containerBegin(); 
+    for (ContConstIterator it = anAlphaThickSegment.containerBegin();
          it != anAlphaThickSegment.containerEnd(); it++) {
       Point p = *it;
-     draw(aBoard,p );  
+     draw(aBoard,p );
     }
   }else {
     for (ConstIterator it = anAlphaThickSegment.begin(); it != anAlphaThickSegment.end(); it++) {
       Point p = *it;
-    draw(aBoard,p );  
-    }  
+    draw(aBoard,p );
+    }
   }
 }
 
 template < typename TInputPoint,  typename TConstIterator>
-void DGtal::Display2DFactory::draw( DGtal::Board2D & aBoard, 
+void DGtal::Display2DFactory::draw( DGtal::Board2D & aBoard,
                                     const DGtal::AlphaThickSegmentComputer< TInputPoint,  TConstIterator>  & anAlphaThickSegment ){
   std::string mode = aBoard.getMode( anAlphaThickSegment.className() );
   if ( mode == "BoundingBox" )
@@ -607,7 +608,7 @@ void DGtal::Display2DFactory::drawSector(Board2D & aBoard, const DGtal::CircleFr
 
 template <typename Point>
 inline
-void DGtal::Display2DFactory::drawAnnulus(Board2D & aBoard, const DGtal::CircleFrom3Points<Point> & cf3p, 
+void DGtal::Display2DFactory::drawAnnulus(Board2D & aBoard, const DGtal::CircleFrom3Points<Point> & cf3p,
 					  const Point& aPoint1, const Point& aPoint2, bool anOrientation, const double& w)
 {
   typedef typename Point::Coordinate Coordinate;
@@ -1047,11 +1048,11 @@ void DGtal::Display2DFactory::drawFill( DGtal::Board2D & aBoard,
 
 // SCellsRange
 template <typename TIterator, typename TSCell>
-void DGtal::Display2DFactory::draw( DGtal::Board2D & aBoard, 
+void DGtal::Display2DFactory::draw( DGtal::Board2D & aBoard,
            const ConstRangeAdapter<TIterator, functors::Identity, TSCell> & object )
 {
-    typedef ConstRangeAdapter<TIterator, functors::Identity, TSCell> Range; 
-    typedef typename Range::ConstIterator ConstIterator; 
+    typedef ConstRangeAdapter<TIterator, functors::Identity, TSCell> Range;
+    typedef typename Range::ConstIterator ConstIterator;
 
     ConstIterator it ( object.begin() );
     ConstIterator itEnd ( object.end() );
@@ -1456,9 +1457,9 @@ void DGtal::Display2DFactory::draw( DGtal::Board2D & board,
 
 // CubicalComplex
 template < typename TKSpace, typename TCellContainer >
-inline 
-void 
-DGtal::Display2DFactory::draw( DGtal::Board2D & board, 
+inline
+void
+DGtal::Display2DFactory::draw( DGtal::Board2D & board,
              const DGtal::CubicalComplex<TKSpace, TCellContainer> & cc )
 {
   FATAL_ERROR( cc.dimension == 2);
@@ -1666,5 +1667,3 @@ DGtal::Display2DFactory::draw
 
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
-
-

--- a/src/DGtal/io/DrawWithDisplay3DModifier.h
+++ b/src/DGtal/io/DrawWithDisplay3DModifier.h
@@ -41,6 +41,7 @@
 // Inclusions
 #include <iostream>
 #include "DGtal/base/Common.h"
+#include "DGtal/helpers/StdDefs.h"
 #include "DGtal/base/Alias.h"
 #include "DGtal/base/ConstAlias.h"
 #include "DGtal/images/CConstImage.h"
@@ -180,11 +181,11 @@ struct TransformedPrism : public DrawWithDisplay3DModifier
   /**
      * Constructor.
      *
-     * @param aSurfel a DGtal::Z3i::SCell ( KhalimskySpaceND< 2, Integer > SCell ) .
+     * @param aSurfel a DGtal::Z3i::SCell ( KhalimskySpaceND< 3, Integer > SCell ) .
      * @param aShift the shift distance (positive or negative).
      * @param aSizeFactor use to change the Prism size (1.0 initial size).
      */
-  TransformedPrism( const DGtal::KhalimskySpaceND< 3, int >::SCell  & aSurfel,
+  TransformedPrism( const DGtal::Z3i::SCell  & aSurfel,
                           double aShift, double aSizeFactor=1.0 ):mySurfel(aSurfel), myShift(aShift), mySizeFactor(aSizeFactor)
   {
   }
@@ -193,13 +194,13 @@ struct TransformedPrism : public DrawWithDisplay3DModifier
   /**
      * Constructor.
      *
-     * @param aSurfel a DGtal::Z3i::SCell ( KhalimskySpaceND< 2, Integer > SCell ) .
+     * @param aSurfel a DGtal::Z3i::SCell ( KhalimskySpaceND< 3, Integer > SCell ) .
      * @param aVoxel a  DGtal::Z3i::SCell represent the voxel for which the surfel is associated. It permits to determine automatically the shift parameter (the surfel is automatically shifted towards this voxel).
      * @param aShift the shift distance (positive or negative (default 0.05)).
      * @param aSizeFactor use to change the Prism size (default 0.75).
      */
-  TransformedPrism( const DGtal::KhalimskySpaceND< 3, int >::SCell  & aSurfel,
-                          const DGtal::KhalimskySpaceND< 3, int >::SCell  & aVoxel,
+  TransformedPrism( const DGtal::Z3i::SCell  & aSurfel,
+                          const DGtal::Z3i::SCell  & aVoxel,
                           double aShift=0.05, double aSizeFactor=0.75  )
   {
     mySurfel= aSurfel;
@@ -221,7 +222,7 @@ struct TransformedPrism : public DrawWithDisplay3DModifier
   }
 
   ///@todo FIX this member
-  DGtal::KhalimskySpaceND< 3, int >::SCell mySurfel;
+  DGtal::Z3i::SCell mySurfel;
   double myShift;
   double mySizeFactor;
 };
@@ -240,7 +241,7 @@ struct TransformedPrism : public DrawWithDisplay3DModifier
   struct SetName3D : public DrawWithDisplay3DModifier {
     /// Sets the "OpenGL name" of future display command(s).
     /// @param aName any integer: an identifier for later selection or -1 for none.
-    SetName3D( DGtal::int32_t aName = -1 ) : name( aName ) {} 
+    SetName3D( DGtal::int32_t aName = -1 ) : name( aName ) {}
     /// @return the class name as a string.
     std::string className() const { return "SetName3D"; }
     /// the "OpenGL name" for selection, or -1 for none.
@@ -258,9 +259,9 @@ struct TransformedPrism : public DrawWithDisplay3DModifier
     /// graphical element and a pointer toward the data that was given
     /// at construction of SetSelectCallback3D.
     typedef int (*CallbackFct)( void* viewer, DGtal::int32_t name, void* data );
-    SetSelectCallback3D( CallbackFct f, 
+    SetSelectCallback3D( CallbackFct f,
                          void* data,
-                         DGtal::int32_t min = 0, DGtal::int32_t max = 0x7fffffff ) 
+                         DGtal::int32_t min = 0, DGtal::int32_t max = 0x7fffffff )
       : myFct( f ), myData( data ), myMin( min ), myMax( max ) {}
     /// @return the class name as a string.
     std::string className() const { return "SetSelectCallback3D"; }

--- a/src/DGtal/kernel/BasicPointFunctors.h
+++ b/src/DGtal/kernel/BasicPointFunctors.h
@@ -44,6 +44,7 @@
 #include <iostream>
 #include <iterator>
 #include "DGtal/base/Common.h"
+#include "DGtal/helpers/StdDefs.h"
 #include "DGtal/kernel/SpaceND.h"
 #include "DGtal/kernel/NumberTraits.h"
 #include "DGtal/base/BasicBoolFunctors.h"
@@ -62,60 +63,60 @@ namespace functors
   // template class Projector
   /**
    * Description of template class 'Projector' <p>
-   * \brief Aim: Functor that maps 
+   * \brief Aim: Functor that maps
    * a point P of dimension i
    * to a point Q of dimension j.
-   * The member @a myDims is an array containing the 
+   * The member @a myDims is an array containing the
    * coordinates - (0, 1, ..., j-1) by default -
-   * that are copied from P to Q. 
+   * that are copied from P to Q.
    *
-   * Ex: for i = 3 and j = 2, the first two coordinates 
-   * (numbered 0 and 1) are copied so that point (x,y,z) is 
-   * is mapped to point (x,y).    
-   * 
-   * All kth coordinates (0 < k < j) that are greater than i, 
-   * are set to a value given at construction (0 by defaut). 
+   * Ex: for i = 3 and j = 2, the first two coordinates
+   * (numbered 0 and 1) are copied so that point (x,y,z) is
+   * is mapped to point (x,y).
    *
-   * Ex: for i = 2 and j = 3, the first two coordinates 
-   * (numbered 0 and 1) are copied so that point (x,y) is 
-   * is mapped to point (x,y,0).    
+   * All kth coordinates (0 < k < j) that are greater than i,
+   * are set to a value given at construction (0 by defaut).
    *
-   * Instead of using the default order, you can define your own 
-   * orthonormal basis as shown below: 
+   * Ex: for i = 2 and j = 3, the first two coordinates
+   * (numbered 0 and 1) are copied so that point (x,y) is
+   * is mapped to point (x,y,0).
+   *
+   * Instead of using the default order, you can define your own
+   * orthonormal basis as shown below:
    *
    * @code
 
-   PointVector<3,int> p(3,1,5): 
+   PointVector<3,int> p(3,1,5):
 
-   Projector<SpaceND<2,int> > proj; 
+   Projector<SpaceND<2,int> > proj;
    proj( p ) //== (3,1)
 
    ...
    //v (2, 0): selection of the 2nd and 0th basis vectors
-   proj.init(v.begin(), v.end()); 
+   proj.init(v.begin(), v.end());
    proj( p ) //== (5,3)
 
    * @endcode
    *
    * @tparam S type for the space where must lie the projected point
    */
-  template <typename S = SpaceND< 2, DGtal::int32_t > >
+  template <typename S = SpaceND< 2, DGtal::Z2i::Integer > >
   struct Projector
   {
     typedef S Space;
     typedef typename Space::Dimension Dimension;
     BOOST_STATIC_CONSTANT( Dimension, dimension = Space::dimension );
-    typedef typename Space::Integer Integer; 
-    typedef typename Space::Point Point; 
+    typedef typename Space::Integer Integer;
+    typedef typename Space::Point Point;
 
     /**
      * Default constructor
      */
     Projector(const Integer& aDefaultInteger = NumberTraits<Integer>::zero());
 
-    
+
     /**
-     * Initialization of the array of relevant dimensions 
+     * Initialization of the array of relevant dimensions
      * @param itb begin iterator on dimensions.
      * @param ite end iterator on dimensions.
      */
@@ -144,21 +145,21 @@ namespace functors
     template<typename TInputPoint>
     Point operator()( const TInputPoint& aPoint ) const;
 
-  private: 
+  private:
     /**
-     * Array storing the coordinates that are copied from 
+     * Array storing the coordinates that are copied from
      * the input point to its projection (order matters)
      */
-    std::array<Dimension, dimension> myDims; 
-    
+    std::array<Dimension, dimension> myDims;
+
     /**
      * Default integer set to coordinates of the projected point
      * not in the input point
      */
-    Integer myDefaultInteger; 
+    Integer myDefaultInteger;
 
   }; // end of class ConstantPointFunctors
-  
+
 
 
 
@@ -175,117 +176,117 @@ namespace functors
    * Ex: a Point P (10, 9) in the domain (defined (0,0,0) (10,10,10))
    * given in 3D by adding the dimension in Z (2) with slice num 7: =>
    * P(10, 9, 7) and after a rotation of PI from center of slice domain (5,5, 7)
-   * will give P(0,1,7). 
+   * will give P(0,1,7).
    * To apply this example you can test it with:
-   * @code 
+   * @code
    // Defining the domain
    PointVector<3, int> pt1(0,0, 0);
    PointVector<3, int> pt2(10,10, 10);
    HyperRectDomain<SpaceND<3, int> >  domain (pt1, pt2);
-   // The functor on axis rotation set to 2 with new Z slice num=7 and angle 3.15: 
+   // The functor on axis rotation set to 2 with new Z slice num=7 and angle 3.15:
    SliceRotator2D< HyperRectDomain<SpaceND<3, int> >, int> sliceRot2(2, domain, 7, 2, 3.14);
-   PointVector<2, int> pt_2(10, 9);  
+   PointVector<2, int> pt_2(10, 9);
    trace.info() <<  sliceRot2(pt_2);
    @endcode
    *
    *
-   * @tparam TDomain3D the type of the 3d domain. 
-   * @tparam TInteger specifies the integer number type used to define the space. 
+   * @tparam TDomain3D the type of the 3d domain.
+   * @tparam TInteger specifies the integer number type used to define the space.
    *
    */
-  template <typename TDomain3D, typename TInteger =  DGtal::int32_t >
+  template <typename TDomain3D, typename TInteger =  DGtal::Z3i::Integer >
   class SliceRotator2D
   {
   public:
-        
+
     typedef SpaceND< 3, TInteger>  Space;
-    typedef typename Space::Dimension Dimension; 
-    typedef typename Space::Point Point; 
-    typedef typename Space::Integer Integer; 
-    /** 
+    typedef typename Space::Dimension Dimension;
+    typedef typename Space::Point Point;
+    typedef typename Space::Integer Integer;
+    /**
      * Constructor.
      * (default point is defined from lower point of the domain)
      * @param dimAdded  the index of the new dimension inserted.
-     * @param aDomain3DImg the 3D domain used to keep the resulting point in the domain. 
-     * @param sliceIndex the value that is used to fill the dimension for a given N-1 point (equivalently the slice index).  
+     * @param aDomain3DImg the 3D domain used to keep the resulting point in the domain.
+     * @param sliceIndex the value that is used to fill the dimension for a given N-1 point (equivalently the slice index).
      * @param dimRotated the index of the rotation axis.
      * @param rotationAngle the angle of rotation (in radians).
      */
-    
-    SliceRotator2D( const Dimension &dimAdded, const TDomain3D &aDomain3DImg, 
+
+    SliceRotator2D( const Dimension &dimAdded, const TDomain3D &aDomain3DImg,
                     const Integer &sliceIndex,  const Dimension &dimRotated,
                     double rotationAngle):
-      myPosDimAdded(dimAdded), mySliceIndex(sliceIndex), myDomain(aDomain3DImg), 
+      myPosDimAdded(dimAdded), mySliceIndex(sliceIndex), myDomain(aDomain3DImg),
       myDimRotated(dimRotated), myRotationAngle(rotationAngle), myDefaultPoint (aDomain3DImg.lowerBound())
     {
-      myCenter[0] = aDomain3DImg.lowerBound()[0]+((aDomain3DImg.upperBound())[0]-(aDomain3DImg.lowerBound())[0])/2.0;  
-      myCenter[1] = aDomain3DImg.lowerBound()[1]+((aDomain3DImg.upperBound())[1]-(aDomain3DImg.lowerBound())[1])/2.0;  
-      myCenter[2] = aDomain3DImg.lowerBound()[2]+((aDomain3DImg.upperBound())[2]-(aDomain3DImg.lowerBound())[2])/2.0;  
+      myCenter[0] = aDomain3DImg.lowerBound()[0]+((aDomain3DImg.upperBound())[0]-(aDomain3DImg.lowerBound())[0])/2.0;
+      myCenter[1] = aDomain3DImg.lowerBound()[1]+((aDomain3DImg.upperBound())[1]-(aDomain3DImg.lowerBound())[1])/2.0;
+      myCenter[2] = aDomain3DImg.lowerBound()[2]+((aDomain3DImg.upperBound())[2]-(aDomain3DImg.lowerBound())[2])/2.0;
       myCenter[dimAdded]=sliceIndex;
     };
-    
-    /** 
+
+    /**
      * Constructor.
      * @param dimAdded  the index of the new dimension inserted.
-     * @param aDomain3DImg the 3D domain used to keep the resulting point in the domain. 
-     * @param sliceIndex the value that is used to fill the dimension for a given N-1 point (equivalently the slice index).  
+     * @param aDomain3DImg the 3D domain used to keep the resulting point in the domain.
+     * @param sliceIndex the value that is used to fill the dimension for a given N-1 point (equivalently the slice index).
      * @param dimRotated the index of the rotation axis.
      * @param rotationAngle the angle of rotation (in radians).
      * @param defaultPoint the point given when the resulting point is outside the domain.
      */
-    
-    SliceRotator2D( const Dimension &dimAdded, const TDomain3D &aDomain3DImg, 
+
+    SliceRotator2D( const Dimension &dimAdded, const TDomain3D &aDomain3DImg,
                     const Integer &sliceIndex,  const Dimension &dimRotated,
                     double rotationAngle,  const Point &defaultPoint):
-      myPosDimAdded(dimAdded), mySliceIndex(sliceIndex), myDomain(aDomain3DImg), 
+      myPosDimAdded(dimAdded), mySliceIndex(sliceIndex), myDomain(aDomain3DImg),
       myDimRotated(dimRotated), myRotationAngle(rotationAngle), myDefaultPoint (defaultPoint)
     {
-      myCenter[0] = aDomain3DImg.lowerBound()[0]+((aDomain3DImg.upperBound())[0]-(aDomain3DImg.lowerBound())[0])/2.0;  
-      myCenter[1] = aDomain3DImg.lowerBound()[1]+((aDomain3DImg.upperBound())[1]-(aDomain3DImg.lowerBound())[1])/2.0;  
-      myCenter[2] = aDomain3DImg.lowerBound()[2]+((aDomain3DImg.upperBound())[2]-(aDomain3DImg.lowerBound())[2])/2.0;  
+      myCenter[0] = aDomain3DImg.lowerBound()[0]+((aDomain3DImg.upperBound())[0]-(aDomain3DImg.lowerBound())[0])/2.0;
+      myCenter[1] = aDomain3DImg.lowerBound()[1]+((aDomain3DImg.upperBound())[1]-(aDomain3DImg.lowerBound())[1])/2.0;
+      myCenter[2] = aDomain3DImg.lowerBound()[2]+((aDomain3DImg.upperBound())[2]-(aDomain3DImg.lowerBound())[2])/2.0;
       myCenter[dimAdded]=sliceIndex;
     };
 
-    /** 
+    /**
      * Constructor.
      * @param dimAdded  the index of the new dimension inserted.
-     * @param aDomain3DImg the 3D domain used to keep the resulting point in the domain. 
-     * @param sliceIndex the value that is used to fill the dimension for a given N-1 point (equivalently the slice index).  
+     * @param aDomain3DImg the 3D domain used to keep the resulting point in the domain.
+     * @param sliceIndex the value that is used to fill the dimension for a given N-1 point (equivalently the slice index).
      * @param dimRotated the index of the rotation axis.
      * @param ptCenter the rotation center.
      * @param rotationAngle the angle of rotation (in radians).
      * @param defaultPoint the point given when the resulting point is outside the domain.
      */
-    
+
     SliceRotator2D( const Dimension &dimAdded, const TDomain3D &aDomain3DImg, const Integer &sliceIndex,
                     const Dimension &dimRotated,  const Point &ptCenter, double rotationAngle, const Point &defaultPoint):
-      myPosDimAdded(dimAdded), mySliceIndex(sliceIndex), myDomain(aDomain3DImg), 
+      myPosDimAdded(dimAdded), mySliceIndex(sliceIndex), myDomain(aDomain3DImg),
       myDimRotated(dimRotated), myRotationAngle(rotationAngle), myCenter(ptCenter), myDefaultPoint (defaultPoint)
     {
     };
 
-    /** 
+    /**
      * Constructor.
      * (default point is defined from lower point of the domain)
      * @param dimAdded  the index of the new dimension inserted.
-     * @param aDomain3DImg the 3D domain used to keep the resulting point in the domain. 
-     * @param sliceIndex the value that is used to fill the dimension for a given N-1 point (equivalently the slice index).  
+     * @param aDomain3DImg the 3D domain used to keep the resulting point in the domain.
+     * @param sliceIndex the value that is used to fill the dimension for a given N-1 point (equivalently the slice index).
      * @param dimRotated the index of the rotation axis.
      * @param ptCenter the rotation center.
      * @param rotationAngle the angle of rotation (in radians).
      */
-    
+
     SliceRotator2D( const Dimension &dimAdded, const TDomain3D &aDomain3DImg, const Integer &sliceIndex,
                     const Dimension &dimRotated,  const Point &ptCenter, double rotationAngle):
-      myPosDimAdded(dimAdded), mySliceIndex(sliceIndex), myDomain(aDomain3DImg), 
+      myPosDimAdded(dimAdded), mySliceIndex(sliceIndex), myDomain(aDomain3DImg),
       myDimRotated(dimRotated), myRotationAngle(rotationAngle), myCenter(ptCenter), myDefaultPoint (aDomain3DImg.lowerBound())
     {
     };
-    
-    /** 
+
+    /**
      * The operator just recover the 3D Point associated to the SliceRotator2D parameters.
      * @param[in] aPoint point of the input domain (of dimension N-1).
-     * 
+     *
      * @return the point of dimension 3.
      */
     template <typename TPointDimMinus>
@@ -300,7 +301,7 @@ namespace functors
           if(i!=myPosDimAdded)
             {
               pt[i]= aPoint[pos];
-              pos++; 
+              pos++;
             }else
             {
               pt[i]=mySliceIndex;
@@ -313,10 +314,10 @@ namespace functors
         }
       double d1 = pt[indexesRotate[0]] - myCenter[indexesRotate[0]];
       double d2 = pt[indexesRotate[1]] - myCenter[indexesRotate[1]];
-      
-      pt[indexesRotate[0]] = myCenter[indexesRotate[0]] + static_cast<Integer>(floor(d1*cos(myRotationAngle)-d2*sin(myRotationAngle) )); 
+
+      pt[indexesRotate[0]] = myCenter[indexesRotate[0]] + static_cast<Integer>(floor(d1*cos(myRotationAngle)-d2*sin(myRotationAngle) ));
       pt[indexesRotate[1]] = myCenter[indexesRotate[1]] + static_cast<Integer>(floor(d1*sin(myRotationAngle)+d2*cos(myRotationAngle) ));
-      
+
       if(myDomain.isInside(pt))
         return pt;
       else
@@ -343,9 +344,9 @@ namespace functors
    * It also checks if the resulting point is inside the 3D domain,
    * else it returns a particular point (by default the point at
    * domain origin (from the domain method lowerBound())).
-   *   
+   *
    * It can be used to extract 2D images from volumetric files. For
-   * instance (see full example images/extract2DImagesFrom3D.cpp): 
+   * instance (see full example images/extract2DImagesFrom3D.cpp):
    *
    * - First some image types and ConstImageAdapter are defined to exploit the functor:
    * @snippet examples/images/extract2DImagesFrom3d.cpp extract2DImagesFrom3DType
@@ -355,36 +356,36 @@ namespace functors
    *
    * - The 2D image we can now be  constructed from the embeder and from the ConstImageAdapter class:
    * @snippet examples/images/extract2DImagesFrom3d.cpp extract2DImagesFrom3DOExtract
-   *   
+   *
    * - Alternatively, you can also construct the same functor from a reference center point, a normal, and a size:
    * @snippet examples/images/extract2DImagesFrom3d.cpp extract2DImagesFrom3DOExtract2
-   *  
    *
-   * @see tests/kernel/testBasicPointFunctors.cpp 
-   * @tparam TDomain3D the type of the 3d domain. 
-   * @tparam TInteger specifies the integer number type used to define the space. 
+   *
+   * @see tests/kernel/testBasicPointFunctors.cpp
+   * @tparam TDomain3D the type of the 3d domain.
+   * @tparam TInteger specifies the integer number type used to define the space.
    *
    */
-  template <typename TDomain3D, typename TInteger =  DGtal::int32_t >
+  template <typename TDomain3D, typename TInteger =  DGtal::Z3i::Integer >
   class Point2DEmbedderIn3D
   {
   public:
-        
+
     typedef SpaceND< 3, TInteger>  Space;
-    typedef typename Space::Point Point; 
-    typedef typename Space::Integer Integer; 
-    
-    /** 
+    typedef typename Space::Point Point;
+    typedef typename Space::Integer Integer;
+
+    /**
      * Constructor.
      * Construct the functor from an origin 3D point, and two other 3D points defining the upper part of the 2D domain.
-     * @param aDomain3DImg  the 3D domain used to keep the resulting point in the domain. 
-     * @param anOriginPoint the origin point given in the 3D domain. 
+     * @param aDomain3DImg  the 3D domain used to keep the resulting point in the domain.
+     * @param anOriginPoint the origin point given in the 3D domain.
      * @param anUpperPointOnAxis1 the upper point given in the 3D domain to define the first axis of the 2D domain.
      * @param anUpperPointOnAxis2 the upper point given in the 3D domain to define the second axis of the 2D domain.
      * @param aDefautPoint the point given when the resulting point is outside the domain (default Point(0,0,0)).
      */
-    
-    Point2DEmbedderIn3D( const TDomain3D &aDomain3DImg, 
+
+    Point2DEmbedderIn3D( const TDomain3D &aDomain3DImg,
                          const Point &anOriginPoint, const Point &anUpperPointOnAxis1,
                          const Point &anUpperPointOnAxis2,
                          const Point &aDefautPoint = Point(0,0,0)): myDomain(aDomain3DImg),
@@ -396,27 +397,27 @@ namespace functors
       mySecondAxisEmbeddedDirection(Point(anUpperPointOnAxis2[0]-anOriginPoint[0],
                                           anUpperPointOnAxis2[1]-anOriginPoint[1],
                                           anUpperPointOnAxis2[2]-anOriginPoint[2]))
-      
-      
-    {    
+
+
+    {
       myFirstAxisEmbeddedDirection /= myFirstAxisEmbeddedDirection.norm();
       mySecondAxisEmbeddedDirection /= mySecondAxisEmbeddedDirection.norm();
     }
 
 
-    /** 
+    /**
      * Constructor.
      * Construct the functor from an origin 3D point, an normal vector (normal to the 2D domain), and a width.
-     * The points of an 2D domain are embedded in 3D by using a normal vector giving the direction of the 2D domain embedded in the 3D space. 
-     * @param aDomain3DImg  the 3D domain used to keep the resulting point in the domain. 
-     * @param anOriginPoint the center point given in the 3D domain. 
-     * @param anNormalVector the normal vector to the 2d domain embedded in 3D. 
+     * The points of an 2D domain are embedded in 3D by using a normal vector giving the direction of the 2D domain embedded in the 3D space.
+     * @param aDomain3DImg  the 3D domain used to keep the resulting point in the domain.
+     * @param anOriginPoint the center point given in the 3D domain.
+     * @param anNormalVector the normal vector to the 2d domain embedded in 3D.
      * @param anWidth the width to determine the 2d domain bounds (the resulting 2d domain will be a square of length anWidth).
      * @param aDefautPoint the point given when the resulting point is outside the domain (default Point(0,0,0)).
      *
      */
-   
-    Point2DEmbedderIn3D( const TDomain3D &aDomain3DImg, 
+
+    Point2DEmbedderIn3D( const TDomain3D &aDomain3DImg,
                          const Point &anOriginPoint, const typename Space::RealPoint & anNormalVector,
                          const typename Point::Component  &anWidth,
                          const Point &aDefautPoint = Point(0,0,0)): myDomain(aDomain3DImg),
@@ -452,22 +453,22 @@ namespace functors
       uDir2[0] = uDir1[1]*anNormalVector[2]-uDir1[2]*anNormalVector[1];
       uDir2[1] = uDir1[2]*anNormalVector[0]-uDir1[0]*anNormalVector[2];
       uDir2[2] = uDir1[0]*anNormalVector[1]-uDir1[1]*anNormalVector[0];
-      
+
       uDir2/=uDir2.norm();
 
       myOriginPointEmbeddedIn3D = anOriginPoint + uDir1*anWidth/2 + uDir2*anWidth/2;
       myFirstAxisEmbeddedDirection = -uDir1;
       mySecondAxisEmbeddedDirection = -uDir2;
-      
+
     }
 
-   
 
 
-    /** 
+
+    /**
      * The operator just recover the 3D Point associated to the Point2DEmbederIn3D parameters.
      * @param[in] aPoint point of the input domain (of dimension 2).
-     * 
+     *
      * @return the digital point of dimension 3 (value rounded downward with floor).
      */
     template <typename TPoint2D>
@@ -484,7 +485,7 @@ namespace functors
       }
 
       if(myDomain.isInside(pt)|| !chechInsideDomain)
-        {          
+        {
           return pt;
         }
       else
@@ -498,9 +499,9 @@ namespace functors
 
   private:
     TDomain3D myDomain;
-    
-    // Origin (or lower point) of the 2D image embedded in the 3D domain 
-    Point  myOriginPointEmbeddedIn3D;    
+
+    // Origin (or lower point) of the 2D image embedded in the 3D domain
+    Point  myOriginPointEmbeddedIn3D;
 
     Point myDefaultPoint;
 
@@ -509,14 +510,14 @@ namespace functors
 
     // Point giving the direction of the embedded second axis of the 2D image.
     typename Space::RealPoint mySecondAxisEmbeddedDirection;
-    
+
   };
 
 
   /**
    * \brief Create a point functor from a point predicate and a domain.
    */
-  template< typename TPointPredicate, typename TDomain, typename TValue=DGtal::int32_t >
+  template< typename TPointPredicate, typename TDomain, typename TValue=typename TDomain::Integer >
   struct PointFunctorFromPointPredicateAndDomain
   {
       typedef TPointPredicate PointPredicate;
@@ -574,9 +575,9 @@ namespace functors
    * ImageAdapter class.
    *
    *
-   * @see tests/kernel/testBasicPointFunctors.cpp 
-   * @tparam TDomain the type of the domain. 
-   * @tparam TInteger specifies the integer number type used to define the space. 
+   * @see tests/kernel/testBasicPointFunctors.cpp
+   * @tparam TDomain the type of the domain.
+   * @tparam TInteger specifies the integer number type used to define the space.
    *
    * @tparam TValue specify the type of the value which define the
    * grid size (generally type int (default) when subsampling with large grid size
@@ -586,25 +587,25 @@ namespace functors
  template <typename TDomain, typename TInteger =  DGtal::int32_t, typename TValue = DGtal::uint32_t >
  class BasicDomainSubSampler
   {
-  public:        
+  public:
     typedef typename TDomain::Space  Space;
-    typedef typename TDomain::Size Size; 
-    typedef typename Space::Dimension Dimension; 
-    typedef typename Space::Point Point; 
+    typedef typename TDomain::Size Size;
+    typedef typename Space::Dimension Dimension;
+    typedef typename Space::Point Point;
 
-    /** 
+    /**
      * Constructor.
      * Construct the functor from a source domain, a grid size, and a shift vector.
      * The points of the resulting domain are defined as the upper left of the sampling grid.
      *
-     * @param aSourceDomain  the source domain. 
-     * @param aGridSize the subsampling grid size. 
-     * @param aGridShift the shift applied to the sampling grid. 
+     * @param aSourceDomain  the source domain.
+     * @param aGridSize the subsampling grid size.
+     * @param aGridShift the shift applied to the sampling grid.
      *
      */
-    
+
     BasicDomainSubSampler(const TDomain &aSourceDomain, const std::vector<TValue> &aGridSize,
-                          const Point  &aGridShift): mySourceDomain(aSourceDomain), 
+                          const Point  &aGridShift): mySourceDomain(aSourceDomain),
                                                      myGridShift(aGridShift),
                                                      myGridSize(aGridSize)
     {
@@ -615,16 +616,16 @@ namespace functors
         domainLowerBound[dim] /= aGridSize[dim];
         domainUpperBound[dim] /= aGridSize[dim];
       }
-      myNewDomain = TDomain(domainLowerBound, 
+      myNewDomain = TDomain(domainLowerBound,
                             domainUpperBound);
       Point upperGrid;
       for (Dimension dim=0; dim < Space::dimension; dim++)
         upperGrid[dim] = myGridSize[dim];
       myGridSampleDomain = TDomain(Point::diagonal(0), upperGrid);
-    };    
-    
+    };
 
-    /** 
+
+    /**
      * The operator computes the coordinates of the point in the
      * subsampled domain.  By default it returns the first lower point
      * of the window associated to the sampling grid. If the resulting
@@ -632,11 +633,11 @@ namespace functors
      * returns a point belonging to the source domain. If such a point
      * does not exits it return the point with null coordinates.
      *
-     * @param aPoint a point which should  belong to the new domain.  
+     * @param aPoint a point which should  belong to the new domain.
      * @return the point to be taken in the subsampled domain.
      *
      */
-    
+
     inline
     Point  operator()(const Point& aPoint) const
     {
@@ -648,10 +649,10 @@ namespace functors
 
       for (Dimension dim=0; dim< Space::dimension; dim++){
         ptRes[dim] = static_cast<TInteger>(floor(NumberTraits<TInteger>::castToDouble(aPoint[dim])*
-                                                 NumberTraits<TValue>::castToDouble(myGridSize[dim]))); 
+                                                 NumberTraits<TValue>::castToDouble(myGridSize[dim])));
       }
       ptRes +=myGridShift;
-      
+
       if(!mySourceDomain.isInside(ptRes)){
         // we are looking for a point inside the domain
         for(typename TDomain::ConstIterator it = myGridSampleDomain.begin();
@@ -662,31 +663,31 @@ namespace functors
       }
       return ptRes;
     }
-    
-    /** 
+
+    /**
      * This method can be usefull to directely recover the new domain
      * associated to the resulting subsampled domain.
      * @return the new subsampled domain.
      */
-    
+
     inline
     const TDomain & getSubSampledDomain(){
       return myNewDomain;
-    } 
-    
+    }
+
   private:
     TDomain mySourceDomain;
-    TDomain myNewDomain;    
+    TDomain myNewDomain;
     // used to search a point when the resulting point is outside the source domain.
-    TDomain myGridSampleDomain;     
+    TDomain myGridSampleDomain;
     Point myGridShift;
-    std::vector<TValue> myGridSize;    
+    std::vector<TValue> myGridSize;
  };
 
 
   /**
    * Description of template class 'FlipDomainAxis' <p> \brief Aim:
-   * Functor that flips the domain coordinate system from some 
+   * Functor that flips the domain coordinate system from some
    * selected axis.  For instance, if a flip on the y axis is applied
    * on a domain of bounds (0, 0, 0) (MaxX, MaxY, MaxZ), then the
    * coordinate of P(x,y,z) will transformed in P(x, MaxY-y, z).
@@ -695,63 +696,63 @@ namespace functors
    * flip from some specific axis directions.
    *
    *
-   * @see tests/kernel/testBasicPointFunctors.cpp 
+   * @see tests/kernel/testBasicPointFunctors.cpp
    *
-   * @tparam TDomain the type of the domain. 
+   * @tparam TDomain the type of the domain.
    *
    */
 
  template <typename TDomain>
  class FlipDomainAxis
   {
-  public:        
+  public:
     typedef typename TDomain::Space  Space;
-    typedef typename TDomain::Size Size; 
-    typedef typename Space::Dimension Dimension; 
-    typedef typename Space::Point Point; 
+    typedef typename TDomain::Size Size;
+    typedef typename Space::Dimension Dimension;
+    typedef typename Space::Point Point;
 
-    /** 
+    /**
      * Constructor.
      * Construct the functor from a source domain and a vector defining the axis being flipped.
-     * Such a vector should contain the dimension number associated to the axis to be flipped. 
-     * For instance to flip the x and z axis of a given 3d domain you have to give a vector 
-     * containing 1 and 2. 
+     * Such a vector should contain the dimension number associated to the axis to be flipped.
+     * For instance to flip the x and z axis of a given 3d domain you have to give a vector
+     * containing 1 and 2.
      *
-     * @param aSourceDomain  the source domain. 
-     * @param axisFlipped a vector containing  the indices of the dimension to be flipped. 
+     * @param aSourceDomain  the source domain.
+     * @param axisFlipped a vector containing  the indices of the dimension to be flipped.
      *
      */
-    
-    FlipDomainAxis(const TDomain &aSourceDomain, const std::vector<Size> & axisFlipped): mySourceDomain(aSourceDomain), 
-                                                                                         myAxisFlipped(axisFlipped){      
-    };    
-    
 
-    /** 
+    FlipDomainAxis(const TDomain &aSourceDomain, const std::vector<Size> & axisFlipped): mySourceDomain(aSourceDomain),
+                                                                                         myAxisFlipped(axisFlipped){
+    };
+
+
+    /**
      * The operator computes the coordinates of the point in the
-     * flipped domain.  
+     * flipped domain.
      *
      * @param aPoint a source point.
      * @return the point with flipped coordinates according the source domain.
      *
      */
-    
+
     inline
     Point  operator()(const Point& aPoint) const
     {
       Point ptRes;
       for (Dimension dim=0; dim< Space::dimension; dim++){
-        ptRes[dim] = aPoint[dim]; 
+        ptRes[dim] = aPoint[dim];
       }
       for(Dimension i = 0; i< myAxisFlipped.size(); i++){
         ptRes[myAxisFlipped[i]] = mySourceDomain.upperBound()[myAxisFlipped[i]]-aPoint[myAxisFlipped[i]];
-      }      
+      }
       return ptRes;
     }
-    
+
   private:
     TDomain mySourceDomain;
-    std::vector<Size> myAxisFlipped;    
+    std::vector<Size> myAxisFlipped;
  };
 
 

--- a/tests/geometry/curves/testAlphaThickSegmentComputer.cpp
+++ b/tests/geometry/curves/testAlphaThickSegmentComputer.cpp
@@ -67,54 +67,54 @@ bool testAlphaThickSegmentConvexHullAndBox()
   anAlphaThickSegmentComputer3.init(aContour.begin());
   AlphaThickSegmentComputer2D anAlphaThickSegmentComputer4(1);
   anAlphaThickSegmentComputer4.init(aContour.begin());
-  
-  
-  while (anAlphaThickSegmentComputer.end() != aContour.end() && 
-         anAlphaThickSegmentComputer.extendFront()){}  
+
+
+  while (anAlphaThickSegmentComputer.end() != aContour.end() &&
+         anAlphaThickSegmentComputer.extendFront()){}
   while (anAlphaThickSegmentComputer2.end() != aContour.end() &&
          anAlphaThickSegmentComputer2.extendFront() ){}
-  while (anAlphaThickSegmentComputer3.end() != aContour.end() && 
+  while (anAlphaThickSegmentComputer3.end() != aContour.end() &&
          anAlphaThickSegmentComputer3.extendFront()){}
   while (anAlphaThickSegmentComputer4.end() != aContour.end() &&
          anAlphaThickSegmentComputer4.extendFront()){}
 
-    
+
   // Display convexhull
   aBoard.setLineWidth(5);
   aBoard.setPenColor(DGtal::Color::Purple);
   for (AlphaThickSegmentComputer2D::ConvexhullConstIterator it = anAlphaThickSegmentComputer.convexhullBegin();
        it != anAlphaThickSegmentComputer.convexhullEnd(); it++){
     if ((it+1) != anAlphaThickSegmentComputer.convexhullEnd()){
-      aBoard.drawLine((*it)[0], (*it)[1], 
+      aBoard.drawLine((*it)[0], (*it)[1],
                       (*(it+1))[0],
-                      (*(it+1))[1]);    
+                      (*(it+1))[1]);
     }else{
-      aBoard.drawLine((*it)[0], (*it)[1], 
+      aBoard.drawLine((*it)[0], (*it)[1],
                       (*(anAlphaThickSegmentComputer.convexhullBegin()))[0],
                       (*(anAlphaThickSegmentComputer.convexhullBegin()))[1]);
     }
   }
 
-  
+
   // Display boundingbox
-  aBoard << SetMode((*anAlphaThickSegmentComputer.begin()).className(), "Grid"); 
+  aBoard << SetMode((*anAlphaThickSegmentComputer.begin()).className(), "Grid");
   aBoard << CustomStyle( anAlphaThickSegmentComputer2.className(),
-                         new CustomColors( DGtal::Color::Green, DGtal::Color::None ) );  
-  aBoard << anAlphaThickSegmentComputer2; 
-  aBoard << CustomStyle( anAlphaThickSegmentComputer.className(), 
-                         new CustomColors( DGtal::Color::Blue, DGtal::Color::None ) );      
+                         new CustomColors( DGtal::Color::Green, DGtal::Color::None ) );
+  aBoard << anAlphaThickSegmentComputer2;
+  aBoard << CustomStyle( anAlphaThickSegmentComputer.className(),
+                         new CustomColors( DGtal::Color::Blue, DGtal::Color::None ) );
   aBoard << anAlphaThickSegmentComputer;
-  aBoard << CustomStyle( anAlphaThickSegmentComputer3.className(), 
-                         new CustomColors( DGtal::Color::Yellow, DGtal::Color::None ) );  
+  aBoard << CustomStyle( anAlphaThickSegmentComputer3.className(),
+                         new CustomColors( DGtal::Color::Yellow, DGtal::Color::None ) );
   aBoard << anAlphaThickSegmentComputer3;
-  aBoard << CustomStyle( anAlphaThickSegmentComputer4.className(), 
-                         new CustomColors( DGtal::Color::Magenta, DGtal::Color::None ) );  
+  aBoard << CustomStyle( anAlphaThickSegmentComputer4.className(),
+                         new CustomColors( DGtal::Color::Magenta, DGtal::Color::None ) );
   aBoard << anAlphaThickSegmentComputer4;
-  
+
 
   // Display the input curve
   aBoard << SetMode((*aContour.begin()).className(), "Grid");
-  for (std::vector<Z2i::Point>::const_iterator it = aContour.begin(); 
+  for (std::vector<Z2i::Point>::const_iterator it = aContour.begin();
        it != aContour.end(); it++){
     aBoard << *it;
     if (it+1 != aContour.end()){
@@ -123,63 +123,63 @@ bool testAlphaThickSegmentConvexHullAndBox()
       aBoard.drawLine((*it)[0], (*it)[1], next[0], next[1]);
     }
   }
-  
-  aBoard.saveEPS("testAlphaThickSegmentComputer_Convexhull.eps"); 
+
+  aBoard.saveEPS("testAlphaThickSegmentComputer_Convexhull.eps");
   trace.info() << " Alpha Thick with alpha 5, size (awaited be 41) = " << anAlphaThickSegmentComputer.getNumberSegmentPoints();
   res = anAlphaThickSegmentComputer.getNumberSegmentPoints()==41;
-  nbok += res ? 1 : 0; 
+  nbok += res ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") " << std::endl;
   trace.endBlock();
-  
+
   trace.beginBlock("Testing access to extremity points");
-  trace.info() << "First extremity point: " << anAlphaThickSegmentComputer.getExtremityPoints().first << 
+  trace.info() << "First extremity point: " << anAlphaThickSegmentComputer.getExtremityPoints().first <<
     " ( should be " << *(aContour.begin())<<  ")" << std::endl;
-  trace.info() << "Second extremity point: " << anAlphaThickSegmentComputer.getExtremityPoints().second << 
+  trace.info() << "Second extremity point: " << anAlphaThickSegmentComputer.getExtremityPoints().second <<
     " ( should be (80, 18) )" << std::endl;
-  
+
   res = anAlphaThickSegmentComputer.getExtremityPoints().first == *(aContour.begin())&&
         anAlphaThickSegmentComputer.getExtremityPoints().second == Z2i::Point(80,18);
-  nbok += res ? 1 : 0; 
+  nbok += res ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") " << std::endl;
   trace.endBlock();
 
 
   trace.beginBlock("Testing access to anti podal points");
-  std::pair<std::pair<Z2i::Point, Z2i::Point>, 
+  std::pair<std::pair<Z2i::Point, Z2i::Point>,
             Z2i::Point> pairAntipodal =  anAlphaThickSegmentComputer.getAntipodalLeaningPoints();
-  
-  Z2i::Point p = pairAntipodal.first.first; 
-  Z2i::Point q = pairAntipodal.first.second; 
-  Z2i::Point s = pairAntipodal.second;   
+
+  Z2i::Point p = pairAntipodal.first.first;
+  Z2i::Point q = pairAntipodal.first.second;
+  Z2i::Point s = pairAntipodal.second;
   aBoard.setPenColor(DGtal::Color::Red);
   aBoard.drawLine(p[0], p[1], q[0], q[1]);
   aBoard.fillCircle(s[0], s[1], 0.2);
-  aBoard.saveEPS("testAlphaThickSegmentComputer_ConvexhullAntipodal.eps"); 
-    
-  trace.info() << "Antipodal pair: p " << p << ", q:" << q << ", s: "<< s << std::endl; 
+  aBoard.saveEPS("testAlphaThickSegmentComputer_ConvexhullAntipodal.eps");
+
+  trace.info() << "Antipodal pair: p " << p << ", q:" << q << ", s: "<< s << std::endl;
   trace.info() << "Should be  " << Z2i::Point(78,16) << " " << Z2i::Point(79,6) << Z2i::Point(83,13) <<std::endl;
 
   res = p==Z2i::Point(78,16) && q==Z2i::Point(79,6) && s == Z2i::Point(83,13);
-  nbok += res ? 1 : 0; 
+  nbok += res ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") " << std::endl;
-  
-  
+
+
   trace.beginBlock("Testing getter of segment parameters");
   pairAntipodal =  anAlphaThickSegmentComputer4.getAntipodalLeaningPoints();
-  p = pairAntipodal.first.first; 
-  q = pairAntipodal.first.second; 
-  s = pairAntipodal.second;   
-  
+  p = pairAntipodal.first.first;
+  q = pairAntipodal.first.second;
+  s = pairAntipodal.second;
+
   Z2i::RealPoint  vectDir =   (p-q)[0]>0? p-q: q-p;
-  
-  trace.info() << "Segment4 params: vect Dir: " << vectDir << std::endl; 
+
+  trace.info() << "Segment4 params: vect Dir: " << vectDir << std::endl;
   trace.info() << "Should be:   " << Z2i::RealPoint(1,1)  <<std::endl;
 
   res = vectDir == Z2i::RealPoint(1,1);
-  nbok += res ? 1 : 0; 
+  nbok += res ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") " << std::endl;
   trace.endBlock();
@@ -203,26 +203,26 @@ bool testAlphaThickSegmentComputerFloatingPointContour()
   std::vector<Z2i::RealPoint> aContour;
   std::string fileContour = testPath + "samples/contourNoiseSample2.sdp";
   aContour = PointListReader<Z2i::RealPoint>::getPointsFromFile(fileContour);
-  
+
   AlphaThickSegmentComputer2D anAlphaThickSegmentComputer(2);
   anAlphaThickSegmentComputer.init(aContour.begin()+10);
-  
-  while (anAlphaThickSegmentComputer.end()!= aContour.end() && 
+
+  while (anAlphaThickSegmentComputer.end()!= aContour.end() &&
          anAlphaThickSegmentComputer.extendFront()){
   }
 
-  
-  // Display alpha thick segment 
-  aBoard << SetMode((*anAlphaThickSegmentComputer.begin()).className(), "Grid"); 
+
+  // Display alpha thick segment
+  aBoard << SetMode((*anAlphaThickSegmentComputer.begin()).className(), "Grid");
   aBoard << anAlphaThickSegmentComputer;
-  
-   
+
+
   // Test primitive of parallelStrip and display the input curve
   Primitive pStrip = anAlphaThickSegmentComputer.primitive();
   unsigned int nbInStrip = 0;
-  
+
   aBoard << SetMode((*aContour.begin()).className(), "Grid");
-  for (std::vector<Z2i::RealPoint>::const_iterator it = aContour.begin(); 
+  for (std::vector<Z2i::RealPoint>::const_iterator it = aContour.begin();
        it != aContour.end(); it++){
     if (it+1 != aContour.end()){
       Z2i::RealPoint next = *(it+1);
@@ -232,22 +232,22 @@ bool testAlphaThickSegmentComputerFloatingPointContour()
     }
     if (pStrip(*it)){
       nbInStrip++;
-      aBoard << *it; 
-    }    
+      aBoard << *it;
+    }
   }
   trace.info() << "Nb contour points in the segment parallel strip (awaited 32)  = " << nbInStrip << std::endl;
 
   nbok += nbInStrip==32;
   nb++;
-  
-  nbok += anAlphaThickSegmentComputer.getNumberSegmentPoints()==31 ? 1 : 0; 
+
+  nbok += anAlphaThickSegmentComputer.getNumberSegmentPoints()==31 ? 1 : 0;
   nb++;
- 
-  trace.info() << "Segment size (awaited 31): " << anAlphaThickSegmentComputer.getNumberSegmentPoints() << std::endl;  
-  aBoard.saveEPS("testAlphaThickSegmentComputer_FloatingPt.eps"); 
-  
+
+  trace.info() << "Segment size (awaited 31): " << anAlphaThickSegmentComputer.getNumberSegmentPoints() << std::endl;
+  aBoard.saveEPS("testAlphaThickSegmentComputer_FloatingPt.eps");
+
   trace.info() << "(" << nbok << "/" << nb << ") " << std::endl;
-  trace.endBlock(); 
+  trace.endBlock();
   return nbok == nb;
 }
 
@@ -263,13 +263,13 @@ bool testAlphaThickSegmentFreeman()
   unsigned int nbok = 0;
   unsigned int nb = 0;
   typedef FreemanChain<Z2i::Space::Integer>::ConstIterator FCConstIterator;
-  typedef  AlphaThickSegmentComputer< Z2i::Point, FCConstIterator > AlphaThickSegmentComputer2D;
+  typedef  AlphaThickSegmentComputer< Z2i::Space::Point, FCConstIterator > AlphaThickSegmentComputer2D;
 
   Board2D aBoard;
 
 
 
-  trace.beginBlock ( "Testing AlphaThickSegmentComputer2D on Freeman chain ..." );  
+  trace.beginBlock ( "Testing AlphaThickSegmentComputer2D on Freeman chain ..." );
 
   // Reading input contour
   std::string freemanChainFilename = testPath + "samples/klokan.fc";
@@ -278,26 +278,26 @@ bool testAlphaThickSegmentFreeman()
   FreemanChain<Z2i::Space::Integer> fc(fst);
   fst.close();
   aBoard << fc;
-  
-  
+
+
   AlphaThickSegmentComputer2D anAlphaThickSegmentComputer(70.0);
   anAlphaThickSegmentComputer.init(fc.begin());
-  while (anAlphaThickSegmentComputer.end() != fc.end() && 
+  while (anAlphaThickSegmentComputer.end() != fc.end() &&
          anAlphaThickSegmentComputer.extendFront()){
   }
 
-  
-  // Display segment 
-  aBoard << SetMode((*anAlphaThickSegmentComputer.begin()).className(), "Grid"); 
+
+  // Display segment
+  aBoard << SetMode((*anAlphaThickSegmentComputer.begin()).className(), "Grid");
   aBoard << anAlphaThickSegmentComputer;
-  trace.info() << "Segment size (awaited 642): " << anAlphaThickSegmentComputer.getNumberSegmentPoints() << std::endl;  
-  nbok += anAlphaThickSegmentComputer.getNumberSegmentPoints()==642 ? 1 : 0; 
-  nb++;  
-  
+  trace.info() << "Segment size (awaited 642): " << anAlphaThickSegmentComputer.getNumberSegmentPoints() << std::endl;
+  nbok += anAlphaThickSegmentComputer.getNumberSegmentPoints()==642 ? 1 : 0;
+  nb++;
+
   // Display points inside the parallel strip
   unsigned int nbInStrip = 0;
   AlphaThickSegmentComputer2D::Primitive parallelStrip = anAlphaThickSegmentComputer.primitive();
-  
+
   for(FCConstIterator it  = fc.begin(); it != fc.end(); it++){
     if(parallelStrip(*it)){
       aBoard.setPenColor(DGtal::Color::Blue);
@@ -307,18 +307,18 @@ bool testAlphaThickSegmentFreeman()
   }
   aBoard.setPenColor(DGtal::Color::Green);
   aBoard.fillCircle( (*(fc.begin()))[0],(*(fc.begin()))[1], 1.0) ;
-      
+
   trace.info() << "Nb contour points in the segment parallel strip  (awaited 818)  = " << nbInStrip << std::endl;
 
 
-  nbok +=  nbInStrip==818 ? 1 : 0; 
+  nbok +=  nbInStrip==818 ? 1 : 0;
   nb++;
-  
+
   trace.info() << "(" << nbok << "/" << nb << ") " << std::endl;
   trace.endBlock();
-  aBoard.saveEPS("testAlphaThickSegmentComputer_Freeman.eps"); 
-  
-  return nbok == nb; 
+  aBoard.saveEPS("testAlphaThickSegmentComputer_Freeman.eps");
+
+  return nbok == nb;
 
 }
 
@@ -333,7 +333,7 @@ bool testAlphaThickSpecialInit()
   Board2D aBoard, aBoard2;
   typedef  AlphaThickSegmentComputer< Z2i::RealPoint> AlphaThickSegmentComputer2D;
   trace.beginBlock ( "Test special cases on various initialisations ..." );
-  
+
   AlphaThickSegmentComputer2D segment(1.3);
   std::vector<Z2i::RealPoint> aContour;
   aContour.push_back(Z2i::RealPoint(29,20));
@@ -347,7 +347,7 @@ bool testAlphaThickSpecialInit()
   }
   nb++;
   nbok  = segment.getNumberSegmentPoints()==4;
-  
+
   // Display alpha thick segment
   for( std::vector<Z2i::RealPoint>::const_iterator it = aContour.begin(); it != aContour.end(); it++){
     aBoard << *it;
@@ -355,21 +355,21 @@ bool testAlphaThickSpecialInit()
   // Display alpha thick segment
   aBoard << SetMode((*segment.begin()).className(), "Grid");
   aBoard << segment;
-  
+
   Z2i::Point p = segment.getAntipodalLeaningPoints().first.first;
   Z2i::Point q = segment.getAntipodalLeaningPoints().first.second;
   Z2i::Point s = segment.getAntipodalLeaningPoints().second;
   aBoard.setPenColor(DGtal::Color::Blue);
   aBoard.drawLine(p[0], p[1], q[0], q[1]);
   aBoard.setPenColor(DGtal::Color::Green);
-  aBoard.fillCircle(s[0], s[1], 0.2);  
+  aBoard.fillCircle(s[0], s[1], 0.2);
   aBoard.saveEPS("testSpecialInit.eps");
 
   trace.info() << "Segment size: " << segment.getNumberSegmentPoints() << "(awaited : " << 4 <<")"<< std::endl;
   trace.info() << "(" << nbok << "/" << nb << ") " << std::endl;
   trace.endBlock();
   aBoard.saveEPS("testSpecialInit.eps");
-    
+
   return nbok==nb;
 }
 
@@ -400,17 +400,17 @@ bool testMultiWidth()
       nbTotalAdded++;
     }
     aBoard << SetMode((*anAlphaThickSegmentComputer.begin()).className(), "Grid");
-    
+
     aBoard << CustomStyle( anAlphaThickSegmentComputer.className(),
                           new CustomColors( hueMap(width), DGtal::Color::None   ) );
     aBoard << anAlphaThickSegmentComputer;
   }
-  trace.info() << "Nb total points added: " << nbTotalAdded << "(awaited:  2300) " << std::endl; 
+  trace.info() << "Nb total points added: " << nbTotalAdded << "(awaited:  2300) " << std::endl;
   trace.endBlock();
   aBoard.saveEPS("testMultiWidth.eps");
   nb++;
   nbok += nbTotalAdded == 2300;
-  return nb==nbok;  
+  return nb==nbok;
 }
 
 
@@ -420,7 +420,7 @@ bool testMultiWidth()
 /**
  * Test euclidean two thickness definitions
  **/
-bool 
+bool
 testThicknessDefinitions(){
   Board2D aBoardHVthickness;
   Board2D aBoardEuclthickness;
@@ -464,26 +464,26 @@ testThicknessDefinitions(){
       aBoardHVthickness.drawLine((*it)[0], (*it)[1], next[0], next[1]);
     }
   }
-  
-  anAlphaSegmentEucl.init(aVect.begin());  
+
+  anAlphaSegmentEucl.init(aVect.begin());
   while(anAlphaSegmentEucl.end() != aVect.end()
         && anAlphaSegmentEucl.extendFront()){
   }
-  anAlphaSegmentHV.init(aVect.begin());  
+  anAlphaSegmentHV.init(aVect.begin());
   while(anAlphaSegmentHV.end() != aVect.end()
         && anAlphaSegmentHV.extendFront()){
   }
 
-  
+
   trace.info() << "Euclidean thickness based segment, th= " << anAlphaSegmentEucl.getThickness() << std::endl;
   trace.info() << "Horizontal/Vertical thickness based segment, th= " << anAlphaSegmentHV.getThickness() << std::endl;
 
-  
-  aBoardHVthickness  << CustomStyle( anAlphaSegmentEucl.className(), new CustomColors( DGtal::Color::Blue, DGtal::Color::None ) );  
-  aBoardEuclthickness  << CustomStyle( anAlphaSegmentHV.className(), new CustomColors( DGtal::Color::Blue, DGtal::Color::None ) );  
-  aBoardHVthickness << anAlphaSegmentHV;    
-  aBoardEuclthickness << anAlphaSegmentEucl;    
-  
+
+  aBoardHVthickness  << CustomStyle( anAlphaSegmentEucl.className(), new CustomColors( DGtal::Color::Blue, DGtal::Color::None ) );
+  aBoardEuclthickness  << CustomStyle( anAlphaSegmentHV.className(), new CustomColors( DGtal::Color::Blue, DGtal::Color::None ) );
+  aBoardHVthickness << anAlphaSegmentHV;
+  aBoardEuclthickness << anAlphaSegmentEucl;
+
   std::vector<Z2i::Point> hullHV = anAlphaSegmentHV.getConvexHull();
   std::vector<Z2i::Point> hullEucl = anAlphaSegmentEucl.getConvexHull();
   aBoardEuclthickness.setLineWidth(5);
@@ -491,29 +491,29 @@ testThicknessDefinitions(){
   aBoardEuclthickness.setPenColor(DGtal::Color::Purple);
   aBoardHVthickness.setPenColor(DGtal::Color::Purple);
   for (unsigned int i = 0; i < hullEucl.size(); i++){
-    aBoardEuclthickness.drawLine(hullEucl.at(i)[0], hullEucl.at(i)[1], 
+    aBoardEuclthickness.drawLine(hullEucl.at(i)[0], hullEucl.at(i)[1],
                                  hullEucl.at((i+1)%hullEucl.size())[0],
-                                 hullEucl.at((i+1)%hullEucl.size())[1]);    
-  } 
-  for (unsigned int i = 0; i < hullHV.size(); i++){
-    aBoardHVthickness.drawLine(hullHV.at(i)[0], hullHV.at(i)[1], 
-                               hullHV.at((i+1)%hullHV.size())[0],
-                               hullHV.at((i+1)%hullHV.size())[1]);    
+                                 hullEucl.at((i+1)%hullEucl.size())[1]);
   }
-  
+  for (unsigned int i = 0; i < hullHV.size(); i++){
+    aBoardHVthickness.drawLine(hullHV.at(i)[0], hullHV.at(i)[1],
+                               hullHV.at((i+1)%hullHV.size())[0],
+                               hullHV.at((i+1)%hullHV.size())[1]);
+  }
+
   Z2i::Point pEucl = anAlphaSegmentEucl.getAntipodalLeaningPoints().first.first;
   Z2i::Point qEucl = anAlphaSegmentEucl.getAntipodalLeaningPoints().first.second;
   Z2i::Point sEucl = anAlphaSegmentEucl.getAntipodalLeaningPoints().second;
 
   Z2i::Point pHV = anAlphaSegmentHV.getAntipodalLeaningPoints().first.first;
   Z2i::Point qHV = anAlphaSegmentHV.getAntipodalLeaningPoints().first.second;
-  Z2i::Point sHV = anAlphaSegmentHV.getAntipodalLeaningPoints().second;  
+  Z2i::Point sHV = anAlphaSegmentHV.getAntipodalLeaningPoints().second;
   aBoardEuclthickness.setPenColor(DGtal::Color::Red);
   aBoardHVthickness.setPenColor(DGtal::Color::Red);
 
   aBoardEuclthickness.drawCircle( pEucl[0], pEucl[1], 0.25);
   aBoardHVthickness.drawCircle( pHV[0], pHV[1], 0.25);
-  
+
   aBoardEuclthickness.drawCircle( qEucl[0], qEucl[1], 0.25);
   aBoardHVthickness.drawCircle( qHV[0], qHV[1], 0.25);
 
@@ -525,7 +525,7 @@ testThicknessDefinitions(){
 
   aBoardEuclthickness.saveEPS("testAlphaThickEucl.eps");
   aBoardHVthickness.saveEPS("testAlphaThickHV.eps");
-  
+
   trace.endBlock();
   return nb==nbok;
 }
@@ -544,12 +544,12 @@ int main( int argc, char** argv )
     trace.info() << " " << argv[ i ];
   trace.info() << endl;
 
-  bool res =  testAlphaThickSegmentConvexHullAndBox() && testAlphaThickSegmentComputerFloatingPointContour() && 
+  bool res =  testAlphaThickSegmentConvexHullAndBox() && testAlphaThickSegmentComputerFloatingPointContour() &&
     testAlphaThickSegmentFreeman() && testAlphaThickSpecialInit() && testMultiWidth() && testThicknessDefinitions();
 
   trace.emphase() << ( res ? "Passed." : "Error." ) << endl;
 
-  
+
   trace.endBlock();
   return res ? 0 : 1;
 }

--- a/tests/geometry/curves/testFrechetShortcut.cpp
+++ b/tests/geometry/curves/testFrechetShortcut.cpp
@@ -68,10 +68,10 @@ bool testFrechetShortcut()
 {
   unsigned int nbok = 0;
   unsigned int nb = 0;
-  
+
   typedef PointVector<2,int> Point;
   typedef std::vector<Point>::iterator Iterator;
-  typedef FrechetShortcut<Iterator,int> Shortcut;  
+  typedef FrechetShortcut<Iterator,int> Shortcut;
 
   std::vector<Point> contour;
   contour.push_back(Point(0,0));
@@ -97,20 +97,20 @@ bool testFrechetShortcut()
   contour.push_back(Point(9,2));
 
   trace.beginBlock ( "Testing block ..." );
-  
+
   Shortcut s(5);
   s.init(contour.begin());
-  
+
   trace.info() << s << std::endl;
-  
+
   while ( (s.end() != contour.end())
     &&(s.extendFront()) ) {}
-  
+
   trace.info() << s << std::endl;
-  
-  
+
+
   trace.endBlock();
-  
+
   return nbok == nb;
 }
 
@@ -118,9 +118,9 @@ bool testFrechetShortcut()
 
 void testFrechetShortcutConceptChecking()
 {
-  typedef PointVector<2,int> Point; 
-  typedef std::vector<Point>::const_iterator ConstIterator; 
-  typedef FrechetShortcut<ConstIterator,int> Shortcut; 
+  typedef PointVector<2,int> Point;
+  typedef std::vector<Point>::const_iterator ConstIterator;
+  typedef FrechetShortcut<ConstIterator,int> Shortcut;
   BOOST_CONCEPT_ASSERT(( CDrawableWithBoard2D<Shortcut> ));
   BOOST_CONCEPT_ASSERT(( CForwardSegmentComputer<Shortcut> ));
 }
@@ -129,10 +129,10 @@ bool testSegmentation()
 {
   unsigned int nbok = 0;
   unsigned int nb = 0;
-  
+
   typedef PointVector<2,int> Point;
   //typedef std::vector<Point>::iterator Iterator;
-  //typedef FrechetShortcut<Iterator,int> SegmentComputer;  
+  //typedef FrechetShortcut<Iterator,int> SegmentComputer;
 
   std::vector<Point> contour;
   contour.push_back(Point(0,0));
@@ -159,52 +159,53 @@ bool testSegmentation()
   contour.push_back(Point(9,2));
 
   trace.beginBlock ( "Testing block ..." );
-  
+
+  typedef GridCurve< KhalimskySpaceND< 2, int > > Curve;
   typedef Curve::PointsRange::ConstIterator Iterator;
   typedef FrechetShortcut<Iterator,int> SegmentComputer;
-  
+
   Curve aCurve; //grid curve
   aCurve.initFromVector(contour);
-  
+
   typedef Curve::PointsRange Range; //range
   Range r = aCurve.getPointsRange(); //range
-  
-  Board2D board; 
+
+  Board2D board;
   board << r;
   board << aCurve.getArrowsRange();
-  
+
 
   double anerror = 3;
   nbok =3;
-  
+
   trace.beginBlock ( "Greedy segmentation" );
   {
     typedef GreedySegmentation<SegmentComputer> Segmentation;
     Segmentation theSegmentation( r.begin(), r.end(), SegmentComputer(anerror) );
-    
+
     Segmentation::SegmentComputerIterator it = theSegmentation.begin();
     Segmentation::SegmentComputerIterator itEnd = theSegmentation.end();
-    
+
     for ( ; it != itEnd; ++it) {
       SegmentComputer s(*it);
       trace.info() << s << std::endl;
-      board << (*it); 
+      board << (*it);
       nb++;
     }
 
     //board << aCurve;
     trace.info() << theSegmentation << std::endl;
-    board.saveEPS("FrechetShortcutGreedySegmentationTest.eps", Board2D::BoundingBox, 5000 ); 
+    board.saveEPS("FrechetShortcutGreedySegmentationTest.eps", Board2D::BoundingBox, 5000 );
   }
-  
+
   /* Saturated segmentation does not work for FrechetShortcut
      computer. Indeed, given two maximal Frechet shortcuts s1(begin, end) et
      s2(begin, end),  we can have s1.begin < s2.begin < s2.end <
-     s1.end. */ 
-  
+     s1.end. */
+
 
   trace.endBlock();
-  
+
   return nbok == nb;
 }
 

--- a/tests/geometry/curves/testFreemanChain.cpp
+++ b/tests/geometry/curves/testFreemanChain.cpp
@@ -48,16 +48,16 @@ using namespace LibBoard;
 ///////////////////////////////////////////////////////////////////////////////
 // Functions for testing class FreemanChain.
 ///////////////////////////////////////////////////////////////////////////////
-typedef SpaceND<2> Space2Type;
+typedef SpaceND<2,int> Space2Type;
 typedef HyperRectDomain<Space2Type> Domain2D;
 
 
 /**
  * Test Constructors
  */
-bool testConstructors() 
+bool testConstructors()
 {
-  typedef FreemanChain<int> FreemanChain;
+  typedef FreemanChain<Space2Type::Integer> FreemanChain;
   typedef FreemanChain::ConstIterator Iterator;
 
   trace.beginBlock ( "Testing FreemanChain constructors" );
@@ -67,7 +67,7 @@ bool testConstructors()
   FreemanChain c1(s, -42, 12);
 
   trace.info() << "Constructor from point vector" << endl;
-  std::vector<Z2i::Point> myVector;
+  std::vector<Space2Type::Point> myVector;
   for (Iterator i = c1.begin(); i != c1.end(); i++)
     myVector.push_back(*i);
   FreemanChain c2(myVector);
@@ -112,12 +112,12 @@ bool testConstructors()
  */
 bool testPublicSercives()
 {
-  typedef FreemanChain<int> FreemanChain;
+  typedef FreemanChain<Space2Type::Integer> FreemanChain;
   typedef FreemanChain::Point Point;
   typedef FreemanChain::ConstIterator Iterator;
 
   trace.beginBlock ( "Testing public sercives" );
-    
+
   FreemanChain fc("000103000322232122", 0, 0);
   int nbOk = 0;
 
@@ -142,7 +142,7 @@ bool testPublicSercives()
   FreemanChain fcB("001",0,0);
   FreemanChain fcC("003",0,0);
   fcB += fcC + fcB;
-  test = ( fcB == FreemanChain("001003001", 0, 0) ) && 
+  test = ( fcB == FreemanChain("001003001", 0, 0) ) &&
     ( fcB.totalDisplacement() == fcA.totalDisplacement()*2 + fcC.totalDisplacement() );
   nbOk += (test) ? 1 : 0;
   trace.info() << "Test 4 " << ((test) ? "passed" : "failed" ) << endl;
@@ -155,7 +155,7 @@ bool testPublicSercives()
   nbOk += (test) ? 1 : 0;
   trace.info() << "Test 5 " << ((test) ? "passed" : "failed" ) << endl;
 
-  //  typename Self::ConstIterator 
+  //  typename Self::ConstIterator
   //    findQuadrantChange( OrderedAlphabet & A ) const;
   OrderedAlphabet oa( '0', 4 );
   Iterator it = fc.findQuadrantChange( oa );
@@ -163,7 +163,7 @@ bool testPublicSercives()
   nbOk += (test) ? 1 : 0;
   trace.info() << "Test 6 " << ((test) ? "passed" : "failed" ) << endl;
 
-  //  typename Self::ConstIterator 
+  //  typename Self::ConstIterator
   //    findQuadrantChange4( OrderedAlphabet & A ) const;
   it = fc.findQuadrantChange4( oa );
   test = ( it.position() == 9 );
@@ -199,7 +199,7 @@ bool testPublicSercives()
 
   // Point firstPoint ( ) const
   // Point lastPoint ( ) const
-  test = ( ( fc.subChain(4,3).firstPoint() == Point(3,1) ) && 
+  test = ( ( fc.subChain(4,3).firstPoint() == Point(3,1) ) &&
       ( fc.subChain(4,3).lastPoint() == Point(5,0) ) );
   nbOk += (test) ? 1 : 0;
   trace.info() << "Test 11 " << ((test) ? "passed" : "failed" ) << endl;
@@ -209,15 +209,15 @@ bool testPublicSercives()
   fcA = fc;
   fcA.extend('2');
   fcB = fcA.extend('1');
-  test = ( (fcB == fc + FreemanChain("21",0,0) ) &&  fcA.isClosed() 
-          && ( fcB.retract().retract() == fc ) ); 
+  test = ( (fcB == fc + FreemanChain("21",0,0) ) &&  fcA.isClosed()
+          && ( fcB.retract().retract() == fc ) );
   nbOk += (test) ? 1 : 0;
   trace.info() << "Test 12 " << ((test) ? "passed" : "failed" ) << endl;
 
   trace.endBlock();
-  
+
   return ( nbOk == 12);
-  
+
 }
 
 
@@ -233,7 +233,7 @@ bool testPointsIterators()
   typedef FreemanChain::Point Point;
   typedef FreemanChain::ConstIterator PointIterator;
   typedef std::reverse_iterator<PointIterator> ReverseIterator;
-   
+
   trace.beginBlock ( "Testing FreemanChain Iterator" );
 
   std::stringstream ss;
@@ -241,14 +241,14 @@ bool testPointsIterators()
   ss << myString << std::endl;
   FreemanChain seq(ss);
 
-  trace.info()<< "Freeman chain set to " << myString << endl;   
+  trace.info()<< "Freeman chain set to " << myString << endl;
   trace.info()<< seq << endl;
 
   trace.info()<< "Iterates on points." << endl;
   std::stack<Point> myStack;
 
   unsigned int nbPts = 0;
-  for (PointIterator i = seq.begin(); i != seq.end(); ++i) 
+  for (PointIterator i = seq.begin(); i != seq.end(); ++i)
   {
     myStack.push(*i);
     nbPts++;
@@ -256,14 +256,14 @@ bool testPointsIterators()
 
   trace.info()<< "Test reverse iterator." << endl;
   bool samePoints = true;
-  for (ReverseIterator ri(seq.end()); 
+  for (ReverseIterator ri(seq.end());
       ri != ReverseIterator(seq.begin());
-      ++ri) 
+      ++ri)
   {
     if ( !myStack.empty() && ( *ri == myStack.top() ) )
     {
       myStack.pop();
-    } 
+    }
     else
     {
       samePoints = false;
@@ -284,7 +284,7 @@ bool testCodesIterators()
   typedef FreemanChain::CodesRange Range;
 //  typedef Range::ConstIterator PointIterator;
 //  typedef std::reverse_iterator<PointIterator> ReverseIterator;
-   
+
   trace.beginBlock ( "Testing CodesRange Iterator" );
 
   std::stringstream ss;
@@ -292,16 +292,16 @@ bool testCodesIterators()
   ss << myString << std::endl;
   FreemanChain seq(ss);
 
-  trace.info()<< "Freeman chain set to " << myString << endl;   
+  trace.info()<< "Freeman chain set to " << myString << endl;
   trace.info()<< seq << endl;
-  Range r = seq.getCodesRange(); 
+  Range r = seq.getCodesRange();
   trace.info()<< r << endl;
-  
+
   trace.info()<< "Iterates on letters." << endl;
   std::stack<char> myStack;
 
   unsigned int nbLetters = 0;
-  for (Range::ConstIterator i = r.begin(); i != r.end(); ++i) 
+  for (Range::ConstIterator i = r.begin(); i != r.end(); ++i)
   {
     myStack.push(*i);
     nbLetters++;
@@ -309,14 +309,14 @@ bool testCodesIterators()
 
   trace.info()<< "Test reverse iterator." << endl;
   bool samePoints = true;
-  for (Range::ConstReverseIterator ri = r.rbegin(); 
+  for (Range::ConstReverseIterator ri = r.rbegin();
       ri != r.rend();
-      ++ri) 
+      ++ri)
   {
     if ( !myStack.empty() && ( *ri == myStack.top() ) )
     {
       myStack.pop();
-    } 
+    }
     else
     {
       samePoints = false;
@@ -357,10 +357,10 @@ bool testStaticServices()
   nbOk += (test) ? 1 : 0;
   trace.info() << "Test 1 " << ((test) ? "passed" : "failed" ) << endl;
 
-  //  static void getContourPoints(const FreemanChain & fc, 
+  //  static void getContourPoints(const FreemanChain & fc,
   //      std::vector<Point> & aVContour );
   Point p0, p1(-1,-1), p2(0,-1), p3(1,-1), p4(2,-1), p5(2,0);
-  vector<Point> pointVecRef, pointVecTest; 
+  vector<Point> pointVecRef, pointVecTest;
   pointVecRef.push_back(p1);
   pointVecRef.push_back(p2);
   pointVecRef.push_back(p3);
@@ -373,7 +373,7 @@ bool testStaticServices()
 
 
   // static void movePointFromFC(Point & aPoint, unsigned int aCode )
-  Point P0(10,10), P1(10,10), P2(10,10), P3(10,10); 
+  Point P0(10,10), P1(10,10), P2(10,10), P3(10,10);
   FreemanChain::movePointFromFC( P0, '0'); FreemanChain::movePointFromFC( P1, '1');
   FreemanChain::movePointFromFC( P2, '2'); FreemanChain::movePointFromFC( P3, '3');
   test = ( P0 == Point(11,10) ) && ( P1 == Point(10,11) ) &&
@@ -383,7 +383,7 @@ bool testStaticServices()
 
 
   //  static unsigned int movement( unsigned int aCode1, unsigned int aCode2,
-  //      bool ccw = true ); 
+  //      bool ccw = true );
   test = ( FreemanChain::movement ( '0' , '0' , true ) == '2' ) &&
          ( FreemanChain::movement ( '0' , '1' , true ) == '1' ) &&
          ( FreemanChain::movement ( '0' , '2' , true ) == '0' ) &&
@@ -454,9 +454,9 @@ bool testStaticServices()
   numVector pix2plExpected;
   pix2plExpected.push_back( 0 ); pix2plExpected.push_back( 1 ); pix2plExpected.push_back( 3 );
   pix2plExpected.push_back( 6 ); pix2plExpected.push_back( 7 ); pix2plExpected.push_back( 7 );
-  pix2plExpected.push_back( 8 ); pix2plExpected.push_back( 10 ); 
-  test = ( pixChain == FreemanChain("00132213", 0, 0) ) && 
-         ( pl2pix == pl2pixExpected ) && 
+  pix2plExpected.push_back( 8 ); pix2plExpected.push_back( 10 );
+  test = ( pixChain == FreemanChain("00132213", 0, 0) ) &&
+         ( pl2pix == pl2pixExpected ) &&
          ( pix2pl == pix2plExpected );
   nbOk += (test) ? 1 : 0;
   trace.info() << "Test 7 " << ((test) ? "passed" : "failed" ) << endl;
@@ -470,8 +470,8 @@ bool testStaticServices()
   FreemanChain innerChain;
   numVector outer2inner, inner2outer;
   FreemanChain::innerContour ( innerChain, outer2inner, inner2outer, f, true);
-  test = ( innerChain == FreemanChain("00132213", 0, 0 ) ) && 
-         ( outer2inner == pl2pixExpected ) && 
+  test = ( innerChain == FreemanChain("00132213", 0, 0 ) ) &&
+         ( outer2inner == pl2pixExpected ) &&
          ( inner2outer == pix2plExpected );
   nbOk += (test) ? 1 : 0;
   trace.info() << "Test 8 " << ((test) ? "passed" : "failed" ) << endl;
@@ -487,7 +487,7 @@ bool testStaticServices()
   FreemanChain cleanC;
   bool cleaned = FreemanChain::cleanOuterSpikes( cleanC, c2clean, clean2c, c, true );
   FreemanChain cleanCExpected("22233000011231", 3, 2);
-  numVector c2cleanExpected; 
+  numVector c2cleanExpected;
   c2cleanExpected.push_back( 5 ); c2cleanExpected.push_back( 6 ); c2cleanExpected.push_back( 7 );
   c2cleanExpected.push_back( 8 ); c2cleanExpected.push_back( 9 ); c2cleanExpected.push_back(10 );
   c2cleanExpected.push_back(11 ); c2cleanExpected.push_back(12 ); c2cleanExpected.push_back(13 );
@@ -495,12 +495,12 @@ bool testStaticServices()
   c2cleanExpected.push_back( 2 ); c2cleanExpected.push_back( 2 ); c2cleanExpected.push_back( 3 );
   c2cleanExpected.push_back( 4 );
   numVector clean2cExpected;
-  clean2cExpected.push_back( 9 ); clean2cExpected.push_back(10 ); clean2cExpected.push_back(13 ); 
-  clean2cExpected.push_back(14 ); clean2cExpected.push_back(15 ); clean2cExpected.push_back( 0 ); 
-  clean2cExpected.push_back( 1 ); clean2cExpected.push_back( 2 ); clean2cExpected.push_back( 3 ); 
-  clean2cExpected.push_back( 4 ); clean2cExpected.push_back( 5 ); clean2cExpected.push_back( 6 ); 
+  clean2cExpected.push_back( 9 ); clean2cExpected.push_back(10 ); clean2cExpected.push_back(13 );
+  clean2cExpected.push_back(14 ); clean2cExpected.push_back(15 ); clean2cExpected.push_back( 0 );
+  clean2cExpected.push_back( 1 ); clean2cExpected.push_back( 2 ); clean2cExpected.push_back( 3 );
+  clean2cExpected.push_back( 4 ); clean2cExpected.push_back( 5 ); clean2cExpected.push_back( 6 );
   clean2cExpected.push_back( 7 ); clean2cExpected.push_back( 8 );
-  test = cleaned && (cleanC == cleanCExpected) && (c2clean == c2cleanExpected) 
+  test = cleaned && (cleanC == cleanCExpected) && (c2clean == c2cleanExpected)
     && (clean2c == clean2cExpected);
   nbOk += (test) ? 1 : 0;
   trace.info() << "Test 9 " << ((test) ? "passed" : "failed" ) << endl;
@@ -525,34 +525,34 @@ bool testDisplay()
 
   Board2D aBoard;
   aBoard.setUnit(Board::UCentimeter);
-  
+
   fstream fst;
   fst.open ((testPath + "samples/contourS.fc").c_str() , ios::in);
-  FreemanChain fc(fst);  
+  FreemanChain fc(fst);
 
   aBoard.setPenColor(Color::Red);
-  
+
   //aBoard << DrawPavingPixel();
-  
+
   aBoard << fc;
-  
+
   std::string filenameImage = testPath + "samples/contourS.png"; // ! only PNG with Cairo for the moment !
-  LibBoard::Image image( 0, 84, 185, 85, filenameImage, 20 ); 
+  LibBoard::Image image( 0, 84, 185, 85, filenameImage, 20 );
   image.shiftDepth(500);
   LibBoard::Board & board = aBoard;
   board << image;
-  
+
   aBoard.saveSVG( "testDisplayFC.svg", Board::BoundingBox, 5000 );
   aBoard.saveEPS( "testDisplayFC.eps", Board::BoundingBox, 5000 );
   aBoard.saveFIG( "testDisplayFC.fig", Board::BoundingBox, 5000 );
-  
+
 #ifdef WITH_CAIRO
   aBoard.saveCairo("testDisplayFC-cairo.pdf", Board2D::CairoPDF, Board::BoundingBox, 5000);
   aBoard.saveCairo("testDisplayFC-cairo.png", Board2D::CairoPNG, Board::BoundingBox, 5000);
   aBoard.saveCairo("testDisplayFC-cairo.ps",  Board2D::CairoPS,  Board::BoundingBox, 5000);
   aBoard.saveCairo("testDisplayFC-cairo.svg", Board2D::CairoSVG, Board::BoundingBox, 5000);
 #endif
-  
+
   return true;
 }
 
@@ -570,9 +570,9 @@ int main( int argc, char** argv )
   for ( int i = 0; i < argc; ++i )
     trace.info() << " " << argv[ i ];
   trace.info() << endl;
-  
-  bool res = 
-    testConstructors() &&  
+
+  bool res =
+    testConstructors() &&
     testPublicSercives() &&
     testPointsIterators() &&
     testCodesIterators() &&
@@ -582,7 +582,7 @@ int main( int argc, char** argv )
   trace.emphase() << ( res ? "Passed." : "Error." ) << endl;
 
   trace.endBlock();
-  
+
   return res ? 0 : 1;
 }
 //                                                                           //

--- a/tests/geometry/volumes/distance/testDistanceTransformationND.cpp
+++ b/tests/geometry/volumes/distance/testDistanceTransformationND.cpp
@@ -57,17 +57,17 @@ bool testDistanceTransformND()
 {
   unsigned int nbok = 0;
   unsigned int nb = 0;
-  
+
   trace.beginBlock ( "Testing dT dim=5 ..." );
-  
+
   typedef SpaceND<5> TSpace;
   typedef TSpace::Point Point;
   typedef HyperRectDomain<TSpace> Domain;
-  int t[5] = {0,0,0,0,0};
+  TSpace::Integer t[5] = {0,0,0,0,0};
   Point a ( t );
-  int t2[5] = {15,15,15,15,15};
+  TSpace::Integer t2[5] = {15,15,15,15,15};
   Point b ( t2 );
-  int t3[5] = {3,3,3,3,3};
+  TSpace::Integer t3[5] = {3,3,3,3,3};
   Point c ( t3 );
   Point d;
 
@@ -86,7 +86,7 @@ bool testDistanceTransformND()
   typedef ExactPredicateLpSeparableMetric<TSpace, 2> L2Metric;
   L2Metric l2;
   DistanceTransformation<TSpace,Predicate,L2Metric> dt(&domain,&aPredicate, &l2 );
-  
+
   //We check the result
   bool res=true;
   for(Domain::ConstIterator itDom = domain.begin(), itDomend = domain.end();
@@ -107,12 +107,12 @@ bool testDistanceTransformND()
   res=false;
   }
     }
-  nbok += res ? 1 : 0; 
+  nbok += res ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
          << "true == true" << std::endl;
   trace.endBlock();
-  
+
   return nbok == nb;
 }
 

--- a/tests/images/testImageSimple.cpp
+++ b/tests/images/testImageSimple.cpp
@@ -95,8 +95,8 @@ bool testCreate()
   typedef Image<VImage6 > MyImage6;
   BOOST_CONCEPT_ASSERT(( concepts::CImage< MyImage6 > ));
 
-  int aa[] = {0,0,0,0,0,0};
-  int bb[] = {2,2,2,2,2,2};
+  Z2i::Integer aa[] = {0,0,0,0,0,0};
+  Z2i::Integer bb[] = {2,2,2,2,2,2};
   Domain6::Point A(aa);
   Domain6::Point B(bb);
 

--- a/tests/images/testImageSpanIterators.cpp
+++ b/tests/images/testImageSpanIterators.cpp
@@ -49,10 +49,10 @@ bool testSpanIterators()
     typedef Space3Type::Point Point;
     typedef HyperRectDomain<Space3Type> TDomain;
     typedef ImageContainerBySTLVector<TDomain, double> TContainerV;
-    
-    const int t[ ] = { 0, 0, 0};
-    const int t2[ ] = { 5, 5, 5};
-    const int t3[ ] = { 0, 0, 0};
+
+    const Point::Component t[ ] = { 0, 0, 0};
+    const Point::Component t2[ ] = { 5, 5, 5};
+    const Point::Component t3[ ] = { 0, 0, 0};
     Point a ( t );
     Point b ( t2 );
     Point c( t3 );
@@ -61,7 +61,7 @@ bool testSpanIterators()
     TContainerV myImageV ( TDomain(a,b ));
 
     double cpt=0;
-    //Image Construction 
+    //Image Construction
     for ( TContainerV::Iterator it = myImageV.begin();
             it != myImageV.end();
             ++it)
@@ -78,7 +78,7 @@ bool testSpanIterators()
     ++it)
       trace.info() << (*it)<<" ";
     trace.info() << endl;
-    
+
     //We process a 1D slice
     trace.info()<<"Slice dim 1 ";
     for ( TContainerV::SpanIterator it = myImageV.spanBegin(c,1), itend = myImageV.spanEnd(c,1);
@@ -86,7 +86,7 @@ bool testSpanIterators()
     ++it)
       trace.info() << (*it)<<" ";
     trace.info() << endl;
-  
+
     //We process a 1D slice
     trace.info()<<"Slice dim 2 ";
     for ( TContainerV::SpanIterator it = myImageV.spanBegin(c,2), itend = myImageV.spanEnd(c,2);
@@ -94,7 +94,7 @@ bool testSpanIterators()
     ++it)
       trace.info() << (*it)<<" ";
     trace.info() << endl;
-  
+
 
     //We process a 1D slice to set a value
     trace.info()<<"SetValue Slice dim 1 "<<endl;
@@ -102,7 +102,7 @@ bool testSpanIterators()
     it != itend;
     ++it)
       myImageV.setValue(it, 12);
-    
+
     //We check the a 1D slice
     trace.info()<<"Check Slice dim 1 ";
     for ( TContainerV::SpanIterator it = myImageV.spanBegin(c,1), itend = myImageV.spanEnd(c,1);
@@ -110,9 +110,9 @@ bool testSpanIterators()
     ++it)
       trace.info() << (*it)<<" ";
     trace.info() << endl;
-  
 
-  
+
+
     trace.endBlock();
 
     return true;

--- a/tests/images/testSliceImageFromFunctor.cpp
+++ b/tests/images/testSliceImageFromFunctor.cpp
@@ -64,23 +64,23 @@ bool testSliceImageFromFunctor()
   typedef DGtal::ConstImageAdapter<Image3D, DGtal::Z2i::Domain, functors::Projector< DGtal::Z3i::Space>,
 				   Image3D::Value,  DGtal::functors::Identity >  MySliceImageAdapter;
 
-  typedef DGtal::ConstImageAdapter<Image3D, DGtal::Z2i::Domain, functors::SliceRotator2D< HyperRectDomain<SpaceND<3, int> >, int>,
+  typedef DGtal::ConstImageAdapter<Image3D, DGtal::Z2i::Domain, functors::SliceRotator2D< HyperRectDomain< DGtal::Z3i::Space >, DGtal::Z3i::Integer>,
 				   Image3D::Value,  DGtal::functors::Identity >  MyRotatorSliceImageAdapter;
 
   bool res= true;
-  Image3D image = VolReader<Image3D>::importVol( filename ); 
+  Image3D image = VolReader<Image3D>::importVol( filename );
   DGtal::functors::Projector<DGtal::Z2i::Space>  projX(0); projX.initRemoveOneDim(0);
-  DGtal::Z2i::Domain domainX(projX(image.domain().lowerBound()), 
+  DGtal::Z2i::Domain domainX(projX(image.domain().lowerBound()),
 			     projX(image.domain().upperBound()));
 
- 
+
   DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctor(0); aSliceFunctor.initAddOneDim(0);
   const auto identityFunctor = DGtal::functors::Identity();
   MySliceImageAdapter sliceImageX(image, domainX, aSliceFunctor, identityFunctor);
   res &= PGMWriter<MySliceImageAdapter>::exportPGM("exportedSlice2DDimX.pgm",sliceImageX);
-  
-   DGtal::functors::Projector<DGtal::Z2i::Space>  projY(0); projY.initRemoveOneDim(1); 
-  DGtal::Z2i::Domain domainY(projY(image.domain().lowerBound()), 
+
+   DGtal::functors::Projector<DGtal::Z2i::Space>  projY(0); projY.initRemoveOneDim(1);
+  DGtal::Z2i::Domain domainY(projY(image.domain().lowerBound()),
 			     projY(image.domain().upperBound()));
 
   DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctor2(0); aSliceFunctor2.initAddOneDim(1);
@@ -89,7 +89,7 @@ bool testSliceImageFromFunctor()
 
 
   DGtal::functors::Projector<DGtal::Z2i::Space>  projZ(0); projZ.initRemoveOneDim(2);
-  DGtal::Z2i::Domain domainZ(projZ(image.domain().lowerBound()), 
+  DGtal::Z2i::Domain domainZ(projZ(image.domain().lowerBound()),
 			     projZ(image.domain().upperBound()));
 
 
@@ -97,24 +97,24 @@ bool testSliceImageFromFunctor()
   MySliceImageAdapter sliceImageZ(image, domainZ, aSliceFunctor3, identityFunctor);
   res &= PGMWriter<MySliceImageAdapter>::exportPGM("exportedSlice2DDimZ.pgm",sliceImageZ);
 
-  
-  PointVector<3, int> center(0,0,0);  
-  DGtal::functors::SliceRotator2D< HyperRectDomain<SpaceND<3, int> >, int> sliceRot(2, image.domain(), 0, 2, M_PI/4.0, center);
-  
-  
+
+  PointVector<3, DGtal::Z3i::Integer> center(0,0,0);
+  DGtal::functors::SliceRotator2D< HyperRectDomain< DGtal::Z3i::Space >, DGtal::Z3i::Integer> sliceRot(2, image.domain(), 0, 2, M_PI/4.0, center);
+
+
   MyRotatorSliceImageAdapter sliceRotImageZ(image, domainZ, sliceRot, identityFunctor);
   res &= PGMWriter<MyRotatorSliceImageAdapter>::exportPGM("exportedRotSliceZ.pgm",sliceRotImageZ);
 
-  
-  
 
 
-  nbok += res ? 1 : 0; 
+
+
+  nbok += res ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
 	       << "true == true" << std::endl;
   trace.endBlock();
-  
+
   return nbok == nb;
 }
 

--- a/tests/kernel/testDigitalSet.cpp
+++ b/tests/kernel/testDigitalSet.cpp
@@ -164,7 +164,7 @@ bool testDigitalSet( const DigitalSetType& aSet1, const DigitalSetType& aSet2 )
   << "Empty set: " << set1 << std::endl;
 
   //insertion
-  std::set<Point> v; 
+  std::set<Point> v;
   Coordinate t [] = { 4, 3, 3 , 4};
   Coordinate t2[] = { 2, 5, 3 , 5};
   Coordinate t3[] =  { 2, 5, 3 , 4} ;
@@ -185,20 +185,20 @@ bool testDigitalSet( const DigitalSetType& aSet1, const DigitalSetType& aSet2 )
   << "Insertion (3 elements): " << set1 << std::endl;
 
   //iterate
-  bool flag = true; 
-  for (typename DigitalSetType::Iterator it = set1.begin(); 
-       it != set1.end(); ++it) 
+  bool flag = true;
+  for (typename DigitalSetType::Iterator it = set1.begin();
+       it != set1.end(); ++it)
     {
       if (v.find( *it ) == v.end())
-	flag = false; 
-    } 
+	flag = false;
+    }
   nbok += (flag) ? 1 : 0;
   nb++;
   trace.info() << "Iterate: (" << nbok << "/" << nb << ") "
   	       << std::endl;
 
   //erasure
-  set1.erase( b ); 
+  set1.erase( b );
   nbok += ( (set1.size() == 2)
   	    &&(set1.find( b ) == set1.end()) )? 1 : 0;
   nb++;
@@ -206,7 +206,7 @@ bool testDigitalSet( const DigitalSetType& aSet1, const DigitalSetType& aSet2 )
   << "Erase one element by key (2 remain): " << set1 << std::endl;
 
   typename DigitalSetType::Iterator it = set1.find( c );
-  set1.erase( it ); 
+  set1.erase( it );
   nbok += ( (set1.size() == 1)
   	    &&(set1.find( c ) == set1.end()) )? 1 : 0;
   nb++;
@@ -215,21 +215,21 @@ bool testDigitalSet( const DigitalSetType& aSet1, const DigitalSetType& aSet2 )
 
   //other sets
   DigitalSetType set2( aSet2 );
-  DigitalSetInserter<DigitalSetType> inserter(set2); 
-  set1.computeComplement(inserter); 
+  DigitalSetInserter<DigitalSetType> inserter(set2);
+  set1.computeComplement(inserter);
   nbok += (set2.size() == (set2.domain().size()-1))? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
   << "Complement: " << set2 << std::endl;
 
-  set2 += set1; 
+  set2 += set1;
   nbok += (set2.size() == (set2.domain().size()))? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
   << "Union: " << set2 << std::endl;
 
   //clear
-  set1.clear(); 
+  set1.clear();
   nbok += ( (set1.size() == 0)&&(set1.empty()) ) ? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
@@ -330,7 +330,7 @@ bool testDigitalSetDomain()
   Point l(  49, 0  );
 
   trace.beginBlock ( "Creating disk( r=50.0 ) ..." );
-  for ( Domain::ConstIterator it = domain.begin(); 
+  for ( Domain::ConstIterator it = domain.begin();
   it != domain.end();
   ++it )
     {
@@ -372,7 +372,7 @@ bool testDigitalSetConcept()
   BOOST_CONCEPT_ASSERT(( concepts::CDomain< concepts::CDomainArchetype< Space > > ));
   typedef concepts::CDigitalSetArchetype<Z2i::Domain> DigitalSetArchetype;
   BOOST_CONCEPT_ASSERT(( concepts::CDigitalSet<DigitalSetArchetype> ));
-  
+
   return true;
 }
 
@@ -382,9 +382,9 @@ int main()
   typedef HyperRectDomain<Space4Type> Domain;
   typedef Space4Type::Point Point;
 
-  DGtal::int32_t t[] =  { 1, 2, 3 , 4};
+  Space4Type::Integer t[] =  { 1, 2, 3 , 4};
   Point a ( t );
-  DGtal::int32_t t2[] = { 5, 5, 3 , 5};
+  Space4Type::Integer t2[] = { 5, 5, 3 , 5};
   Point b ( t2);
   trace.beginBlock ( "HyperRectDomain init" );
 
@@ -405,10 +405,10 @@ int main()
   trace.endBlock();
 
   trace.beginBlock( "DigitalSetFromMap" );
-  typedef ImageContainerBySTLMap<Domain,short int> Map; 
+  typedef ImageContainerBySTLMap<Domain,short int> Map;
   Map map(domain); Map map2(domain);        //maps
-  DigitalSetFromMap<Map> setFromMap(map);   //sets from these maps 
-  DigitalSetFromMap<Map> setFromMap2(map2);  
+  DigitalSetFromMap<Map> setFromMap(map);   //sets from these maps
+  DigitalSetFromMap<Map> setFromMap2(map2);
   bool okMap = testDigitalSet< DigitalSetFromMap<Map> >( setFromMap, setFromMap2 );
   trace.endBlock();
 
@@ -417,13 +417,13 @@ int main()
   bool okAssoctestSet = testDigitalSet< DigitalSetByAssociativeContainer<Domain,Container> >
   ( DigitalSetByAssociativeContainer<Domain, Container>(domain), DigitalSetByAssociativeContainer<Domain, Container>(domain) );
   trace.endBlock();
-  
+
   trace.beginBlock( "DigitalSetByUnorderedSet" );
   typedef std::unordered_set<Point> ContainerU;
   bool okUnorderedSet = testDigitalSet< DigitalSetByAssociativeContainer<Domain,ContainerU> >
   ( DigitalSetByAssociativeContainer<Domain, ContainerU>(domain), DigitalSetByAssociativeContainer<Domain, ContainerU>(domain) );
   trace.endBlock();
-    
+
   bool okSelectorSmall = testDigitalSetSelector
       < Domain, SMALL_DS + LOW_VAR_DS + LOW_ITER_DS + LOW_BEL_DS >
       ( domain, "Small set" );
@@ -442,7 +442,7 @@ int main()
 
   bool okDigitalSetDrawSnippet = testDigitalSetBoardSnippet();
 
-  bool res = okVector && okSet && okMap 
+  bool res = okVector && okSet && okMap
       && okSelectorSmall && okSelectorBig && okSelectorMediumHBel
       && okDigitalSetDomain && okDigitalSetDraw && okDigitalSetDrawSnippet
      && okUnorderedSet && okAssoctestSet;

--- a/tests/kernel/testHyperRectDomain-snippet.cpp
+++ b/tests/kernel/testHyperRectDomain-snippet.cpp
@@ -45,8 +45,8 @@ int main()
   typedef DGtal::SpaceND<4> Space4D;
   typedef Space4D::Point Point4D;
 
-  const DGtal::int32_t rawA[ ] = { 1, 2, 3 ,4};
-  const DGtal::int32_t rawB[ ] = { 4, 4, 5 ,5};
+  const Space4D::Integer rawA[ ] = { 1, 2, 3 ,4};
+  const Space4D::Integer rawB[ ] = { 4, 4, 5 ,5};
   Point4D A ( rawA );
   Point4D B ( rawB );
 

--- a/tests/kernel/testHyperRectDomain.cpp
+++ b/tests/kernel/testHyperRectDomain.cpp
@@ -56,9 +56,9 @@ bool testSimpleHyperRectDomain()
   typedef SpaceND<4> Space4Type;
   typedef Space4Type::Point Point;
 
-  DGtal::int32_t t [] = { 1, 2, 3 , 4};
+  Space4Type::Integer t [] = { 1, 2, 3 , 4};
   Point a ( t );
-  DGtal::int32_t t2[] = { 5, 5, 3 , 4};
+  Space4Type::Integer t2[] = { 5, 5, 3 , 4};
   Point b ( t2 );
 
   trace.beginBlock ( "HyperRectDomain init" );
@@ -66,7 +66,7 @@ bool testSimpleHyperRectDomain()
   typedef HyperRectDomain<Space4Type> HRDomain4;
   BOOST_CONCEPT_ASSERT(( concepts::CDomain< HRDomain4 > ));
   BOOST_CONCEPT_ASSERT(( CConstBidirectionalRange<HRDomain4> ));
-      
+
   ///Empty domain using the default constructor
   HyperRectDomain<Space4Type> myEmptyDomain;
   trace.info() << "Empty Domain: " << myEmptyDomain << std::endl;
@@ -120,14 +120,14 @@ bool testIterator()
   for ( HyperRectDomain<TSpace>::ConstReverseIterator it = myHyperRectDomain.rbegin(),
     itend = myHyperRectDomain.rend(); it != itend; ++it )
     trace.warning() << ( *it ) << std::endl;
-  
+
   trace.emphase() << "Iterator 2d (permutation initializer list): ";
-  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstIterator 
+  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstIterator
     it = myHyperRectDomain.subRange( {1, 0} ).begin();
   it != myHyperRectDomain.subRange( {1, 0} ).end(); ++it )
     trace.warning() << ( *it ) << std::endl;
   trace.emphase() << "Reverse Iterator 2d (permutation initializer list): ";
-  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstReverseIterator 
+  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstReverseIterator
     it = myHyperRectDomain.subRange( {1, 0} ).rbegin(),
     itend=myHyperRectDomain.subRange( {1, 0} ).rend(); it!=itend;  ++it )
     trace.warning() << ( *it ) << std::endl;
@@ -138,7 +138,7 @@ bool testIterator()
   it != myHyperRectDomain.subRange( {1, 0} ).end(); ++it )
     trace.warning() << ( *it ) << std::endl;
   trace.emphase() << "Reverse Iterator 2d (permutation+starting initializer list): ";
-  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstReverseIterator 
+  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstReverseIterator
     it = myHyperRectDomain.subRange( {1, 0} ).rbegin(c),
     itend=myHyperRectDomain.subRange( {1, 0} ).rend(); it !=itend ; ++it )
     trace.warning() << ( *it ) << std::endl;
@@ -149,7 +149,7 @@ bool testIterator()
   it != myHyperRectDomain.subRange( {1} ).end(); ++it )
     trace.warning() << ( *it ) << std::endl;
   trace.emphase() << "Reverse Iterator 2d (span initializer list): ";
-  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstReverseIterator 
+  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstReverseIterator
     it = myHyperRectDomain.subRange( {1} ).rbegin(),
     itend=myHyperRectDomain.subRange( {1} ).rend(); it != itend; ++it )
     trace.warning() << ( *it ) << std::endl;
@@ -160,7 +160,7 @@ bool testIterator()
   it != myHyperRectDomain.subRange( {1} , c ).end(); ++it )
     trace.warning() << ( *it ) << std::endl;
   trace.emphase() << "Reverse Iterator 2d (span+starting initializer list): ";
-  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstReverseIterator 
+  for ( HyperRectDomain<TSpace>::ConstSubRange::ConstReverseIterator
     it = myHyperRectDomain.subRange( {1} , c ).rbegin(c),
     itend=myHyperRectDomain.subRange( {1} , c ).rend(); it !=itend; ++it )
     trace.warning() << ( *it ) << std::endl;
@@ -169,9 +169,9 @@ bool testIterator()
   typedef SpaceND<4> TSpace4D;
   typedef TSpace4D::Point Point4D;
 
-  DGtal::int32_t t[] = {1, 1, 1, 1};
+  TSpace4D::Integer t[] = {1, 1, 1, 1};
   Point4D a4D ( t );
-  DGtal::int32_t t2[] = {3, 3, 3, 3};
+  TSpace4D::Integer t2[] = {3, 3, 3, 3};
   Point4D b4D ( t2 );
 
   HyperRectDomain<TSpace4D> myHyperRectDomain4D ( a4D, b4D );
@@ -187,7 +187,7 @@ bool testIterator()
     itend=myHyperRectDomain4D.rend(); it != itend; ++it )
     trace.info() << ( *it ) << std::endl;
 
-  
+
   trace.emphase() << "Iterator 4d by using order different from lexicographic initializer list: ";
   for ( HyperRectDomain<TSpace4D>::ConstSubRange::ConstIterator
     it = myHyperRectDomain4D.subRange( {3, 2, 1, 0}).begin();
@@ -211,7 +211,7 @@ bool testIterator()
     trace.info() << ( *it3 ) << std::endl;
 
   trace.emphase() << "Decreasing iterator on a subset of 4d by using order different from lexicographic initializer list: ";
-  HyperRectDomain<TSpace4D>::ConstSubRange::ConstIterator 
+  HyperRectDomain<TSpace4D>::ConstSubRange::ConstIterator
     it4 = myHyperRectDomain4D.subRange({1, 3}).begin();
   HyperRectDomain<TSpace4D>::ConstSubRange::ConstIterator
     it5 = myHyperRectDomain4D.subRange({1, 3}).end();
@@ -228,9 +228,9 @@ bool testReverseIterator()
 {
   typedef SpaceND<4> TSpace4D;
   typedef TSpace4D::Point Point4D;
-  DGtal::int32_t t[] = {1, 1, 1, 1};
+  TSpace4D::Integer t[] = {1, 1, 1, 1};
   Point4D a4D (t);
-  DGtal::int32_t t2[] = {3, 3, 3, 3};
+  TSpace4D::Integer t2[] = {3, 3, 3, 3};
   Point4D b4D (t2);
 
   trace.beginBlock ( "Test reverse iterator" );
@@ -240,13 +240,13 @@ bool testReverseIterator()
 
   trace.emphase() << "Increasing order: ";
 
-  HyperRectDomain<TSpace4D>::ConstIterator 
+  HyperRectDomain<TSpace4D>::ConstIterator
     it = myHyperRectDomain4D.begin();
   for ( ; it != myHyperRectDomain4D.end(); ++it )
     trace.info() << ( *it ) << std::endl;
 
   trace.emphase() << "Now decreasing order: ";
-  HyperRectDomain<TSpace4D>::ConstIterator 
+  HyperRectDomain<TSpace4D>::ConstIterator
     it2 = myHyperRectDomain4D.begin();
   --it;
   --it2;
@@ -264,9 +264,9 @@ bool testSTLCompat()
 {
   typedef SpaceND<4> TSpace4D;
   typedef TSpace4D::Point Point4D;
-  DGtal::int32_t t[] = {1, 1, 1, 1};
+  TSpace4D::Integer t[] = {1, 1, 1, 1};
   Point4D a4D (t);
-  DGtal::int32_t t2[] = {3, 3, 3, 3};
+  TSpace4D::Integer t2[] = {3, 3, 3, 3};
   Point4D b4D (t2);
 
   trace.beginBlock ( "TestSTL Compatibility" );
@@ -292,13 +292,13 @@ bool testEmptyDomain()
 
   unsigned int nb = 0;
   unsigned int nbok = 0;
-  
+
   trace.beginBlock( "Test empty domain." );
-  
+
   const TDomain nonempty_domain( TPoint::diagonal(0), TPoint::diagonal(0) );
   ++nb; nbok += nonempty_domain.isEmpty() ? 0 : 1;
   trace.info() << "(" << nbok << "/" << nb << ") Creating non-empty domain & checking isEmpty." << std::endl;
-  
+
   const TDomain default_domain;
   ++nb; nbok += default_domain.isEmpty() ? 1 : 0;
   trace.info() << "(" << nbok << "/" << nb << ") Creating default empty domain & checking isEmpty." << std::endl;
@@ -322,7 +322,7 @@ bool testEmptyDomain()
 
   ++nb; nbok += range.rbegin() == range.rend() ? 1 : 0;
   trace.info() << "(" << nbok << "/" << nb << ") Checking that rbegin() == rend() for sub-range {0,1,2}" << std::endl;
-  
+
   range = domain.subRange( 2, 1, 0, domain.lowerBound()  );
   ++nb; nbok += range.begin() == range.end() ? 1 : 0;
   trace.info() << "(" << nbok << "/" << nb << ") Checking that begin() == end() for sub-range {2,1,0}" << std::endl;
@@ -336,14 +336,14 @@ bool testEmptyDomain()
 
   ++nb; nbok += range.rbegin() == range.rend() ? 1 : 0;
   trace.info() << "(" << nbok << "/" << nb << ") Checking that rbegin() == rend() for sub-range {0,2}" << std::endl;
-  
+
   range = domain.subRange( 2, 0, domain.lowerBound()  );
   ++nb; nbok += range.begin() == range.end() ? 1 : 0;
   trace.info() << "(" << nbok << "/" << nb << ") Checking that begin() == end() for sub-range {2,0}" << std::endl;
 
   ++nb; nbok += range.rbegin() == range.rend() ? 1 : 0;
   trace.info() << "(" << nbok << "/" << nb << ") Checking that rbegin() == rend() for sub-range {2,0}" << std::endl;
-  
+
   range = domain.subRange( 1, domain.lowerBound()  );
   ++nb; nbok += range.begin() == range.end() ? 1 : 0;
   trace.info() << "(" << nbok << "/" << nb << ") Checking that begin() == end() for sub-range {1}" << std::endl;
@@ -353,7 +353,7 @@ bool testEmptyDomain()
 
   trace.endBlock();
   return nb == nbok;
-  
+
 }
 
 int main()

--- a/tests/topology/testCellularGridSpaceND.cpp
+++ b/tests/topology/testCellularGridSpaceND.cpp
@@ -61,6 +61,7 @@ bool testCellularGridSpaceND()
   typedef typename KSpace::Cell Cell;
   typedef typename KSpace::SCell SCell;
   typedef typename KSpace::Point Point;
+  typedef typename KSpace::Integer Integer;
   typedef typename KSpace::DirIterator DirIterator;
   typedef typename KSpace::Cells Cells;
   unsigned int nbok = 0;
@@ -68,8 +69,8 @@ bool testCellularGridSpaceND()
 
   trace.beginBlock ( "Testing block KSpace instantiation and scan ..." );
   KSpace K;
-  int xlow[ 4 ] = { -3, -2, -2, -1 };
-  int xhigh[ 4 ] = { 5, 3, 2, 3 };
+  Integer xlow[ 4 ] = { -3, -2, -2, -1 };
+  Integer xhigh[ 4 ] = { 5, 3, 2, 3 };
   Point low( xlow );
   Point high( xhigh );
   bool space_ok = K.init( low, high, true );
@@ -78,7 +79,7 @@ bool testCellularGridSpaceND()
   trace.info() << "(" << nbok << "/" << nb << ") "
          << "K.init( low, high )" << std::endl;
   trace.info() << "K.dim()=" << K.dimension << endl;
-  int spel[ 4 ] = { 1, 1, 1, 1 }; // pixel
+  Integer spel[ 4 ] = { 1, 1, 1, 1 }; // pixel
   Point kp( spel );
   Cell center = K.uCell( kp );
   Cell c1 = K.uCell( kp );
@@ -205,8 +206,8 @@ bool testSurfelAdjacency()
 
   trace.beginBlock ( "Testing block KSpace instantiation and scan ..." );
   KSpace K;
-  int xlow[ 4 ] = { -3, -3, -3, -3 };
-  int xhigh[ 4 ] = { 5, 3, 3, 3 };
+  Integer xlow[ 4 ] = { -3, -3, -3, -3 };
+  Integer xhigh[ 4 ] = { 5, 3, 3, 3 };
   Point low( xlow );
   Point high( xhigh );
   bool space_ok = K.init( low, high, true );
@@ -226,7 +227,7 @@ bool testSurfelAdjacency()
   trace.info() << endl;
   trace.endBlock();
 
-  int spel[ 4 ] = { 1, 1, 1, 1 }; // pixel
+  Integer spel[ 4 ] = { 1, 1, 1, 1 }; // pixel
   Point kp( spel );
   SCell sspel = K.sCell( kp, K.POS );
   trace.beginBlock ( "Testing surfel directness ..." );
@@ -270,7 +271,7 @@ bool testSurfelAdjacency()
   typedef typename DigitalSetSelector< Domain, BIG_DS+HIGH_BEL_DS >::Type DigitalSet;
   Domain domain( low, high );
   DigitalSet shape_set( domain );
-  int center[ 4 ] = { 1, 0, 0, 0 }; // pixel
+  Integer center[ 4 ] = { 1, 0, 0, 0 }; // pixel
   Point pcenter( center );
   Shapes<Domain>::addNorm1Ball( shape_set, pcenter, 1 );
   trace.info() << "surfel      = " << surfel << endl;
@@ -332,8 +333,8 @@ bool testCellDrawOnBoard()
   unsigned int nb = 0;
   trace.beginBlock ( "Testing cell draw on digital board ..." );
   KSpace K;
-  int xlow[ 4 ] = { -3, -3 };
-  int xhigh[ 4 ] = { 5, 3 };
+  Integer xlow[ 4 ] = { -3, -3 };
+  Integer xhigh[ 4 ] = { 5, 3 };
   Point low( xlow );
   Point high( xhigh );
   bool space_ok = K.init( low, high, true );
@@ -342,14 +343,14 @@ bool testCellDrawOnBoard()
   board.setUnit( LibBoard::Board::UCentimeter );
   board << SetMode( domain.className(), "Paving" )
   << domain;
-  int spel[ 2 ] = { 1, 1 }; // pixel 0,0
+  Integer spel[ 2 ] = { 1, 1 }; // pixel 0,0
   Point kp( spel );
   Cell uspel = K.uCell( kp );
   board << uspel
   << low << high
   << K.uIncident( uspel, 0, false )
   << K.uIncident( uspel, 1, false );
-  int spel2[ 2 ] = { 5, 1 }; // pixel 2,0
+  Integer spel2[ 2 ] = { 5, 1 }; // pixel 2,0
   Point kp2( spel2 );
   SCell sspel2 = K.sCell( kp2, K.POS );
   board << CustomStyle( sspel2.className(),

--- a/tests/topology/testSurfaceHelper.cpp
+++ b/tests/topology/testSurfaceHelper.cpp
@@ -61,65 +61,69 @@ bool testComputeInterior()
 {
   unsigned int nbok = 0;
   unsigned int nb = 0;
-  typedef  KhalimskySpaceND<2, int>::SCell SCell;
-  typedef ImageContainerBySTLMap< Z2i::Domain, bool> BoolImage2D;
-  
+  typedef SpaceND<2, int> Space;
+  typedef KhalimskySpaceND<2, int> KSpace;
+  typedef HyperRectDomain< Space > Domain;
+  typedef KSpace::SCell SCell;
+  typedef KSpace::Point Point;
+  typedef ImageContainerBySTLMap< Domain, bool> BoolImage2D;
+
 
   trace.beginBlock ( "Testing computation of interior from a freeman chain ..." );
   std::string freemanChainFilename = testPath + "samples/contourS.fc";
   std::string freemanChainFilename2 = testPath + "samples/SmallBall.fc";
   fstream fst;
   fst.open (freemanChainFilename.c_str(), ios::in);
-  FreemanChain<Z2i::Space::Integer> fc(fst);
+  FreemanChain<Space::Integer> fc(fst);
   fst.close();
   fst.open (freemanChainFilename2.c_str(), ios::in);
-  FreemanChain<Z2i::Space::Integer> fc2(fst);
+  FreemanChain<Space::Integer> fc2(fst);
   fst.close();
   std::set<SCell> boundaryCell;
   std::set<SCell> boundaryCell2;
-  DGtal::KhalimskySpaceND< 2, int > K, Ko;
-  
-  int minx, miny, maxx, maxy; 
+  KSpace K, Ko;
+
+  int minx, miny, maxx, maxy;
   fc.computeBoundingBox(minx, miny, maxx, maxy);
 
-  BoolImage2D::Domain dom(Z2i::Point(minx-5,miny-5), Z2i::Point(maxx+5, maxy+5));
+  BoolImage2D::Domain dom(Point(minx-5,miny-5), Point(maxx+5, maxy+5));
   trace.info() << "Domain defined by :" << dom.lowerBound() << " " << dom.upperBound() << std::endl;
   K.init(dom.lowerBound(), dom.upperBound(), true);
   Ko.init(dom.lowerBound(), dom.upperBound(), false);
-  FreemanChain<Z2i::Space::Integer>::getInterPixelLinels(K, fc, boundaryCell );
+  FreemanChain<Space::Integer>::getInterPixelLinels(K, fc, boundaryCell );
 
   BoolImage2D interiorImage(dom);
-  unsigned int nbInt = Surfaces<DGtal::KhalimskySpaceND< 2, int > >::uFillInterior(K, SurfelSetPredicate<std::set<SCell>, SCell>(boundaryCell), 
+  unsigned int nbInt = Surfaces<KSpace>::uFillInterior(K, SurfelSetPredicate<std::set<SCell>, SCell>(boundaryCell),
                                                                                    interiorImage, 1, false);
   trace.info() << "Interior size: " << nbInt << " (awaited:  3082)" <<  std::endl;
 
   BoolImage2D exteriorImage(dom);
-  unsigned int nbExt = Surfaces<DGtal::KhalimskySpaceND< 2, int > >::uFillExterior(K ,SurfelSetPredicate<std::set<SCell>, SCell>(boundaryCell),
+  unsigned int nbExt = Surfaces< KSpace >::uFillExterior(K ,SurfelSetPredicate<std::set<SCell>, SCell>(boundaryCell),
                                                                                    exteriorImage, 1, true);
-  unsigned int nbExto = Surfaces<DGtal::KhalimskySpaceND< 2, int > >::uFillExterior(Ko ,SurfelSetPredicate<std::set<SCell>, SCell>(boundaryCell), 
+  unsigned int nbExto = Surfaces< KSpace >::uFillExterior(Ko ,SurfelSetPredicate<std::set<SCell>, SCell>(boundaryCell),
                                                                                     exteriorImage, 1, true);
   trace.info() << "Exterior size: (KhalimskySpaceND open) " << nbExto << " (awaited:   9182)" <<  std::endl;
   trace.info() << "Exterior size: (KhalimskySpaceND close)" << nbExt << " (awaited:   9182)" <<  std::endl;
 
 
-  DGtal::KhalimskySpaceND< 2, int > K2, K2c; 
-  int minx2, miny2, maxx2, maxy2; 
-  fc2.computeBoundingBox(minx2, miny2, maxx2, maxy2); 
-  BoolImage2D::Domain dom2(Z2i::Point(minx2-5,miny2-5), Z2i::Point(maxx2+5, maxy2+5));
+  KSpace K2, K2c;
+  int minx2, miny2, maxx2, maxy2;
+  fc2.computeBoundingBox(minx2, miny2, maxx2, maxy2);
+  BoolImage2D::Domain dom2(Point(minx2-5,miny2-5), Point(maxx2+5, maxy2+5));
   K2.init(dom2.lowerBound(), dom2.upperBound(), false);
   K2c.init(dom2.lowerBound(), dom2.upperBound(), true);
-  FreemanChain<Z2i::Space::Integer>::getInterPixelLinels(K2, fc2, boundaryCell2 ); 
+  FreemanChain<Space::Integer>::getInterPixelLinels(K2, fc2, boundaryCell2 );
 
   BoolImage2D interiorImage2(dom2);
-  unsigned int nbInt2 = Surfaces<DGtal::KhalimskySpaceND< 2, int > >::uFillInterior(K2, SurfelSetPredicate<std::set<SCell>,SCell>(boundaryCell2), 
+  unsigned int nbInt2 = Surfaces< KSpace >::uFillInterior(K2, SurfelSetPredicate<std::set<SCell>,SCell>(boundaryCell2),
                                                                                     interiorImage2, 1, false);
  trace.info() << "Interior size2: (KhalimskySpaceND open) " << nbInt2 << " (awaited:  196316)" <<  std::endl;
- unsigned int nbInt2c = Surfaces<DGtal::KhalimskySpaceND< 2, int > >::uFillInterior(K2c, SurfelSetPredicate<std::set<SCell>,SCell>(boundaryCell2), 
+ unsigned int nbInt2c = Surfaces< KSpace >::uFillInterior(K2c, SurfelSetPredicate<std::set<SCell>,SCell>(boundaryCell2),
                                                                                     interiorImage2, 1, false);
  trace.info() << "Interior size2: (KhalimskySpaceND closed) " << nbInt2c << " (awaited:  196316)" <<  std::endl;
-  
+
   // Displaying interiorCell
-  Board2D aBoard, aBoard2, aBoard3; 
+  Board2D aBoard, aBoard2, aBoard3;
 
   for( BoolImage2D::Domain::ConstIterator it = interiorImage.domain().begin();  it!= interiorImage.domain().end(); ++it){
     if(interiorImage(*it)){
@@ -129,22 +133,22 @@ bool testComputeInterior()
 
   for( BoolImage2D::Domain::ConstIterator it = exteriorImage.domain().begin();  it!= exteriorImage.domain().end(); it++){
     if(exteriorImage(*it)){
-      aBoard3 << *it; 
+      aBoard3 << *it;
     }
   }
 
   for( BoolImage2D::Domain::ConstIterator it = interiorImage2.domain().begin();  it!= interiorImage2.domain().end(); it++){
     if(interiorImage2(*it)){
-      aBoard2 << *it; 
+      aBoard2 << *it;
     }
   }
- 
-  aBoard<< CustomStyle( (*(boundaryCell.begin())).className(), 
-                        new CustomColors(  Color::Red,  Color::None ) );          
-  aBoard3<< CustomStyle( (*(boundaryCell.begin())).className(), 
-                        new CustomColors(  Color::Red,  Color::None ) );          
-  aBoard2<< CustomStyle( (*(boundaryCell.begin())).className(), 
-                        new CustomColors(  Color::Red,  Color::None ) );          
+
+  aBoard<< CustomStyle( (*(boundaryCell.begin())).className(),
+                        new CustomColors(  Color::Red,  Color::None ) );
+  aBoard3<< CustomStyle( (*(boundaryCell.begin())).className(),
+                        new CustomColors(  Color::Red,  Color::None ) );
+  aBoard2<< CustomStyle( (*(boundaryCell.begin())).className(),
+                        new CustomColors(  Color::Red,  Color::None ) );
   for( std::set<SCell>::const_iterator it= boundaryCell.begin();  it!= boundaryCell.end(); it++){
     aBoard << *it;
     aBoard3 << *it;
@@ -154,30 +158,30 @@ bool testComputeInterior()
     aBoard2 << *it;
   }
 
-  aBoard << CustomStyle( fc.className(), 
-                        new CustomColors(  Color::Red,  Color::None ) );        
-  aBoard3 << CustomStyle( fc.className(), 
-                        new CustomColors(  Color::Red,  Color::None ) );        
-  aBoard2 << CustomStyle( fc.className(), 
-                        new CustomColors(  Color::Red,  Color::None ) );        
+  aBoard << CustomStyle( fc.className(),
+                        new CustomColors(  Color::Red,  Color::None ) );
+  aBoard3 << CustomStyle( fc.className(),
+                        new CustomColors(  Color::Red,  Color::None ) );
+  aBoard2 << CustomStyle( fc.className(),
+                        new CustomColors(  Color::Red,  Color::None ) );
   aBoard << SetMode( fc.className(), "InterGrid" );
-  aBoard3 << SetMode( fc.className(), "InterGrid" ); 
+  aBoard3 << SetMode( fc.className(), "InterGrid" );
   aBoard2 << SetMode( fc.className(), "InterGrid" );
   aBoard << fc;
   aBoard3 << fc;
-  aBoard2 << fc2;    
-  
+  aBoard2 << fc2;
+
   aBoard.saveEPS("testSurfaceHelperComputeInterior.eps");
   aBoard3.saveEPS("testSurfaceHelperComputeExterior.eps");
   aBoard2.saveEPS("testSurfaceHelperComputeInterior2.eps");
-  nbok += (nbInt == 3082 && nbInt2 == 196316 && nbInt2c == 196316 && nbExt== 9182 && nbExto== 9182)? 1 : 0; 
+  nbok += (nbInt == 3082 && nbInt2 == 196316 && nbInt2c == 196316 && nbExt== 9182 && nbExto== 9182)? 1 : 0;
   nb++;
   trace.info() << "(" << nbok << "/" << nb << ") "
 	       << nbInt << " (interiorCell.size()) == 3014 and "
                << nbInt2 << " (interiorCell2.size()) == 60196 "
                << std::endl;
   trace.endBlock();
-  
+
   return nbok == nb;
 }
 
@@ -188,7 +192,7 @@ test3dSurfaceHelper()
   typedef DGtal::DigitalSetBySTLSet<DGtal::Z3i::Domain> Set;
   unsigned int nbok = 0;
   unsigned int nb = 0;
-  
+
   trace.beginBlock ( "Testing extraction of 3D connected component ..." );
   // import point from a vol file
   typedef ImageContainerBySTLVector< Z3i::Domain, unsigned char> Image3dChar;
@@ -199,7 +203,7 @@ test3dSurfaceHelper()
       if(image(p)>0)
         {
           aSet.insert(p);
-        } 
+        }
      }
    Z3i::KSpace Kc;
    Kc.init(image.domain().lowerBound(),
@@ -211,12 +215,12 @@ test3dSurfaceHelper()
    nbok += vectConnectedSCell.size()==1;
    trace.info() << "Connected component :" << vectConnectedSCell.size() << " (should be 1) "  << std::endl;
    trace.endBlock();
-   
+
    trace.beginBlock("Test 3D filling interior of surface (in an closed KhalimskySpaceND ) ...");
    Image3dChar imageFilled(image.domain());
    std::set<Z3i::SCell> setSCell; for (auto const &s: vectConnectedSCell[0]) setSCell.insert(s);
    functors::SurfelSetPredicate<std::set<Z3i::SCell>,Z3i::SCell> surfacePred (setSCell);
-  
+
    unsigned int nbFilled = DGtal::Surfaces<DGtal::Z3i::KSpace>::uFillInterior(Kc, surfacePred, imageFilled, 1);
    trace.info() << "Nb voxel filled:" << nbFilled << " (should be " << aSet.size() << " )"  << std::endl;
    nb++;
@@ -234,8 +238,8 @@ test3dSurfaceHelper()
    nbok += nbFilled2 == aSet.size();
    trace.endBlock();
 
-   
-   trace.beginBlock("Test 3D filling exterior of surface (in an closed KhalimskySpaceND ) ...");  
+
+   trace.beginBlock("Test 3D filling exterior of surface (in an closed KhalimskySpaceND ) ...");
    unsigned int nbFilled3 = DGtal::Surfaces<DGtal::Z3i::KSpace>::uFillExterior(Kc, surfacePred, imageFilled, 1);
    trace.info() << "Nb voxel filled:" << nbFilled3 << " (should be " << aSet.size() << " )"  << std::endl;
    nb++;
@@ -252,8 +256,8 @@ test3dSurfaceHelper()
    trace.endBlock();
 
 
-   
-   
+
+
   return nb == nbok;
 }
 
@@ -261,7 +265,7 @@ test3dSurfaceHelper()
 /**
 * Checks that method Surfaces::findABel can take in argument any pair
 * of points (one inside, one outside) to determine a boundary surfel
-* by dichotomy. 
+* by dichotomy.
 */
 template <typename KSpace3D>
 bool testFindABel()
@@ -275,7 +279,7 @@ bool testFindABel()
   unsigned int nbok = 0;
   unsigned int nb = 0;
   trace.beginBlock ( "Testing Surfaces::findABel." );
-  Point pts[ 8 ];  
+  Point pts[ 8 ];
   Point p1( -5, -5, -5 );
   Point p2(  5,  5,  5 );
   pts[ 0 ] = p1;
@@ -298,8 +302,8 @@ bool testFindABel()
       ++nb, nbok += K.sDim( bel ) == 2;
       trace.info() << "(" << nbok << "/" << nb << ") "
                    << " K.sDim( bel ) == " <<  K.sDim( bel ) << " (should be 2)" << std::endl;
-      SCell vox_in = K.sDirectIncident( bel, K.sOrthDir( bel ) ); 
-      SCell vox_out = K.sIndirectIncident( bel, K.sOrthDir( bel ) ); 
+      SCell vox_in = K.sDirectIncident( bel, K.sOrthDir( bel ) );
+      SCell vox_out = K.sIndirectIncident( bel, K.sOrthDir( bel ) );
       ++nb, nbok += aSet( K.sCoords( vox_in ) ) ? 1 : 0;
       trace.info() << "(" << nbok << "/" << nb << ") "
                    << " vox_in should be inside the shape." << std::endl;


### PR DESCRIPTION
# PR Description

The aim of this PR is to remove arithmetic ring issue when we change the integer type of `SpaceND`/`KhalimskySpaceND`.
By convention, we use `SpaceND<dim, int32_t>` and `KhalimskySpaceND<dim, int32_t>`.
But, in some case (if we want to reduce the memory footprint for example), we could be led to use `int16_t` instead of `int32_t` (or other).
The issue is that some algorithms are hard-coded to use `int32_t`. This PR try to resolve this issue.

*(I'm sorry, the reviewing process will not be easy because my editor has deleted some unnecessary space in comments ...)*

## Critical files modified

These files need to be closely reviewed.

- `AlphaThickSegmentComputer.h`
- `PowerMap.h` / `PowerMap.ih`
- `VoronoiMap.h` / `VoronoiMap.ih`
- `RigidTransformation3D.h`
- `Display2DFactory.ih`
- `DrawWithDisplay3DModifier.h`
- `BasicPointFunctors.h`

## Test files modified

- `testAlphaThickSegmentComputer.cpp`
- `testFrechetShortcut.cpp`
- `testFreemanChain.cpp`
- `testDistanceTransformationND.cpp`
- `testImageSimple.cpp`
- `testImageSpanIterators.cpp`
- `testSliceImageFromFunctor.cpp`
- `testDigitalSet.cpp`
- `testHyperRectDomain-snippet.cpp`
- `testHyperRectDomain.cpp`
- `testCellularGridSpaceND.cpp`
- `testSurfaceHelper.cpp`

# Checklist

- [N/A] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [N/A] Doxygen documentation of the code completed (classes, methods, types, members...)
- [N/A] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)

:octocat: 