### PR TITLE
Fix base doc

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,9 @@
  - Travis Continuous integration will check that DGtalTools still compiles with
    changes in new pull-requests. (David Coeurjolly,
    [#1133](https://github.com/DGtal-team/DGtal/pull/1133))
- - Add cmake configuration file NeighborhoodTablesConfig to decompress and install look up tables. (Pablo Hernandez-Cerdan, [#1155](https://github.com/DGtal-team/DGtal/pull/1155))
+ - Add cmake configuration file NeighborhoodTablesConfig to
+   decompress and install look up tables. (Pablo Hernandez-Cerdan,
+   [#1155](https://github.com/DGtal-team/DGtal/pull/1155))
 
 
 
@@ -25,6 +27,9 @@
    (Roland Denis, [#1140](https://github.com/DGtal-team/DGtal/pull/1140))
    (With ITK related compilation fix, Bertrand Kerautret
    [#1153](https://github.com/DGtal-team/DGtal/pull/1153))
+ - Moving all base concepts into namespace concepts. Update doc and
+   concepts graphs accordingly. (Jacques-Olivier Lachaud, [#1164]
+   (https://github.com/DGtal-team/DGtal/pull/1164)) 
 
 - *IO Package*
 
@@ -90,7 +95,8 @@
   - Fix interior/exterior fill methods of topology/helpers/Surfaces class which
     was wrong on 3d and on closed Khalimsky space.
     (Bertrand Kerautret, [#1156](https://github.com/DGtal-team/DGtal/pull/1156))
-  - Add pre-calculated look up tables to speed up Object::isSimple calculations. (Pablo Hernandez-Cerdan, [#1155](https://github.com/DGtal-team/DGtal/pull/1155))
+  - Add pre-calculated look up tables to speed up Object::isSimple calculations.
+    (Pablo Hernandez-Cerdan, [#1155](https://github.com/DGtal-team/DGtal/pull/1155))
 
 - *Shape Package*
   - Fix a tubular mesh construction problem (missing faces) which appears

--- a/src/DGtal/arithmetic/CPositiveIrreducibleFraction.h
+++ b/src/DGtal/arithmetic/CPositiveIrreducibleFraction.h
@@ -51,6 +51,9 @@
 namespace DGtal
 {
 
+  namespace concepts
+  {
+
 /////////////////////////////////////////////////////////////////////////////
 // class CPositiveIrreducibleFraction
 /**
@@ -157,7 +160,7 @@ except the last one. In this sense, a fraction is a sequence
 */
 template <typename T>
 struct CPositiveIrreducibleFraction 
-  : boost::CopyConstructible<T>, boost::DefaultConstructible<T>, boost::Assignable<T>, DGtal::CBackInsertable<T>, DGtal::CConstSinglePassRange<T>
+  : boost::CopyConstructible<T>, boost::DefaultConstructible<T>, boost::Assignable<T>, CBackInsertable<T>, CConstSinglePassRange<T>
 
 {
     // ----------------------- Concept checks ------------------------------
@@ -230,6 +233,8 @@ private:
 private:
 
 }; // end of concept CPositiveIrreducibleFraction
+
+} // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/arithmetic/Pattern.h
+++ b/src/DGtal/arithmetic/Pattern.h
@@ -79,7 +79,7 @@ namespace DGtal
   {
   public:
     typedef TFraction Fraction;
-    BOOST_CONCEPT_ASSERT(( CPositiveIrreducibleFraction< Fraction > ));
+    BOOST_CONCEPT_ASSERT(( concepts::CPositiveIrreducibleFraction< Fraction > ));
 
     typedef Pattern<TFraction> Self;
     typedef typename Fraction::Integer Integer;

--- a/src/DGtal/arithmetic/doc/packageArithmeticConcepts.dox
+++ b/src/DGtal/arithmetic/doc/packageArithmeticConcepts.dox
@@ -34,8 +34,8 @@ digraph GARITHMETIC {
                  node [style=filled,color=white];
                  label="base";
 
-                 CBackInsertable [ label="CBackInsertable" URL="\ref CBackInsertable" ];
-                 CConstSinglePassRange [ label="CConstSinglePassRange" URL="\ref CConstSinglePassRange" ];
+                 CBackInsertable [ label="CBackInsertable" URL="\ref concepts::CBackInsertable" ];
+                 CConstSinglePassRange [ label="CConstSinglePassRange" URL="\ref concepts::CConstSinglePassRange" ];
         }
         subgraph cluster_kernel {
                  style=filled;
@@ -67,7 +67,7 @@ digraph GARITHMETIC {
         node [style=filled,color=white];
         label="arithmetic (main concepts)";
 
-        CPositiveIrreducibleFraction [ label="CPositiveIrreducibleFraction" URL="\ref CPositiveIrreducibleFraction" ] ;
+        CPositiveIrreducibleFraction [ label="CPositiveIrreducibleFraction" URL="\ref concepts::CPositiveIrreducibleFraction" ] ;
     }
     CPositiveIrreducibleFraction -> CBackInsertable;
     CPositiveIrreducibleFraction -> CConstSinglePassRange;

--- a/src/DGtal/base/CBackInsertable.h
+++ b/src/DGtal/base/CBackInsertable.h
@@ -47,70 +47,75 @@
 namespace DGtal
 {
 
-/////////////////////////////////////////////////////////////////////////////
-// class CBackInsertable
-/**
-Description of \b concept '\b CBackInsertable' <p>
-@ingroup Concepts
-
-@brief Aim: Represents types for which a std::back_insert_iterator can
-be constructed with std::back_inserter. Back Insertion Sequence are
-refinements of CBackInsertable. They require more services than
-CBackInsertable, for instance read services or erase services.
-
-### Refinement of
-
-### Associated types :
-- \e value_type: the type of object that can be inserted at the back.
-
-### Notation
- - \e X : A type that is a model of CBackInsertable
- - \e x : object of type X
- - \e e : object of type value_type
-
-### Definitions
-
-### Valid expressions and semantics
-
-| Name  | Expression | Type requirements | Return type   | Precondition | Semantics | Post condition | Complexity |
-|-------|------------|-------------------|---------------|--------------|-----------|----------------|------------|
-| Add to back | \e x.push_back( \e e )|  |               |              | adds the element \e e at the end of object \e x | | |
-
-### Invariants
-
-### Models
-
-- Most standard linear containers: std::vector, std::list, std::deque
-- CPositiveIrreducibleFraction is a refinement of CBackInsertable
-- hence fractions: SternBrocot::Fraction, LighterSternBrocot::Fraction, LightSternBrocot::Fraction
-
-### Notes
-
-@tparam T the type that should be a model of CBackInsertable.
- */
-template <typename T>
-struct CBackInsertable
-{
-    // ----------------------- Concept checks ------------------------------
-public:
-  typedef typename T::value_type value_type;
-  BOOST_CONCEPT_USAGE( CBackInsertable )
+  namespace concepts
   {
-    myX.push_back( myV );
-    checkConstConstraints();
-  }
-  void checkConstConstraints() const
-  {
-  }
-  // ------------------------- Private Datas --------------------------------
-private:
-  T myX; // do not require T to be default constructible.
-  value_type myV;
 
-    // ------------------------- Internals ------------------------------------
-private:
+    /////////////////////////////////////////////////////////////////////////////
+    // class CBackInsertable
+    /**
+       Description of \b concept '\b CBackInsertable' <p>
+       @ingroup Concepts
 
-}; // end of concept CBackInsertable
+       @brief Aim: Represents types for which a std::back_insert_iterator can
+       be constructed with std::back_inserter. Back Insertion Sequence are
+       refinements of CBackInsertable. They require more services than
+       CBackInsertable, for instance read services or erase services.
+
+       ### Refinement of
+
+       ### Associated types :
+       - \e value_type: the type of object that can be inserted at the back.
+
+       ### Notation
+       - \e X : A type that is a model of CBackInsertable
+       - \e x : object of type X
+       - \e e : object of type value_type
+
+       ### Definitions
+
+       ### Valid expressions and semantics
+
+       | Name  | Expression | Type requirements | Return type   | Precondition | Semantics | Post condition | Complexity |
+       |-------|------------|-------------------|---------------|--------------|-----------|----------------|------------|
+       | Add to back | \e x.push_back( \e e )|  |               |              | adds the element \e e at the end of object \e x | | |
+
+       ### Invariants
+
+       ### Models
+
+       - Most standard linear containers: std::vector, std::list, std::deque
+       - CPositiveIrreducibleFraction is a refinement of CBackInsertable
+       - hence fractions: SternBrocot::Fraction, LighterSternBrocot::Fraction, LightSternBrocot::Fraction
+
+       ### Notes
+
+       @tparam T the type that should be a model of CBackInsertable.
+    */
+    template <typename T>
+    struct CBackInsertable
+    {
+      // ----------------------- Concept checks ------------------------------
+    public:
+      typedef typename T::value_type value_type;
+      BOOST_CONCEPT_USAGE( CBackInsertable )
+      {
+        myX.push_back( myV );
+        checkConstConstraints();
+      }
+      void checkConstConstraints() const
+      {
+      }
+      // ------------------------- Private Datas --------------------------------
+    private:
+      T myX; // do not require T to be default constructible.
+      value_type myV;
+
+      // ------------------------- Internals ------------------------------------
+    private:
+
+    }; // end of concept CBackInsertable
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CBidirectionalRange.h
+++ b/src/DGtal/base/CBidirectionalRange.h
@@ -49,60 +49,65 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CBidirectionalRange
-  /**
-Description of \b concept '\b CBidirectionalRange'
-     @ingroup Concepts
-
-\brief Aim: Defines the concept describing a bidirectional range.
-
-### Refinement of CConstBidirectionalRange
-
-### Provided types :
-
-- ReverseIterator: the reverse iterator type, a model of
-iterator concept.
-
-### Valid expressions and semantics
-
-| Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
-|---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
-|rbegin         |\e x.rbegin()  |                     |ReverseIterator |               |           |                |            |
-|rend           |\e x.rend()    |                     |ReverseIterator |               |           |                |            |
-|rbegin         |\e x.rbegin() const |                |ConstReverseIterator |               |           |                |            | 
-|rend         |\e x.rend() const |                |ConstReverseIterator |               |           |                |            |                 
-
-### Invariants
-
-### Models
-PointVector
-
-### Notes
-
-@tparam T the type that is checked. T should be a model of CBidirectionalRange.
-
-*/
-  template <typename T>
-  struct CBidirectionalRange : public CConstBidirectionalRange<T>
+  namespace concepts
   {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    typedef typename T::ReverseIterator ReverseIterator;
-    
-    BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ReverseIterator> ));
-    
-    BOOST_CONCEPT_USAGE(CBidirectionalRange)
+
+    /////////////////////////////////////////////////////////////////////////////
+    // class CBidirectionalRange
+    /**
+       Description of \b concept '\b CBidirectionalRange'
+       @ingroup Concepts
+
+       \brief Aim: Defines the concept describing a bidirectional range.
+
+       ### Refinement of CConstBidirectionalRange
+
+       ### Provided types :
+
+       - ReverseIterator: the reverse iterator type, a model of
+       iterator concept.
+
+       ### Valid expressions and semantics
+
+       | Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
+       |---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
+       |rbegin         |\e x.rbegin()  |                     |ReverseIterator |               |           |                |            |
+       |rend           |\e x.rend()    |                     |ReverseIterator |               |           |                |            |
+       |rbegin         |\e x.rbegin() const |                |ConstReverseIterator |               |           |                |            | 
+       |rend         |\e x.rend() const |                |ConstReverseIterator |               |           |                |            |                 
+
+       ### Invariants
+
+       ### Models
+       PointVector
+
+       ### Notes
+
+       @tparam T the type that is checked. T should be a model of CBidirectionalRange.
+
+    */
+    template <typename T>
+    struct CBidirectionalRange : public CConstBidirectionalRange<T>
     {
-      concepts::ConceptUtils::sameType( it, i.rbegin() );
-      concepts::ConceptUtils::sameType( it, i.rend() );
-    };
+      // ----------------------- Concept checks ------------------------------
+    public:
+      typedef typename T::ReverseIterator ReverseIterator;
     
-  private:
-    T i;
-    ReverseIterator it;
-  }; // end of concept CBidirectionalRange
+      BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ReverseIterator> ));
+    
+      BOOST_CONCEPT_USAGE(CBidirectionalRange)
+      {
+        concepts::ConceptUtils::sameType( it, i.rbegin() );
+        concepts::ConceptUtils::sameType( it, i.rend() );
+      };
+    
+    private:
+      T i;
+      ReverseIterator it;
+    }; // end of concept CBidirectionalRange
   
+  } // namespace concepts
+
 } // namespace DGtal
 
 

--- a/src/DGtal/base/CBidirectionalRangeFromPoint.h
+++ b/src/DGtal/base/CBidirectionalRangeFromPoint.h
@@ -49,77 +49,82 @@
 namespace DGtal
 {
 
-/////////////////////////////////////////////////////////////////////////////
-// class CBidirectionalRangeFromPoint
-/**
-   DescriptionDescription of \b concept '\b CBidirectionalRangeFromPoint'
-   @ingroup Concepts
-   @brief Aim: refined concept of  single pass range with a begin() method from a point.
+  namespace concepts
+  {
 
-### Refinement of CBidirectionalRange
+    /////////////////////////////////////////////////////////////////////////////
+    // class CBidirectionalRangeFromPoint
+    /**
+       DescriptionDescription of \b concept '\b CBidirectionalRangeFromPoint'
+       @ingroup Concepts
+       @brief Aim: refined concept of  single pass range with a begin() method from a point.
 
-### Associated types :
+       ### Refinement of CBidirectionalRange
 
-- ReverseIterator
+       ### Associated types :
 
-### Notation
-- X : A type that is a model of CBidirectionalRangeFromPoint
-- x,  y : object of type X
-- Point: A type of Point
+       - ReverseIterator
 
-
-### Definitions
-
-### Valid expressions and
+       ### Notation
+       - X : A type that is a model of CBidirectionalRangeFromPoint
+       - x,  y : object of type X
+       - Point: A type of Point
 
 
+       ### Definitions
 
-| Name  | Expression       | Type requirements    | Return type   | Precondition | Semantics                                           | Post condition | Complexity |
-|-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
-| reverse begin | rbegin(const Point &aPoint) | aPoint of type Point | ReverseIterator |              | Returns a reverse iterator on the range at point \a aPoint |                |            |
-
-### Invariants
-
-### Models
-
-ImageContainerBySTLVector::Range
-
-### Notes
-
-@tparam T the type that should be a model of CBidirectionalRangeFromPoint.
- */
-template <typename T>
-
-struct CBidirectionalRangeFromPoint:
-            CBidirectionalRange<T>,
-            CConstBidirectionalRangeFromPoint<T>
-{
-    // ----------------------- Concept checks ------------------------------
-
-public:
-    // 1. define first provided types (i.e. inner types), like
-    typedef typename T::Point Point;
-    typedef typename T::ReverseIterator ReverseIterator;
+       ### Valid expressions and
 
 
-    // 2. then check the presence of data members, operators and methods with
-    BOOST_CONCEPT_USAGE ( CBidirectionalRangeFromPoint )
+
+       | Name  | Expression       | Type requirements    | Return type   | Precondition | Semantics                                           | Post condition | Complexity |
+       |-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
+       | reverse begin | rbegin(const Point &aPoint) | aPoint of type Point | ReverseIterator |              | Returns a reverse iterator on the range at point \a aPoint |                |            |
+
+       ### Invariants
+
+       ### Models
+
+       ImageContainerBySTLVector::Range
+
+       ### Notes
+
+       @tparam T the type that should be a model of CBidirectionalRangeFromPoint.
+    */
+    template <typename T>
+
+    struct CBidirectionalRangeFromPoint:
+      CBidirectionalRange<T>,
+      CConstBidirectionalRangeFromPoint<T>
     {
+      // ----------------------- Concept checks ------------------------------
+
+    public:
+      // 1. define first provided types (i.e. inner types), like
+      typedef typename T::Point Point;
+      typedef typename T::ReverseIterator ReverseIterator;
+
+
+      // 2. then check the presence of data members, operators and methods with
+      BOOST_CONCEPT_USAGE ( CBidirectionalRangeFromPoint )
+      {
         concepts::ConceptUtils::sameType ( myIt, myX.rbegin ( myPoint ) );
-    }
+      }
 
-    // ------------------------- Private Datas --------------------------------
+      // ------------------------- Private Datas --------------------------------
 
-private:
-    T myX; // do not require T to be default constructible.
-    Point myPoint;
-    ReverseIterator myIt;
+    private:
+      T myX; // do not require T to be default constructible.
+      Point myPoint;
+      ReverseIterator myIt;
 
-    // ------------------------- Internals ------------------------------------
+      // ------------------------- Internals ------------------------------------
 
-private:
+    private:
 
-}; // end of concept CBidirectionalRangeFromPoint
+    }; // end of concept CBidirectionalRangeFromPoint
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CBidirectionalRangeWithWritableIterator.h
+++ b/src/DGtal/base/CBidirectionalRangeWithWritableIterator.h
@@ -47,68 +47,73 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CBidirectionalRangeWithWritableIterator
-  /**
-Description of \b concept '\b CBidirectionalRangeWithWritableIterator'
-     @ingroup Concepts
-     @brief Aim: refined concept of bidirectional range which require that a reverse output iterator exists.
-
-
-### Refinement of CSinglePassRangeWithWritableIterator
-
-### Associated types :
-- OutputIterator: type of output iterator on the range.
-
-### Notation
-- \a X : A type that is a model of CBidirectionalRangeWithWritableIterator
-- \a x, \a y : object of type X
-
-
-### Definitions
-
-
-| Name| Expression       | Type requirements | Return type    | Precondition | Semantics                                          | Post condition | Complexity |
-|----------|------------------|-------------------|----------------|--------------|----------------------------------------------------|----------------|------------|
-| creation | routputIterator() |                   | ReverseOutputIterator |              | Returns a reverse output iterator on the range first element |                |            |
-|          |                  |                   |                |              |                                                    |                |            |
-
-
-### Invariants###
-
-### Models###
-
-ImageContainerBySTLVector::Range
-
-### Notes###
-
-@tparam T the type that should be a model of CBidirectionalRangeWithWritableIterator.
-@tparam Value the type of object t in (*it) = t.
-
-   */
-  template <typename T, typename Value>
-  struct CBidirectionalRangeWithWritableIterator : CSinglePassRangeWithWritableIterator<T, Value>
+  namespace concepts
   {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    // 1. define first provided types (i.e. inner types), like
-    typedef typename T::ReverseOutputIterator  ReverseOutputIterator;
-    // possibly check these types so as to satisfy a concept with
-    //BOOST_CONCEPT_ASSERT(( CConcept< InnerType > ));
 
-    BOOST_CONCEPT_USAGE( CBidirectionalRangeWithWritableIterator )
+    /////////////////////////////////////////////////////////////////////////////
+    // class CBidirectionalRangeWithWritableIterator
+    /**
+       Description of \b concept '\b CBidirectionalRangeWithWritableIterator'
+       @ingroup Concepts
+       @brief Aim: refined concept of bidirectional range which require that a reverse output iterator exists.
+
+
+       ### Refinement of CSinglePassRangeWithWritableIterator
+
+       ### Associated types :
+       - OutputIterator: type of output iterator on the range.
+
+       ### Notation
+       - \a X : A type that is a model of CBidirectionalRangeWithWritableIterator
+       - \a x, \a y : object of type X
+
+
+       ### Definitions
+
+
+       | Name| Expression       | Type requirements | Return type    | Precondition | Semantics                                          | Post condition | Complexity |
+       |----------|------------------|-------------------|----------------|--------------|----------------------------------------------------|----------------|------------|
+       | creation | routputIterator() |                   | ReverseOutputIterator |              | Returns a reverse output iterator on the range first element |                |            |
+       |          |                  |                   |                |              |                                                    |                |            |
+
+
+       ### Invariants###
+
+       ### Models###
+
+       ImageContainerBySTLVector::Range
+
+       ### Notes###
+
+       @tparam T the type that should be a model of CBidirectionalRangeWithWritableIterator.
+       @tparam Value the type of object t in (*it) = t.
+
+    */
+    template <typename T, typename Value>
+    struct CBidirectionalRangeWithWritableIterator : CSinglePassRangeWithWritableIterator<T, Value>
     {
-      concepts::ConceptUtils::sameType( myOutput, myX.routputIterator( ) );
-    }
-    // ------------------------- Private Datas --------------------------------
-  private:
-    T myX; // do not require T to be default constructible.
-    ReverseOutputIterator myOutput;
+      // ----------------------- Concept checks ------------------------------
+    public:
+      // 1. define first provided types (i.e. inner types), like
+      typedef typename T::ReverseOutputIterator  ReverseOutputIterator;
+      // possibly check these types so as to satisfy a concept with
+      //BOOST_CONCEPT_ASSERT(( CConcept< InnerType > ));
 
-    // ------------------------- Internals ------------------------------------
-  private:
+      BOOST_CONCEPT_USAGE( CBidirectionalRangeWithWritableIterator )
+      {
+        concepts::ConceptUtils::sameType( myOutput, myX.routputIterator( ) );
+      }
+      // ------------------------- Private Datas --------------------------------
+    private:
+      T myX; // do not require T to be default constructible.
+      ReverseOutputIterator myOutput;
 
-  }; // end of concept CBidirectionalRangeWithWritableIterator
+      // ------------------------- Internals ------------------------------------
+    private:
+
+    }; // end of concept CBidirectionalRangeWithWritableIterator
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CBidirectionalRangeWithWritableIteratorFromPoint.h
+++ b/src/DGtal/base/CBidirectionalRangeWithWritableIteratorFromPoint.h
@@ -48,69 +48,74 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CBidirectionalRangeWithWritableIteratorFromPoint
-  /**
-DescriptionDescription of \b concept '\b CBidirectionalRangeWithWritableIteratorFromPoint' <p>
-@ingroup Concepts
-@brief Aim: refined concept of  single pass range with an routputIterator() method from a point.
-
-### Refinement of CBidirectionalRangeWithWritableIterator
-
-### Associated types :
-
-### Notation
-- X : A type that is a model of CBidirectionalRangeWithWritableIteratorFromPoint
-- x,  y : object of type X
-- Point: A type of Point
-
-
-### Definitions
-
-### Valid expressions and semantics
-
-
-| Name                    | Expression                           | Type requirements    | Return type          | Precondition | Semantics                                                         | Post condition | Complexity |
-|-------------------------|--------------------------------------|----------------------|----------------------|--------------|-------------------------------------------------------------------|----------------|------------|
-| reverse output iterator | routputIterator(const Point &aPoint) | aPoint of type Point | ReveseOutputIterator |              | Returns a reverse output iterator on the range at point \a aPoint |                |            |
-
-### Invariants
-
-### Models
-
-ImageContainerBySTLVector::Range
-
-### Notes
-
-@tparam T the type that should be a model of CBidirectionalRangeWithWritableIteratorFromPoint.
-@tparam Value the type of object t in (*it) = t.
-      */
-  template <typename T, typename Value>
-  struct CBidirectionalRangeWithWritableIteratorFromPoint:
-    CBidirectionalRangeWithWritableIterator<T,Value>
+  namespace concepts
   {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    // 1. define first provided types (i.e. inner types), like
-    typedef typename T::Point Point;
-    typedef typename T::ReverseOutputIterator ReverseOutputIterator;
 
-    // 2. then check the presence of data members, operators and methods with
-    BOOST_CONCEPT_USAGE( CBidirectionalRangeWithWritableIteratorFromPoint )
+    /////////////////////////////////////////////////////////////////////////////
+    // class CBidirectionalRangeWithWritableIteratorFromPoint
+    /**
+       DescriptionDescription of \b concept '\b CBidirectionalRangeWithWritableIteratorFromPoint' <p>
+       @ingroup Concepts
+       @brief Aim: refined concept of  single pass range with an routputIterator() method from a point.
+
+       ### Refinement of CBidirectionalRangeWithWritableIterator
+
+       ### Associated types :
+
+       ### Notation
+       - X : A type that is a model of CBidirectionalRangeWithWritableIteratorFromPoint
+       - x,  y : object of type X
+       - Point: A type of Point
+
+
+       ### Definitions
+
+       ### Valid expressions and semantics
+
+
+       | Name                    | Expression                           | Type requirements    | Return type          | Precondition | Semantics                                                         | Post condition | Complexity |
+       |-------------------------|--------------------------------------|----------------------|----------------------|--------------|-------------------------------------------------------------------|----------------|------------|
+       | reverse output iterator | routputIterator(const Point &aPoint) | aPoint of type Point | ReveseOutputIterator |              | Returns a reverse output iterator on the range at point \a aPoint |                |            |
+
+       ### Invariants
+
+       ### Models
+
+       ImageContainerBySTLVector::Range
+
+       ### Notes
+
+       @tparam T the type that should be a model of CBidirectionalRangeWithWritableIteratorFromPoint.
+       @tparam Value the type of object t in (*it) = t.
+    */
+    template <typename T, typename Value>
+    struct CBidirectionalRangeWithWritableIteratorFromPoint:
+      CBidirectionalRangeWithWritableIterator<T,Value>
     {
-       concepts::ConceptUtils::sameType( myIt, myX.routputIterator( myPoint ) );
-    }
+      // ----------------------- Concept checks ------------------------------
+    public:
+      // 1. define first provided types (i.e. inner types), like
+      typedef typename T::Point Point;
+      typedef typename T::ReverseOutputIterator ReverseOutputIterator;
 
-    // ------------------------- Private Datas --------------------------------
-  private:
-    T myX; // do not require T to be default constructible.
-    Point myPoint;
-    ReverseOutputIterator myIt;
+      // 2. then check the presence of data members, operators and methods with
+      BOOST_CONCEPT_USAGE( CBidirectionalRangeWithWritableIteratorFromPoint )
+      {
+        concepts::ConceptUtils::sameType( myIt, myX.routputIterator( myPoint ) );
+      }
 
-    // ------------------------- Internals ------------------------------------
-  private:
+      // ------------------------- Private Datas --------------------------------
+    private:
+      T myX; // do not require T to be default constructible.
+      Point myPoint;
+      ReverseOutputIterator myIt;
 
-  }; // end of concept CBidirectionalRangeWithWritableIteratorFromPoint
+      // ------------------------- Internals ------------------------------------
+    private:
+
+    }; // end of concept CBidirectionalRangeWithWritableIteratorFromPoint
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CConstBidirectionalRange.h
+++ b/src/DGtal/base/CConstBidirectionalRange.h
@@ -46,64 +46,70 @@
 #include "DGtal/base/CConstSinglePassRange.h"
 //////////////////////////////////////////////////////////////////////////////
 
-namespace DGtal{
-
-/////////////////////////////////////////////////////////////////////////////
-// class CConstBidirectionalRange
-/**
-Description of \b concept '\b CConstBidirectionalRange'
-@ingroup Concepts
-
-\brief Aim: Defines the concept describing a bidirectional const range.
-
-###  Refinement of
- CConstSinglePassRange
-
-###  Provided types :
-
-- ConstReverseIterator: the const reverse iterator type, a model of
-  const iterator concept.
-
- 
- 
- | Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
- |---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
- | rbegin of range| \e x.rbegin()|                    | \e ConstReverseIterator |             | returns a reverse forward iterator on the beginning of the range | | |
- | rend of range  | \e x.rend()|                      | \e ConstReverseIterator |             | returns a reverse forward iterator after the end of the range | | |
- 
- 
-###  Invariants
-
-###  Models
-
-###  Notes
-
-@tparam T the type that is checked. T should be a model of CConstBidirectionalRange.
-
- */
-template <typename T>
-struct CConstBidirectionalRange: CConstSinglePassRange<T>
+namespace DGtal
 {
-  // ----------------------- Concept checks ------------------------------
-public:
-  typedef typename T::ConstReverseIterator ConstReverseIterator;
-  
-  BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ConstReverseIterator> ));
-  
-  BOOST_CONCEPT_USAGE(CConstBidirectionalRange)
+
+  namespace concepts
   {
-    checkConstConstraints();
-  }
-  void checkConstConstraints() const
-  {
-    concepts::ConceptUtils::sameType( it, i.rbegin() );
-    concepts::ConceptUtils::sameType( it, i.rend() );
-  }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // class CConstBidirectionalRange
+    /**
+       Description of \b concept '\b CConstBidirectionalRange'
+       @ingroup Concepts
+
+       \brief Aim: Defines the concept describing a bidirectional const range.
+
+       ###  Refinement of
+       CConstSinglePassRange
+
+       ###  Provided types :
+
+       - ConstReverseIterator: the const reverse iterator type, a model of
+       const iterator concept.
+
+ 
+ 
+       | Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
+       |---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
+       | rbegin of range| \e x.rbegin()|                    | \e ConstReverseIterator |             | returns a reverse forward iterator on the beginning of the range | | |
+       | rend of range  | \e x.rend()|                      | \e ConstReverseIterator |             | returns a reverse forward iterator after the end of the range | | |
+ 
+ 
+       ###  Invariants
+
+       ###  Models
+
+       ###  Notes
+
+       @tparam T the type that is checked. T should be a model of CConstBidirectionalRange.
+
+    */
+    template <typename T>
+    struct CConstBidirectionalRange: CConstSinglePassRange<T>
+    {
+      // ----------------------- Concept checks ------------------------------
+    public:
+      typedef typename T::ConstReverseIterator ConstReverseIterator;
   
-private:
-  T i;
-  ConstReverseIterator it;
-}; // end of concept CConstBidirectionalRange
+      BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ConstReverseIterator> ));
+  
+      BOOST_CONCEPT_USAGE(CConstBidirectionalRange)
+      {
+        checkConstConstraints();
+      }
+      void checkConstConstraints() const
+      {
+        concepts::ConceptUtils::sameType( it, i.rbegin() );
+        concepts::ConceptUtils::sameType( it, i.rend() );
+      }
+  
+    private:
+      T i;
+      ConstReverseIterator it;
+    }; // end of concept CConstBidirectionalRange
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CConstBidirectionalRangeFromPoint.h
+++ b/src/DGtal/base/CConstBidirectionalRangeFromPoint.h
@@ -48,73 +48,78 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CConstBidirectionalRangeFromPoint
-  /**
-DescriptionDescription of \b concept '\b CConstBidirectionalRangeFromPoint'
-@ingroup Concepts
-@brief Aim: refined concept of const bidirectional range with a begin() method from a point.
-
-###  Refinement of CConstBidirectionalRange
-
-###  Associated types :
-
-###  Notation
-- X : A type that is a model of CConstBidirectionalRangeFromPoint
-- x,  y : object of type X
-- Point: A type of Point
-
-
-###  Definitions
-
-###  Valid expressions and semantics
-
-
-
-| Name  | Expression  | Type requirements    | Return type   | Precondition | Semantics   | Post condition | Complexity |
-|-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
-| reverse begin | rbegin(const Point &aPoint) | aPoint of type Point | ConstIterator |    | Returns a const reverse iterator on the range first element | |  |
-
-
-###  Invariants
-
-###  Models
-
-ImageContainerBySTLVector::Range
-
-###  Notes
-
-@tparam T the type that should be a model of CConstBidirectionalRangeFromPoint.
-   */
-  template <typename T>
-  struct CConstBidirectionalRangeFromPoint: CConstBidirectionalRange<T>
+  namespace concepts
   {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    // 1. define first provided types (i.e. inner types), like
-    typedef typename T::Point Point;
 
-    // 2. then check the presence of data members, operators and methods with
-    BOOST_CONCEPT_USAGE( CConstBidirectionalRangeFromPoint )
+    /////////////////////////////////////////////////////////////////////////////
+    // class CConstBidirectionalRangeFromPoint
+    /**
+       DescriptionDescription of \b concept '\b CConstBidirectionalRangeFromPoint'
+       @ingroup Concepts
+       @brief Aim: refined concept of const bidirectional range with a begin() method from a point.
+
+       ###  Refinement of CConstBidirectionalRange
+
+       ###  Associated types :
+
+       ###  Notation
+       - X : A type that is a model of CConstBidirectionalRangeFromPoint
+       - x,  y : object of type X
+       - Point: A type of Point
+
+
+       ###  Definitions
+
+       ###  Valid expressions and semantics
+
+
+
+       | Name  | Expression  | Type requirements    | Return type   | Precondition | Semantics   | Post condition | Complexity |
+       |-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
+       | reverse begin | rbegin(const Point &aPoint) | aPoint of type Point | ConstIterator |    | Returns a const reverse iterator on the range first element | |  |
+
+
+       ###  Invariants
+
+       ###  Models
+
+       ImageContainerBySTLVector::Range
+
+       ###  Notes
+
+       @tparam T the type that should be a model of CConstBidirectionalRangeFromPoint.
+    */
+    template <typename T>
+    struct CConstBidirectionalRangeFromPoint: CConstBidirectionalRange<T>
     {
- checkConstConstraints();
-    }
-    void checkConstConstraints() const
-    {
- // const method dummyConst should take parameter myA of type A and return
- // something of type B
-      concepts::ConceptUtils::sameType( myB, myX.rbegin( myPoint ) );
-    }
-    // ------------------------- Private Datas --------------------------------
-  private:
-    T myX; // do not require T to be default constructible.
-    Point myPoint;
-    typename T::ConstReverseIterator myB;
+      // ----------------------- Concept checks ------------------------------
+    public:
+      // 1. define first provided types (i.e. inner types), like
+      typedef typename T::Point Point;
 
-    // ------------------------- Internals ------------------------------------
-  private:
+      // 2. then check the presence of data members, operators and methods with
+      BOOST_CONCEPT_USAGE( CConstBidirectionalRangeFromPoint )
+      {
+        checkConstConstraints();
+      }
+      void checkConstConstraints() const
+      {
+        // const method dummyConst should take parameter myA of type A and return
+        // something of type B
+        concepts::ConceptUtils::sameType( myB, myX.rbegin( myPoint ) );
+      }
+      // ------------------------- Private Datas --------------------------------
+    private:
+      T myX; // do not require T to be default constructible.
+      Point myPoint;
+      typename T::ConstReverseIterator myB;
 
-  }; // end of concept CConstBidirectionalRangeFromPoint
+      // ------------------------- Internals ------------------------------------
+    private:
+
+    }; // end of concept CConstBidirectionalRangeFromPoint
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CConstSinglePassRange.h
+++ b/src/DGtal/base/CConstSinglePassRange.h
@@ -48,68 +48,72 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CConstSinglePassRange
-  /**
-     Description of \b concept '\b CConstSinglePassRange' <p>
-     @ingroup Concepts
+  namespace concepts {
     
-     \brief Aim: Defines the concept describing a const single pass range.
+    /////////////////////////////////////////////////////////////////////////////
+    // class CConstSinglePassRange
+    /**
+       Description of \b concept '\b CConstSinglePassRange' <p>
+       @ingroup Concepts
+    
+       \brief Aim: Defines the concept describing a const single pass range.
      
-     \tparam T the type that should be a model of CConstSinglePassRange.
+       \tparam T the type that should be a model of CConstSinglePassRange.
 
-     ### Refinement of
+       ### Refinement of
     
-     ### Associated types :
+       ### Associated types :
 
-     - \e ConstIterator: the const iterator type, a model of const iterator
-     concept (see boost_concepts::SinglePassIteratorConcept).
+       - \e ConstIterator: the const iterator type, a model of const iterator
+       concept (see boost_concepts::SinglePassIteratorConcept).
 
-     ### Notation
-     - \e T : A type that is a model of CConstSinglePassRange
-     - \e x : object of type \e T
+       ### Notation
+       - \e T : A type that is a model of CConstSinglePassRange
+       - \e x : object of type \e T
 
-     ### Valid expressions and semantics
+       ### Valid expressions and semantics
 
-     | Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
-     |---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
-     | begin of range| \e x.begin()|                    | \e ConstIterator |             | returns a forward iterator on the beginning of the range | | |
-     | end of range  | \e x.end()|                      | \e ConstIterator |             | returns a forward iterator after the end of the range | | |
+       | Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
+       |---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
+       | begin of range| \e x.begin()|                    | \e ConstIterator |             | returns a forward iterator on the beginning of the range | | |
+       | end of range  | \e x.end()|                      | \e ConstIterator |             | returns a forward iterator after the end of the range | | |
     
-     ### Invariants
+       ### Invariants
     
-     - Valid range. For any Range x, [\e x.begin(), \e x.end()) is a
+       - Valid range. For any Range x, [\e x.begin(), \e x.end()) is a
        valid range, that is, \e x.end() is reachable from \e x.begin()
        in a finite number of increments.
-     - Completeness. An algorithm that iterates through the range [\e x.begin(), \e x.end()) will pass through every element of \e x.
+       - Completeness. An algorithm that iterates through the range [\e x.begin(), \e x.end()) will pass through every element of \e x.
 
-     ### Models
+       ### Models
 
-   */
-  template <typename T>
-  struct CConstSinglePassRange
-  {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    typedef typename T::ConstIterator ConstIterator;
-    
-    BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ConstIterator> ));
-    
-    BOOST_CONCEPT_USAGE(CConstSinglePassRange)
+    */
+    template <typename T>
+    struct CConstSinglePassRange
     {
-      checkConstConstraints();
-    }
-    void checkConstConstraints() const
-    {
-      concepts::ConceptUtils::sameType( it, i.begin() );
-      concepts::ConceptUtils::sameType( it, i.end() );
-    }
+      // ----------------------- Concept checks ------------------------------
+    public:
+      typedef typename T::ConstIterator ConstIterator;
     
-  private:
-    T i;
-    ConstIterator it;
-  }; // end of concept CConstSinglePassRange
-  
+      BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<ConstIterator> ));
+    
+      BOOST_CONCEPT_USAGE(CConstSinglePassRange)
+      {
+        checkConstConstraints();
+      }
+      void checkConstConstraints() const
+      {
+        concepts::ConceptUtils::sameType( it, i.begin() );
+        concepts::ConceptUtils::sameType( it, i.end() );
+      }
+    
+    private:
+      T i;
+      ConstIterator it;
+    }; // end of concept CConstSinglePassRange
+
+  } // namespace concepts
+    
 } // namespace DGtal
 
 

--- a/src/DGtal/base/CConstSinglePassRangeFromPoint.h
+++ b/src/DGtal/base/CConstSinglePassRangeFromPoint.h
@@ -48,66 +48,71 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CConstSinglePassRangeFromPoint
-  /**
-     Description of \b concept '\b CConstSinglePassRangeFromPoint' <p>
-     @ingroup Concepts
-     @brief Aim: refined concept of const single pass range with a begin() method from a point.
-
-     ###  Refinement of CConstSinglePassRange
-
-     ###  Associated types :
-
-     ###  Notation
-     - X : A type that is a model of CConstSinglePassRangeFromPoint
-     - x,  y : object of type X
-     - Point: A type of Point
-
-     ###  Definitions
-
-     ###  Valid expressions and semantics
-
-     | Name  | Expression                 | Type requirements    | Return type   | Precondition | Semantics                                           | Post condition | Complexity |
-     |-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
-     | begin | begin(const Point &aPoint) | aPoint of type Point | ConstIterator |              | Returns a const iterator on the range first element |                |            |
-     ###  Invariants
-
-     ###  Models
-     - ImageContainerBySTLVector::Range
-
-     ###  Notes
-     @tparam T the type that should be a model of CConstSinglePassRangeFromPoint.
-   */
-  template <typename T>
-  struct CConstSinglePassRangeFromPoint: CConstSinglePassRange<T>
+  namespace concepts
   {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    // 1. define first provided types (i.e. inner types), like
-    typedef typename T::Point Point;
 
-    // 2. then check the presence of data members, operators and methods with
-    BOOST_CONCEPT_USAGE( CConstSinglePassRangeFromPoint )
-    {
-      checkConstConstraints();
-    }
-    void checkConstConstraints() const
-    {
-      // const method dummyConst should take parameter myA of type A and return
-      // something of type B
-      ConceptUtils::sameType( myB, myX.begin( myPoint ) );
-    }
-    // ------------------------- Private Datas --------------------------------
-  private:
-    T myX; // do not require T to be default constructible.
-    Point myPoint;
-    ConstIterartor myB;
+    /////////////////////////////////////////////////////////////////////////////
+    // class CConstSinglePassRangeFromPoint
+    /**
+       Description of \b concept '\b CConstSinglePassRangeFromPoint' <p>
+       @ingroup Concepts
+       @brief Aim: refined concept of const single pass range with a begin() method from a point.
 
-    // ------------------------- Internals ------------------------------------
-  private:
+       ###  Refinement of CConstSinglePassRange
 
-  }; // end of concept CConstSinglePassRangeFromPoint
+       ###  Associated types :
+
+       ###  Notation
+       - X : A type that is a model of CConstSinglePassRangeFromPoint
+       - x,  y : object of type X
+       - Point: A type of Point
+
+       ###  Definitions
+
+       ###  Valid expressions and semantics
+
+       | Name  | Expression                 | Type requirements    | Return type   | Precondition | Semantics                                           | Post condition | Complexity |
+       |-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
+       | begin | begin(const Point &aPoint) | aPoint of type Point | ConstIterator |              | Returns a const iterator on the range first element |                |            |
+       ###  Invariants
+
+       ###  Models
+       - ImageContainerBySTLVector::Range
+
+       ###  Notes
+       @tparam T the type that should be a model of CConstSinglePassRangeFromPoint.
+    */
+    template <typename T>
+      struct CConstSinglePassRangeFromPoint: CConstSinglePassRange<T>
+      {
+        // ----------------------- Concept checks ------------------------------
+      public:
+        // 1. define first provided types (i.e. inner types), like
+        typedef typename T::Point Point;
+
+        // 2. then check the presence of data members, operators and methods with
+        BOOST_CONCEPT_USAGE( CConstSinglePassRangeFromPoint )
+        {
+          checkConstConstraints();
+        }
+        void checkConstConstraints() const
+        {
+          // const method dummyConst should take parameter myA of type A and return
+          // something of type B
+          ConceptUtils::sameType( myB, myX.begin( myPoint ) );
+        }
+        // ------------------------- Private Datas --------------------------------
+      private:
+        T myX; // do not require T to be default constructible.
+        Point myPoint;
+        ConstIterartor myB;
+
+        // ------------------------- Internals ------------------------------------
+      private:
+
+      }; // end of concept CConstSinglePassRangeFromPoint
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CLabel.h
+++ b/src/DGtal/base/CLabel.h
@@ -49,47 +49,52 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CLabel
-  /**
-Description of \b concept '\b CLabel' <p>
-     @ingroup Concepts
-     @brief Aim: Define the concept of DGtal labels.
-     Models of CLabel can be default-constructible, assignable and equality comparable.
-
- ### Refinement of 
-   - boost::DefaultConstructible
-   - boost::Assignable 
-   - boost::EqualityComparable
-
- ### Associated types :
-
- ### Notation
-     - \t X : A type that is a model of CLabel
-     - \t x, \t y : object of type X
-
- ### Definitions
-
- ### Valid expressions and semantics
-
-
-| Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
-|---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
-|               |            |                     |             |                  |           |                |            |     
- ### Invariants###
-
- ### Models###
-
- ### Notes###
-
-@tparam T the type that should be a model of CLabel.
-   */
-  template <typename T>
-  struct CLabel  : boost::DefaultConstructible<T>, boost::Assignable<T>,
-    boost::EqualityComparable<T>
+  namespace concepts
   {
 
-  }; // end of concept CLabel
+    /////////////////////////////////////////////////////////////////////////////
+    // class CLabel
+    /**
+       Description of \b concept '\b CLabel' <p>
+       @ingroup Concepts
+       @brief Aim: Define the concept of DGtal labels.
+       Models of CLabel can be default-constructible, assignable and equality comparable.
+
+       ### Refinement of 
+       - boost::DefaultConstructible
+       - boost::Assignable 
+       - boost::EqualityComparable
+
+       ### Associated types :
+
+       ### Notation
+       - \t X : A type that is a model of CLabel
+       - \t x, \t y : object of type X
+
+       ### Definitions
+
+       ### Valid expressions and semantics
+
+
+       | Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
+       |---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
+       |               |            |                     |             |                  |           |                |            |     
+       ### Invariants###
+
+       ### Models###
+
+       ### Notes###
+
+       @tparam T the type that should be a model of CLabel.
+    */
+    template <typename T>
+    struct CLabel  : boost::DefaultConstructible<T>, boost::Assignable<T>,
+      boost::EqualityComparable<T>
+    {
+
+    }; // end of concept CLabel
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CPredicate.h
+++ b/src/DGtal/base/CPredicate.h
@@ -49,63 +49,63 @@ namespace DGtal
 {
   namespace concepts
   {
-  /////////////////////////////////////////////////////////////////////////////
-  // class CPredicate
-  /**
-     Description of \b concept '\b CPredicate'
-     @ingroup Concepts
-     \brief Aim: Defines a predicate function, ie. a functor mapping a domain into the set of booleans.
+    /////////////////////////////////////////////////////////////////////////////
+    // class CPredicate
+    /**
+       Description of \b concept '\b CPredicate'
+       @ingroup Concepts
+       \brief Aim: Defines a predicate function, ie. a functor mapping a domain into the set of booleans.
 
-     @tparam T the type that should be a model of this predicate
-     @tparam TElement the type of an element of the predicate domain.
+       @tparam T the type that should be a model of this predicate
+       @tparam TElement the type of an element of the predicate domain.
 
-     ###  Refinement of 
+       ###  Refinement of 
 
-  - CUnaryFunctor
+       - CUnaryFunctor
 
-     ###  Associated types :
+       ###  Associated types :
 
-     ###  Notation
-     - \e X : A type that is a model of CPredicate
-     - \e x : Object of type \e X
-     - \e p : Object of type TElement
+       ###  Notation
+       - \e X : A type that is a model of CPredicate
+       - \e x : Object of type \e X
+       - \e p : Object of type TElement
 
-     ###  Definitions
+       ###  Definitions
 
-     ###  Valid expressions and semantics
+       ###  Valid expressions and semantics
 
-     | Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
-     |---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
-     | Apply predicate| \e x.( \e p )|                  | \e bool     |                  | the value of the predicate \e x at element \e p | | |
+       | Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
+       |---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
+       | Apply predicate| \e x.( \e p )|                  | \e bool     |                  | the value of the predicate \e x at element \e p | | |
 
-     ###  Invariants
+       ###  Invariants
 
-     ###  Models
+       ###  Models
 
-     - specializations: concepts::CPointPredicate, concepts::CVertexPredicate
+       - specializations: concepts::CPointPredicate, concepts::CVertexPredicate
 
-     ###  Notes
+       ###  Notes
 
-     CPredicate allows to factor codes when writing concepts for new
-     kinds of predicates.
-   */
-  template <typename T, typename TElement>
-  struct CPredicate :  CUnaryFunctor<T,TElement,bool>
-  {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    typedef TElement Element;
+       CPredicate allows to factor codes when writing concepts for new
+       kinds of predicates.
+    */
+    template <typename T, typename TElement>
+    struct CPredicate :  CUnaryFunctor<T,TElement,bool>
+    {
+      // ----------------------- Concept checks ------------------------------
+    public:
+      typedef TElement Element;
 
-    // ------------------------- Private Datas --------------------------------
-  private:
-    T myPred;
-    Element myElement;
-    bool myBool;
-    // ------------------------- Internals ------------------------------------
-  private:
+      // ------------------------- Private Datas --------------------------------
+    private:
+      T myPred;
+      Element myElement;
+      bool myBool;
+      // ------------------------- Internals ------------------------------------
+    private:
 
-  }; // end of concept CPredicate
-  }
+    }; // end of concept CPredicate
+  } // namespace concepts
 } // namespace DGtal
 
 //                                                                           //

--- a/src/DGtal/base/CQuantity.h
+++ b/src/DGtal/base/CQuantity.h
@@ -50,47 +50,52 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CQuantity
-  /**
-Description of \b concept '\b CQuantity' <p>
-     @ingroup Concepts
-     @brief Aim: defines the concept of quantity in DGtal.
-
-###  Refinement of
-  -  CLabel 
-  -  boost::LessThanComparable
-
-###  Associated types :
-
-###  Notation
-     - \t X : A type that is a model of CQuantity
-     - \t x, \t y : object of type X
-
-###  Definitions
-
-###  Valid expressions and semantics
-
-| Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
-|---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
-|               |            | | | | | | | 
-
-
-###  Invariants
-
-###  Models
-
-
-###  Notes
-
-@tparam T the type that should be a model of CQuantity.
-   */
-  template <typename T>
-  struct CQuantity : CLabel<T>, boost::LessThanComparable<T>
+  namespace concepts
   {
 
+    /////////////////////////////////////////////////////////////////////////////
+    // class CQuantity
+    /**
+       Description of \b concept '\b CQuantity' <p>
+       @ingroup Concepts
+       @brief Aim: defines the concept of quantity in DGtal.
 
-  }; // end of concept CQuantity
+       ###  Refinement of
+       -  CLabel 
+       -  boost::LessThanComparable
+
+       ###  Associated types :
+
+       ###  Notation
+       - \t X : A type that is a model of CQuantity
+       - \t x, \t y : object of type X
+
+       ###  Definitions
+
+       ###  Valid expressions and semantics
+
+       | Name          | Expression | Type requirements   | Return type | Precondition     | Semantics | Post condition | Complexity |
+       |---------------|------------|---------------------|-------------|------------------|-----------|----------------|------------|
+       |               |            | | | | | | | 
+
+
+       ###  Invariants
+
+       ###  Models
+
+
+       ###  Notes
+
+       @tparam T the type that should be a model of CQuantity.
+    */
+    template <typename T>
+    struct CQuantity : CLabel<T>, boost::LessThanComparable<T>
+    {
+
+
+    }; // end of concept CQuantity
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CSinglePassRange.h
+++ b/src/DGtal/base/CSinglePassRange.h
@@ -47,58 +47,62 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CSinglePassRange
-  /**
-     DescriptionDescription of \b concept '\b CSinglePassRange' ###
-     @ingroup Concepts
+  namespace concepts {
+    
+    /////////////////////////////////////////////////////////////////////////////
+    // class CSinglePassRange
+    /**
+       DescriptionDescription of \b concept '\b CSinglePassRange' ###
+       @ingroup Concepts
 
-     \brief Aim: Defines the concept describing a range.
+       \brief Aim: Defines the concept describing a range.
 
-     ### Refinement of CConstSinglePassRange
+       ### Refinement of CConstSinglePassRange
 
-     ### Provided types:
+       ### Provided types:
 
-     - Iterator: the iterator type, a model of iterator concept
-     (see boost concept SinglePassIteratorConcept).
+       - Iterator: the iterator type, a model of iterator concept
+       (see boost concept SinglePassIteratorConcept).
 
-     ### Notation:
+       ### Notation:
 
-     - x an object of a model of CSinglePassConstRange.
+       - x an object of a model of CSinglePassConstRange.
 
-     Name | Expression | Type requirements | Return type | Precondition | Semantics | Post condition | Complexity|
-     -----|------------|-------------------|-------------|--------------|-----------|----------------|-----------|
-     begin| x.begin()  |                   | Iterator    |              |           |                |           |
-     end  | x.end()    |                   | Iterator    |              |           |                |           |
+       Name | Expression | Type requirements | Return type | Precondition | Semantics | Post condition | Complexity|
+       -----|------------|-------------------|-------------|--------------|-----------|----------------|-----------|
+       begin| x.begin()  |                   | Iterator    |              |           |                |           |
+       end  | x.end()    |                   | Iterator    |              |           |                |           |
 
 
-     ### Invariants
+       ### Invariants
 
-     ### Models
+       ### Models
 
-     ### Notes
+       ### Notes
 
-     @tparam T the type that is checked. T should be a model of CSinglePassRange.
+       @tparam T the type that is checked. T should be a model of CSinglePassRange.
 
-   */
-  template <typename T>
-  struct CSinglePassRange : CConstSinglePassRange<T>
-  {
-    // ----------------------- Concept checks ------------------------------
-  public:
-   typedef typename T::Iterator Iterator;
-
-    BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<Iterator> ));
-
-    BOOST_CONCEPT_USAGE(CSinglePassRange)
+    */
+    template <typename T>
+    struct CSinglePassRange : CConstSinglePassRange<T>
     {
-      Iterator it=i.begin();
-      it=i.end();
-    };
+      // ----------------------- Concept checks ------------------------------
+    public:
+      typedef typename T::Iterator Iterator;
 
-  private:
-    T i;
-  }; // end of concept CSinglePassRange
+      BOOST_CONCEPT_ASSERT(( boost_concepts::SinglePassIteratorConcept<Iterator> ));
+
+      BOOST_CONCEPT_USAGE(CSinglePassRange)
+      {
+        Iterator it=i.begin();
+        it=i.end();
+      };
+
+    private:
+      T i;
+    }; // end of concept CSinglePassRange
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CSinglePassRangeFromPoint.h
+++ b/src/DGtal/base/CSinglePassRangeFromPoint.h
@@ -49,64 +49,69 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CSinglePassRangeFromPoint
-  /**
-     Description of \b concept '\b CSinglePassRangeFromPoint' <p>
-     @ingroup Concepts
-     @brief Aim: refined concept of  single pass range with a begin() method from a point.
-
-     ### Refinement of CSinglePassRange and CConstSinglePassRangeFromPoint
-
-     ### Associated types :
-
-     ### Notation
-     - X : A type that is a model of CSinglePassRangeFromPoint
-     - x,  y : object of type X
-     - Point: A type of Point
-
-     ### Definitions
-
-     ### Valid expressions and semantics
-
-     | Name  | Expression                 | Type requirements    | Return type   | Precondition | Semantics                                           | Post condition | Complexity |
-     |-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
-     | begin | begin(const Point &aPoint) | aPoint of type Point | Iterator |              | Returns an iterator on the range first element |                |            |
-
-     ### Invariants
-
-     ### Models
-     - ImageContainerBySTLVector::Range
-
-     ### Notes
-     @tparam T the type that should be a model of CSinglePassRangeFromPoint.
-   */
-  template <typename T>
-  struct CSinglePassRangeFromPoint:
-    CSinglePassRange<T>,
-    CConstSinglePassRangeFromPoint<T>
+  namespace concepts
   {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    // 1. define first provided types (i.e. inner types), like
-    typedef typename T::Point Point;
 
-    // 2. then check the presence of data members, operators and methods with
-    BOOST_CONCEPT_USAGE( CSinglePassRangeFromPoint )
+    /////////////////////////////////////////////////////////////////////////////
+    // class CSinglePassRangeFromPoint
+    /**
+       Description of \b concept '\b CSinglePassRangeFromPoint' <p>
+       @ingroup Concepts
+       @brief Aim: refined concept of  single pass range with a begin() method from a point.
+
+       ### Refinement of CSinglePassRange and CConstSinglePassRangeFromPoint
+
+       ### Associated types :
+
+       ### Notation
+       - X : A type that is a model of CSinglePassRangeFromPoint
+       - x,  y : object of type X
+       - Point: A type of Point
+
+       ### Definitions
+
+       ### Valid expressions and semantics
+
+       | Name  | Expression                 | Type requirements    | Return type   | Precondition | Semantics                                           | Post condition | Complexity |
+       |-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
+       | begin | begin(const Point &aPoint) | aPoint of type Point | Iterator |              | Returns an iterator on the range first element |                |            |
+
+       ### Invariants
+
+       ### Models
+       - ImageContainerBySTLVector::Range
+
+       ### Notes
+       @tparam T the type that should be a model of CSinglePassRangeFromPoint.
+    */
+    template <typename T>
+    struct CSinglePassRangeFromPoint:
+      CSinglePassRange<T>,
+      CConstSinglePassRangeFromPoint<T>
     {
-       ConceptUtils::sameType( myIt, myX.begin( myPoint ) );
-    }
+      // ----------------------- Concept checks ------------------------------
+    public:
+      // 1. define first provided types (i.e. inner types), like
+      typedef typename T::Point Point;
 
-    // ------------------------- Private Datas --------------------------------
-  private:
-    T myX; // do not require T to be default constructible.
-    Point myPoint;
-    Iterartor myIt;
+      // 2. then check the presence of data members, operators and methods with
+      BOOST_CONCEPT_USAGE( CSinglePassRangeFromPoint )
+      {
+        ConceptUtils::sameType( myIt, myX.begin( myPoint ) );
+      }
 
-    // ------------------------- Internals ------------------------------------
-  private:
+      // ------------------------- Private Datas --------------------------------
+    private:
+      T myX; // do not require T to be default constructible.
+      Point myPoint;
+      Iterartor myIt;
 
-  }; // end of concept CSinglePassRangeFromPoint
+      // ------------------------- Internals ------------------------------------
+    private:
+
+    }; // end of concept CSinglePassRangeFromPoint
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CSinglePassRangeWithWritableIterator.h
+++ b/src/DGtal/base/CSinglePassRangeWithWritableIterator.h
@@ -47,63 +47,68 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CSinglePassRangeWithWritableIterator
-  /**
-     Description of \b concept '\b CSinglePassRangeWithWritableIterator' <p>
-     @ingroup Concepts
-     @brief Aim: refined concept of const single pass range which require that an output iterator exists.
+  namespace concepts
+  {
 
-     ###  Refinement of CSinglePassRange
+    /////////////////////////////////////////////////////////////////////////////
+    // class CSinglePassRangeWithWritableIterator
+    /**
+       Description of \b concept '\b CSinglePassRangeWithWritableIterator' <p>
+       @ingroup Concepts
+       @brief Aim: refined concept of const single pass range which require that an output iterator exists.
 
-     ###  Associated types :
-     - OutputIterator: type of output iterator on the range.
+       ###  Refinement of CSinglePassRange
 
-     ###  Notation
-     - \a X : A type that is a model of CSinglePassRangeWithWritableIterator
-     - \a x, \a y : object of type X
+       ###  Associated types :
+       - OutputIterator: type of output iterator on the range.
 
-     ###  Definitions
+       ###  Notation
+       - \a X : A type that is a model of CSinglePassRangeWithWritableIterator
+       - \a x, \a y : object of type X
 
-     | Name     | Expression       | Type requirements | Return type    | Precondition | Semantics                                          | Post condition | Complexity |
-     |----------|------------------|-------------------|----------------|--------------|----------------------------------------------------|----------------|------------|
-     | creation | \e x.\c outputIterator() |                   | OutputIterator |              | Returns an output iterator on the range first element |                |            |
+       ###  Definitions
+
+       | Name     | Expression       | Type requirements | Return type    | Precondition | Semantics                                          | Post condition | Complexity |
+       |----------|------------------|-------------------|----------------|--------------|----------------------------------------------------|----------------|------------|
+       | creation | \e x.\c outputIterator() |                   | OutputIterator |              | Returns an output iterator on the range first element |                |            |
      
 
-     ###  Invariants
+       ###  Invariants
 
-     ###  Models
-     - ImageContainerBySTLVector::Range
+       ###  Models
+       - ImageContainerBySTLVector::Range
 
-     ###  Notes
+       ###  Notes
 
-     @tparam T the type that should be a model of CSinglePassRangeWithWritableIterator.
-     @tparam Value the type of object t in (*it) = t.
-   */
-  template <typename T, typename Value>
-  struct CSinglePassRangeWithWritableIterator : CConstSinglePassRange<T>
-  {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    // 1. define first provided types (i.e. inner types), like
-    typedef typename T::OutputIterator  OutputIterator;
-
-    // possibly check these types so as to satisfy a concept with
-    BOOST_CONCEPT_ASSERT(( boost::OutputIterator<OutputIterator,Value> ));
-
-    BOOST_CONCEPT_USAGE( CSinglePassRangeWithWritableIterator )
+       @tparam T the type that should be a model of CSinglePassRangeWithWritableIterator.
+       @tparam Value the type of object t in (*it) = t.
+    */
+    template <typename T, typename Value>
+    struct CSinglePassRangeWithWritableIterator : CConstSinglePassRange<T>
     {
-      concepts::ConceptUtils::sameType( myOutput, myX.outputIterator( ) );
-    }
-    // ------------------------- Private Datas --------------------------------
-  private:
-    T myX; // do not require T to be default constructible.
-    OutputIterator myOutput;
+      // ----------------------- Concept checks ------------------------------
+    public:
+      // 1. define first provided types (i.e. inner types), like
+      typedef typename T::OutputIterator  OutputIterator;
 
-    // ------------------------- Internals ------------------------------------
-  private:
+      // possibly check these types so as to satisfy a concept with
+      BOOST_CONCEPT_ASSERT(( boost::OutputIterator<OutputIterator,Value> ));
 
-  }; // end of concept CSinglePassRangeWithWritableIterator
+      BOOST_CONCEPT_USAGE( CSinglePassRangeWithWritableIterator )
+      {
+        concepts::ConceptUtils::sameType( myOutput, myX.outputIterator( ) );
+      }
+      // ------------------------- Private Datas --------------------------------
+    private:
+      T myX; // do not require T to be default constructible.
+      OutputIterator myOutput;
+
+      // ------------------------- Internals ------------------------------------
+    private:
+
+    }; // end of concept CSinglePassRangeWithWritableIterator
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/CSinglePassRangeWithWritableIteratorFromPoint.h
+++ b/src/DGtal/base/CSinglePassRangeWithWritableIteratorFromPoint.h
@@ -49,68 +49,73 @@
 namespace DGtal
 {
 
-  /////////////////////////////////////////////////////////////////////////////
-  // class CSinglePassRangeWithWritableIteratorFromPoint
-  /**
-     Description of \b concept '\b CSinglePassRangeWithWritableIteratorFromPoint' <p>
-     @ingroup Concepts
-     @brief Aim: refined concept of single pass range with a outputIterator() method from a point.
-
-     ### Refinement of CConstSinglePassRangeFromPoint and CSinglePassRangeWithWritableIterator
-
-     ### Associated types :
-
-     ### Notation
-     - X : A type that is a model of CSinglePassRangeWithWritableIteratorFromPoint
-     - x,  y : object of type X
-     - Point: A type of Point
-
-     ### Definitions
-
-     ### Valid expressions and semantics
-
-     | Name  | Expression                 | Type requirements    | Return type   | Precondition | Semantics                                           | Post condition | Complexity |
-     |-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
-     | output iterator | outputIterator(const Point &aPoint) | aPoint of type Point | OutputIterator |              | Returns an output iterator on the range first element |                |            |
-
-     ### Invariants
-
-     ### Models
-     - ImageContainerBySTLVector::Range
-
-     ### Notes
-
-     @tparam T the type that should be a model of CSinglePassRangeWithWritableIteratorFromPoint.
-     @tparam Value the type of object t in (*it) = t.
-
-   */
-  template <typename T, typename Value>
-  struct CSinglePassRangeWithWritableIteratorFromPoint:
-    CConstSinglePassRangeFromPoint<T,Value>,
-    CSinglePassRangeWithWritableIterator<T,Value>
+  namespace concepts
   {
-    // ----------------------- Concept checks ------------------------------
-  public:
-    // 1. define first provided types (i.e. inner types), like
-    typedef typename T::OutputIterator OutputIterator;
-    typedef typename T::Point Point;
 
-    // 2. then check the presence of data members, operators and methods with
-    BOOST_CONCEPT_USAGE( CSinglePassRangeWithWritableIteratorFromPoint )
+    /////////////////////////////////////////////////////////////////////////////
+    // class CSinglePassRangeWithWritableIteratorFromPoint
+    /**
+       Description of \b concept '\b CSinglePassRangeWithWritableIteratorFromPoint' <p>
+       @ingroup Concepts
+       @brief Aim: refined concept of single pass range with a outputIterator() method from a point.
+
+       ### Refinement of CConstSinglePassRangeFromPoint and CSinglePassRangeWithWritableIterator
+
+       ### Associated types :
+
+       ### Notation
+       - X : A type that is a model of CSinglePassRangeWithWritableIteratorFromPoint
+       - x,  y : object of type X
+       - Point: A type of Point
+
+       ### Definitions
+
+       ### Valid expressions and semantics
+
+       | Name  | Expression                 | Type requirements    | Return type   | Precondition | Semantics                                           | Post condition | Complexity |
+       |-------|----------------------------|----------------------|---------------|--------------|-----------------------------------------------------|----------------|------------|
+       | output iterator | outputIterator(const Point &aPoint) | aPoint of type Point | OutputIterator |              | Returns an output iterator on the range first element |                |            |
+
+       ### Invariants
+
+       ### Models
+       - ImageContainerBySTLVector::Range
+
+       ### Notes
+
+       @tparam T the type that should be a model of CSinglePassRangeWithWritableIteratorFromPoint.
+       @tparam Value the type of object t in (*it) = t.
+
+    */
+    template <typename T, typename Value>
+    struct CSinglePassRangeWithWritableIteratorFromPoint:
+      CConstSinglePassRangeFromPoint<T,Value>,
+      CSinglePassRangeWithWritableIterator<T,Value>
     {
-       ConceptUtils::sameType( myIt, myX.begin( myPoint ) );
-    }
+      // ----------------------- Concept checks ------------------------------
+    public:
+      // 1. define first provided types (i.e. inner types), like
+      typedef typename T::OutputIterator OutputIterator;
+      typedef typename T::Point Point;
 
-    // ------------------------- Private Datas --------------------------------
-  private:
-    T myX; // do not require T to be default constructible.
-    Point myPoint;
-    OutputIterartor myIt;
+      // 2. then check the presence of data members, operators and methods with
+      BOOST_CONCEPT_USAGE( CSinglePassRangeWithWritableIteratorFromPoint )
+      {
+        ConceptUtils::sameType( myIt, myX.begin( myPoint ) );
+      }
 
-    // ------------------------- Internals ------------------------------------
-  private:
+      // ------------------------- Private Datas --------------------------------
+    private:
+      T myX; // do not require T to be default constructible.
+      Point myPoint;
+      OutputIterartor myIt;
 
-  }; // end of concept CSinglePassRangeWithWritableIteratorFromPoint
+      // ------------------------- Internals ------------------------------------
+    private:
+
+    }; // end of concept CSinglePassRangeWithWritableIteratorFromPoint
+
+  } // namespace concepts
 
 } // namespace DGtal
 

--- a/src/DGtal/base/doc/Boost.dox
+++ b/src/DGtal/base/doc/Boost.dox
@@ -26,27 +26,27 @@
    - the BOOST type traits main page http://www.boost.org/doc/libs/1_52_0/libs/type_traits/doc/html/index.html
 */
 namespace boost {
-  /// Go to http://www.boost.org/doc/html/DefaultConstructible.html
+  /// Go to http://www.sgi.com/tech/stl/DefaultConstructible.html
   template <typename T> struct DefaultConstructible {};
-  /// Go to http://www.boost.org/doc/html/Assignable.html
+  /// Go to http://www.sgi.com/tech/stl/Assignable.html
   template <typename T> struct Assignable {};
-  /// Go to http://www.boost.org/doc/html/CopyConstructible.html
+  /// Go to http://www.sgi.com/tech/stl/CopyConstructible.html
   template <typename T> struct CopyConstructible {};
-  /// Go to http://www.boost.org/doc/html/InputIterator.html
+  /// Go to http://www.sgi.com/tech/stl/InputIterator.html
   template <typename T> struct InputIterator {};
-  /// Go to http://www.boost.org/doc/html/OutputIterator.html
+  /// Go to http://www.sgi.com/tech/stl/OutputIterator.html
   template <typename T> struct OutputIterator {};
-  /// Go to http://www.boost.org/doc/html/ForwardIterator.html
+  /// Go to http://www.sgi.com/tech/stl/ForwardIterator.html
   template <typename T> struct ForwardIterator {};
-  /// Go to http://www.boost.org/doc/html/BidirectionalIterator.html
+  /// Go to http://www.sgi.com/tech/stl/BidirectionalIterator.html
   template <typename T> struct BidirectionalIterator {};
-  /// Go to http://www.boost.org/doc/html/RandomAccessIterator.html
+  /// Go to http://www.sgi.com/tech/stl/RandomAccessIterator.html
   template <typename T> struct RandomAccessIterator {};
-  /// Go to http://www.boost.org/doc/html/EqualityComparable.html
+  /// Go to http://www.sgi.com/tech/stl/EqualityComparable.html
   template <typename T> struct EqualityComparable {};
-  /// Go to http://www.boost.org/doc/html/LessThanComparable.html
+  /// Go to http://www.sgi.com/tech/stl/LessThanComparable.html
   template <typename T> struct LessThanComparable {};
-  /// Go to http://www.boost.org/doc/html/SignedInteger.html
+  /// Go to http://www.sgi.com/tech/stl/SignedInteger.html
   template <typename T> struct SignedInteger {};
 
   /// Go to http://www.boost.org/libs/concept_check/reference.htm

--- a/src/DGtal/base/doc/moduleIteratorsRanges.dox
+++ b/src/DGtal/base/doc/moduleIteratorsRanges.dox
@@ -139,16 +139,16 @@ return two iterators bounding the range of elements contained
 in the data structure. Similarly, in DGtal, there are several 
 concepts of range having at least these `begin()` and `end()` methods. 
 
-The concept [CConstSinglePassRange](@ref CConstSinglePassRange)
+The concept [CConstSinglePassRange](@ref concepts::CConstSinglePassRange)
  describes any object for which, 
 one can iterate at least one time over a range of elements.  
-Models of CConstSinglePassRange have a nested type ConstIterator, 
+Models of concepts::CConstSinglePassRange have a nested type ConstIterator, 
 which is a readable and (at least) single-pass iterator.  
 Instances of ConstIterator are returned by `begin()` 
 and `end()` methods.     
 
-The concept [CConstBidirectionalRange](@ref CConstBidirectionalRange), 
-which is a refinement of CConstSinglePassRange,
+The concept [CConstBidirectionalRange](@ref concepts::CConstBidirectionalRange), 
+which is a refinement of concepts::CConstSinglePassRange,
 describes any collection of elements that can be scanned several times, 
 either forward or backward.  
 Models of this concept have obviously a nested type ConstIterator, but it 
@@ -158,9 +158,9 @@ iterator too. Finally, `begin()` and `end()` methods return instances of
 ConstIterator, whereas `rbegin()` and `rend()` methods return instances of 
 ConstReverseIterator. 
      
-The concept [CSinglePassRange](@ref CSinglePassRange) 
-(resp. [CBidirectionalRange](@ref CBidirectionalRange)) is 
-a refinement of CConstSinglePassRange (resp. CConstBidirectionalRange) 
+The concept [CSinglePassRange](@ref concepts::CSinglePassRange) 
+(resp. [CBidirectionalRange](@ref concepts::CBidirectionalRange)) is 
+a refinement of concepts::CConstSinglePassRange (resp. concepts::CConstBidirectionalRange) 
 for not constant, mutable elements. All their models have a nested type
 Iterator (resp. ReverseIterator), which are the readable and writable 
 counterparts of ConstIterator (resp. ConstReverseIterator).    
@@ -175,6 +175,11 @@ digraph GBASE {
     style=filled;
     color=lightgrey;
     node [style=filled,color=white];
+
+    CSinglePassRange [ label="CSinglePassRange" URL="\ref concepts::CSinglePassRange"];
+    CConstSinglePassRange [ label="CConstSinglePassRange" URL="\ref concepts::CConstSinglePassRange"];
+    CBidirectionalRange [ label="CBidirectionalRange" URL="\ref concepts::CBidirectionalRange"];
+    CConstBidirectionalRange [ label="CConstBidirectionalRange" URL="\ref concepts::CConstBidirectionalRange"];
 
     CSinglePassRange-> CConstSinglePassRange;
     CConstBidirectionalRange -> CConstSinglePassRange;
@@ -203,7 +208,7 @@ as follows:
     template<typename Range>
     void anyProcedure(const Range& aRange)
       {
-        BOOST_CONCEPT_ASSERT(( CBidirectionalRange<Range> )); 
+        BOOST_CONCEPT_ASSERT(( concepts::CBidirectionalRange<Range> )); 
         ...
         for (typename Range::ReverseIterator ri = r.rbegin(), 
              typename Range::ReverseIterator riEnd = r.rend(); 
@@ -267,10 +272,11 @@ incremental iterator.
 
 \subsection subsecIteratorRangesAdaptersCirculators  Circulators
 
-Like [Cgal](http://www.cgal.org/ "CGAL"), DGtal extends the concept of iterator to circular data structures
- by defining the concept of circular iterator or *circulator* for short.
+Like [Cgal](http://www.cgal.org/ "CGAL"), DGtal extends the concept of
+ iterator to circular data structures by defining the concept of
+ circular iterator or *circulator* for short.
 
-The class Circulator is an adatper that creates a circulator from a classic iterator. 
+The class Circulator is an adapter that creates a circulator from a classic iterator. 
 
 In circular data structures, any pairs of iterators [`i,j`) always describes a valid range 
 (ie. `j` is always reachable from `i`) and there is no past-the-end element.

--- a/src/DGtal/base/doc/packageBaseConcepts.dox
+++ b/src/DGtal/base/doc/packageBaseConcepts.dox
@@ -19,18 +19,48 @@ namespace DGtal {
 /*!
 @page packageBaseConcepts Base Concepts
 @writers David Coeurjolly
+@writers Jacques-Olivier Lachaud
 
 
 @dot
 digraph GBASE {
   rankdir=BT;
 
+  subgraph cluster_ext {
+    style=filled;
+    color=white;
+    label = "std/boost concepts"
+    boost_OutputIterator [ label="OutputIterator" URL="\ref boost::OutputIterator" ];
+    boost_SinglePassIteratorConcept [ label="SinglePassIteratorConcept" URL="\ref boost::SinglePassIteratorConcept" ];
+    boost_Assignable [ label="Assignable" URL="\ref boost::Assignable" ];
+    boost_LessThanComparable [ label="LessThanComparable" URL="\ref boost::LessThanComparable" ];
+    boost_DefaultConstructible [ label="DefaultConstructible" URL="\ref boost::DefaultConstructible" ];
+    boost_EqualityComparable [ label="EqualityComparable" URL="\ref boost::EqualityComparable" ];
+  }
+
   subgraph cluster_0 {
     style=filled;
     color=lightgrey;
     node [style=filled,color=white];
 
-    CSinglePassRange-> CConstSinglePassRange ;
+    CSinglePassRange [ label="CSinglePassRange" URL="\ref concepts::CSinglePassRange"];
+    CConstSinglePassRange [ label="CConstSinglePassRange" URL="\ref concepts::CConstSinglePassRange"];
+    CSinglePassRangeFromPoint [ label="CSinglePassRangeFromPoint" URL="\ref concepts::CSinglePassRangeFromPoint"];
+    CConstSinglePassRangeFromPoint [ label="CConstSinglePassRangeFromPoint" URL="\ref concepts::CConstSinglePassRangeFromPoint"];
+    CBidirectionalRange [ label="CBidirectionalRange" URL="\ref concepts::CBidirectionalRange"];
+    CConstBidirectionalRange [ label="CConstBidirectionalRange" URL="\ref concepts::CConstBidirectionalRange"];
+    CBidirectionalRangeFromPoint [ label="CBidirectionalRangeFromPoint" URL="\ref concepts::CBidirectionalRangeFromPoint"];
+    CConstBidirectionalRangeFromPoint [ label="CConstBidirectionalRangeFromPoint" URL="\ref concepts::CConstBidirectionalRangeFromPoint"];
+    CSinglePassRangeWithWritableIterator [ label="CSinglePassRangeWithWritableIterator" URL="\ref concepts::CSinglePassRangeWithWritableIterator"];
+    CSinglePassRangeWithWritableIteratorFromPoint [ label="CSinglePassRangeWithWritableIteratorFromPoint" URL="\ref concepts::CSinglePassRangeWithWritableIteratorFromPoint"];
+    CBidirectionalRangeWithWritableIterator [ label="CBidirectionalRangeWithWritableIterator" URL="\ref concepts::CBidirectionalRangeWithWritableIterator"];
+    CBidirectionalRangeWithWritableIteratorFromPoint [ label="CBidirectionalRangeWithWritableIteratorFromPoint" URL="\ref concepts::CBidirectionalRangeWithWritableIteratorFromPoint"];
+
+    CLabel [ label="CLabel" URL="\ref concepts::CLabel"];
+    CQuantity [ label="CQuantity" URL="\ref concepts::CQuantity"];
+    CPredicate [ label="CPredicate" URL="\ref concepts::CPredicate"];
+
+    CSinglePassRange -> CConstSinglePassRange ;
     CSinglePassRangeFromPoint -> CConstSinglePassRangeFromPoint;
     CSinglePassRangeFromPoint -> CSinglePassRange;
     CConstSinglePassRangeFromPoint -> CConstSinglePassRange;
@@ -49,9 +79,9 @@ digraph GBASE {
     label = "Base";
   }
 
-  "CSinglePassRangeWithWritableIterator" -> boost_OutputIterator [label="use", style=dashed];
-  "CConstSinglePassRange" -> boost_SingePassIteratorConcept [label="use",style=dashed];
-  "CSinglePassRange"->  boost_SingePassIteratorConcept [label="use",style=dashed] ;
+  CSinglePassRangeWithWritableIterator -> boost_OutputIterator [label="use", style=dashed];
+  CConstSinglePassRange -> boost_SinglePassIteratorConcept [label="use",style=dashed];
+  CSinglePassRange ->  boost_SinglePassIteratorConcept [label="use",style=dashed] ;
   CPredicate -> boost_Assignable;
   CQuantity -> boost_LessThanComparable;
   CLabel -> boost_DefaultConstructible;

--- a/src/DGtal/base/doc/packageBaseConcepts.dox
+++ b/src/DGtal/base/doc/packageBaseConcepts.dox
@@ -59,6 +59,8 @@ digraph GBASE {
     CLabel [ label="CLabel" URL="\ref concepts::CLabel"];
     CQuantity [ label="CQuantity" URL="\ref concepts::CQuantity"];
     CPredicate [ label="CPredicate" URL="\ref concepts::CPredicate"];
+    CBackInsertable [ label="CBackInsertable" URL="\ref concepts::CBackInsertable"];
+    CUnaryFunctor [ label="CUnaryFunctor" URL="\ref concepts::CUnaryFunctor"];
 
     CSinglePassRange -> CConstSinglePassRange ;
     CSinglePassRangeFromPoint -> CConstSinglePassRangeFromPoint;
@@ -74,8 +76,6 @@ digraph GBASE {
     CBidirectionalRangeWithWritableIterator -> CSinglePassRangeWithWritableIterator;
     CBidirectionalRangeWithWritableIteratorFromPoint -> CBidirectionalRangeWithWritableIterator;
 
-    CQuantity -> CLabel;
-    CPredicate;
     label = "Base";
   }
 
@@ -84,9 +84,12 @@ digraph GBASE {
   CSinglePassRange ->  boost_SinglePassIteratorConcept [label="use",style=dashed] ;
   CPredicate -> boost_Assignable;
   CQuantity -> boost_LessThanComparable;
+  CQuantity -> CLabel;
+  CPredicate -> CUnaryFunctor;
   CLabel -> boost_DefaultConstructible;
   CLabel -> boost_Assignable;
   CLabel -> boost_EqualityComparable;
+  CUnaryFunctor -> boost_Assignable;
   }
  @enddot
 

--- a/src/DGtal/geometry/curves/FreemanChain.ih
+++ b/src/DGtal/geometry/curves/FreemanChain.ih
@@ -708,7 +708,7 @@ template <typename TRange>
 inline
 void DGtal::FreemanChain<TInteger>::readFromPointsRange( const TRange& aRange, FreemanChain & c ) 
 {
-  BOOST_CONCEPT_ASSERT(( CConstSinglePassRange<TRange> ));
+  BOOST_CONCEPT_ASSERT(( concepts::CConstSinglePassRange<TRange> ));
   readFromPointsRange( aRange.begin(), aRange.end(), c ); 
 }
 

--- a/src/DGtal/geometry/curves/estimation/CCurveLocalGeometricEstimator.h
+++ b/src/DGtal/geometry/curves/estimation/CCurveLocalGeometricEstimator.h
@@ -102,7 +102,7 @@ namespace DGtal
   public:
 
     typedef typename T::Quantity Quantity;
-    BOOST_CONCEPT_ASSERT(( CQuantity< Quantity > ));
+    BOOST_CONCEPT_ASSERT(( concepts::CQuantity< Quantity > ));
 
     typedef typename T::ConstIterator ConstIterator;
     BOOST_CONCEPT_ASSERT(( boost_concepts::ReadableIteratorConcept< ConstIterator > ));

--- a/src/DGtal/geometry/curves/estimation/CGlobalCurveGeometricEstimator.h
+++ b/src/DGtal/geometry/curves/estimation/CGlobalCurveGeometricEstimator.h
@@ -100,7 +100,7 @@ namespace DGtal
   public:
 
     typedef typename T::Quantity Quantity;
-    BOOST_CONCEPT_ASSERT(( CQuantity< Quantity > ));
+    BOOST_CONCEPT_ASSERT(( concepts::CQuantity< Quantity > ));
 
     typedef typename T::ConstIterator ConstIterator;
     BOOST_CONCEPT_ASSERT(( boost_concepts::ReadableIteratorConcept< ConstIterator > ));

--- a/src/DGtal/images/ImageContainerByHashTree.h
+++ b/src/DGtal/images/ImageContainerByHashTree.h
@@ -161,7 +161,7 @@ namespace DGtal
                                           HyperRectDomain<typename Domain::Space > >::value));
 
     /// values range
-    BOOST_CONCEPT_ASSERT(( CLabel<TValue> ));
+  BOOST_CONCEPT_ASSERT(( concepts::CLabel<TValue> ));
     typedef TValue Value;
     //typedef ConstRangeAdapter<typename Domain::ConstIterator, Self, Value > ConstRange;
     typedef DefaultConstImageRange<Self> ConstRange;

--- a/src/DGtal/images/ImageContainerBySTLMap.h
+++ b/src/DGtal/images/ImageContainerBySTLMap.h
@@ -120,7 +120,7 @@ namespace DGtal
     static const typename Domain::Dimension dimension;
 
     /// range of values
-    BOOST_CONCEPT_ASSERT(( CLabel<TValue> ));
+    BOOST_CONCEPT_ASSERT(( concepts::CLabel<TValue> ));
     typedef TValue Value;
     typedef DefaultConstImageRange<Self> ConstRange; 
     typedef DefaultImageRange<Self> Range; 

--- a/src/DGtal/images/ImageContainerBySTLVector.h
+++ b/src/DGtal/images/ImageContainerBySTLVector.h
@@ -147,7 +147,7 @@ namespace DGtal
 					    HyperRectDomain< typename Domain::Space > >::value ) );
 
     /// range of values
-    BOOST_CONCEPT_ASSERT ( ( CLabel<TValue> ) );
+    BOOST_CONCEPT_ASSERT ( ( concepts::CLabel<TValue> ) );
     typedef TValue Value;
 
     /////////////////// Data members //////////////////

--- a/src/DGtal/images/ImageHelper.h
+++ b/src/DGtal/images/ImageHelper.h
@@ -353,7 +353,7 @@ namespace DGtal
     
     BOOST_CONCEPT_ASSERT(( concepts::CConstImage<Image> ));
     BOOST_CONCEPT_ASSERT(( concepts::CPointPredicate<PointPredicate> ));
-    BOOST_CONCEPT_ASSERT(( CQuantity<Value> ));
+    BOOST_CONCEPT_ASSERT(( concepts::CQuantity<Value> ));
     
     /*BOOST_CONCEPT_USAGE(ImageToConstantFunctor)
     {

--- a/src/DGtal/images/ImageHelper.ih
+++ b/src/DGtal/images/ImageHelper.ih
@@ -129,7 +129,7 @@ void
 DGtal::imageFromRangeAndValue(const R& aRange, I& aImg, 
 			      const typename I::Value& aValue)
 {
-  BOOST_CONCEPT_ASSERT(( CConstSinglePassRange<R> ));
+  BOOST_CONCEPT_ASSERT(( concepts::CConstSinglePassRange<R> ));
   BOOST_CONCEPT_ASSERT(( concepts::CImage<I> )); 
 
   imageFromRangeAndValue( aRange.begin(), aRange.end(), aImg, aValue); 

--- a/src/DGtal/images/ImageSelector.h
+++ b/src/DGtal/images/ImageSelector.h
@@ -66,7 +66,7 @@ namespace DGtal
   struct ImageSelector
   {
 
-    BOOST_CONCEPT_ASSERT((CLabel<Value>));
+    BOOST_CONCEPT_ASSERT((concepts::CLabel<Value>));
 
     // ----------------------- Local types ------------------------------
     /**

--- a/src/DGtal/kernel/BasicPointFunctors.h
+++ b/src/DGtal/kernel/BasicPointFunctors.h
@@ -526,7 +526,7 @@ namespace functors
 
       BOOST_CONCEPT_ASSERT(( concepts::CPointPredicate< PointPredicate > ));
       BOOST_CONCEPT_ASSERT(( concepts::CDomain< Domain > ));
-      BOOST_CONCEPT_ASSERT(( CQuantity< Value > ));
+      BOOST_CONCEPT_ASSERT(( concepts::CQuantity< Value > ));
 
       /**
        * @brief Constructor.

--- a/src/DGtal/kernel/doc/packageKernelConcepts.dox
+++ b/src/DGtal/kernel/doc/packageKernelConcepts.dox
@@ -35,10 +35,10 @@ digraph GKERNEL {
 	   color="#eeeeff";
 	   node [style=filled,color=white];
 	   label="base";
-	   CQuantity [ label="CQuantity" URL="\ref CQuantity" ];
-	   CUnaryFunctor [ label="CUnaryFunctor" URL="\ref CUnaryFunctor" ];
-	   CPredicate [ label="CPredicate" URL="\ref CPredicate" ];
-	   CConstSinglePassRange [ label="CConstSinglePassRange" URL="@ref CConstSinglePassRange"]
+	   CQuantity [ label="CQuantity" URL="\ref concepts::CQuantity" ];
+	   CUnaryFunctor [ label="CUnaryFunctor" URL="\ref concepts::CUnaryFunctor" ];
+	   CPredicate [ label="CPredicate" URL="\ref concepts::CPredicate" ];
+	   CConstSinglePassRange [ label="CConstSinglePassRange" URL="@ref concepts::CConstSinglePassRange"]
 	   }
 	   
        subgraph cluster_boost {

--- a/src/DGtal/topology/doc/packageTopologyConcepts.dox
+++ b/src/DGtal/topology/doc/packageTopologyConcepts.dox
@@ -34,8 +34,8 @@ digraph GTOPOLOGY {
                  node [style=filled,color=white];
                  label="base";
 
-                 CConstSinglePassRange [ label="CConstSinglePassRange" URL="\ref CConstSinglePassRange" ]; 
-                 CPredicate [ label="CPredicate" URL="\ref CPredicate" ]; 
+                 CConstSinglePassRange [ label="CConstSinglePassRange" URL="\ref concepts::CConstSinglePassRange" ]; 
+                 CPredicate [ label="CPredicate" URL="\ref concepts::CPredicate" ]; 
         }
         subgraph cluster_2 {
                  style=filled;

--- a/src/DGtal/topology/doc/packageTopologyConcepts1.dox
+++ b/src/DGtal/topology/doc/packageTopologyConcepts1.dox
@@ -34,7 +34,7 @@ digraph GTOPOLOGY {
                  node [style=filled,color=white];
                  label="base";
 
-                 CConstSinglePassRange [ label="CConstSinglePassRange" URL="\ref CConstSinglePassRange" ]; 
+                 CConstSinglePassRange [ label="CConstSinglePassRange" URL="\ref concepts::CConstSinglePassRange" ]; 
         }
         subgraph cluster_2 {
                  style=filled;

--- a/src/DGtal/topology/doc/packageTopologyConcepts2.dox
+++ b/src/DGtal/topology/doc/packageTopologyConcepts2.dox
@@ -34,7 +34,7 @@ digraph GTOPOLOGY {
                  node [style=filled,color=white];
                  label="base";
 
-                 CPredicate [ label="CPredicate" URL="\ref CPredicate" ]; 
+                 CPredicate [ label="CPredicate" URL="\ref concepts::CPredicate" ]; 
         }
         subgraph cluster_2 {
                  style=filled;

--- a/tests/arithmetic/testLightSternBrocot.cpp
+++ b/tests/arithmetic/testLightSternBrocot.cpp
@@ -763,7 +763,7 @@ int main( int , char** )
   typedef SB::Fraction Fraction;
   typedef Fraction::ConstIterator ConstIterator;
 
-  BOOST_CONCEPT_ASSERT(( CPositiveIrreducibleFraction< Fraction > ));
+  BOOST_CONCEPT_ASSERT(( concepts::CPositiveIrreducibleFraction< Fraction > ));
   BOOST_CONCEPT_ASSERT(( boost::InputIterator< ConstIterator > ));
 
   trace.beginBlock ( "Testing class LightSternBrocot" );

--- a/tests/arithmetic/testLighterSternBrocot.cpp
+++ b/tests/arithmetic/testLighterSternBrocot.cpp
@@ -855,7 +855,7 @@ int main( int , char** )
   typedef SB::Fraction Fraction;
   typedef Fraction::ConstIterator ConstIterator;
 
-  BOOST_CONCEPT_ASSERT(( CPositiveIrreducibleFraction< Fraction > ));
+  BOOST_CONCEPT_ASSERT(( concepts::CPositiveIrreducibleFraction< Fraction > ));
   BOOST_CONCEPT_ASSERT(( boost::InputIterator< ConstIterator > ));
   
   testTrivial<SB>( "LrSB" );

--- a/tests/arithmetic/testSternBrocot.cpp
+++ b/tests/arithmetic/testSternBrocot.cpp
@@ -870,7 +870,7 @@ int main( int , char** )
   typedef SB::Fraction Fraction;
   typedef Fraction::ConstIterator ConstIterator;
 
-  BOOST_CONCEPT_ASSERT(( CPositiveIrreducibleFraction< Fraction > ));
+  BOOST_CONCEPT_ASSERT(( concepts::CPositiveIrreducibleFraction< Fraction > ));
   BOOST_CONCEPT_ASSERT(( boost::InputIterator< ConstIterator > ));
 
   trace.beginBlock ( "Testing class SternBrocot" );

--- a/tests/base/testConstRangeAdapter.cpp
+++ b/tests/base/testConstRangeAdapter.cpp
@@ -128,7 +128,7 @@ bool testRange(const Range &aRange)
 template <typename Range>
 void testRangeConceptChecking()
 {
-  BOOST_CONCEPT_ASSERT(( CConstBidirectionalRange<Range> ));
+  BOOST_CONCEPT_ASSERT(( concepts::CConstBidirectionalRange<Range> ));
 }
 
 /*

--- a/tests/geometry/curves/testArithmeticalDSS.cpp
+++ b/tests/geometry/curves/testArithmeticalDSS.cpp
@@ -52,7 +52,7 @@ template <typename DSS>
 bool mainTest()
 {
   BOOST_CONCEPT_ASSERT(( concepts::CPointPredicate<DSS> ));
-  BOOST_CONCEPT_ASSERT(( CConstBidirectionalRange<DSS> ));
+  BOOST_CONCEPT_ASSERT(( concepts::CConstBidirectionalRange<DSS> ));
 
   typedef typename DSS::Point Point;
 
@@ -740,7 +740,7 @@ template <typename DSS>
 bool constructorsTest()
 {
   BOOST_CONCEPT_ASSERT(( concepts::CPointPredicate<DSS> ));
-  BOOST_CONCEPT_ASSERT(( CConstBidirectionalRange<DSS> ));
+  BOOST_CONCEPT_ASSERT(( concepts::CConstBidirectionalRange<DSS> ));
 
   typedef typename DSS::Point Point;
 

--- a/tests/geometry/curves/testGridCurve.cpp
+++ b/tests/geometry/curves/testGridCurve.cpp
@@ -318,7 +318,7 @@ template <typename Range>
 void testRangeConceptChecking()
 {
     BOOST_CONCEPT_ASSERT(( CDrawableWithBoard2D<Range> ));
-    BOOST_CONCEPT_ASSERT(( CConstBidirectionalRange<Range> ));
+    BOOST_CONCEPT_ASSERT(( concepts::CConstBidirectionalRange<Range> ));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/kernel/testHyperRectDomain.cpp
+++ b/tests/kernel/testHyperRectDomain.cpp
@@ -65,7 +65,7 @@ bool testSimpleHyperRectDomain()
   // Checking that HyperRectDomain is a model of CDomain.
   typedef HyperRectDomain<Space4Type> HRDomain4;
   BOOST_CONCEPT_ASSERT(( concepts::CDomain< HRDomain4 > ));
-  BOOST_CONCEPT_ASSERT(( CConstBidirectionalRange<HRDomain4> ));
+  BOOST_CONCEPT_ASSERT(( concepts::CConstBidirectionalRange<HRDomain4> ));
       
   ///Empty domain using the default constructor
   HyperRectDomain<Space4Type> myEmptyDomain;


### PR DESCRIPTION
# PR Description

A lot of concepts in package base were not in namespace concepts (for historical reasons). We move them into namespace concepts. The concept graph of base package was also missing links to concepts. It is now updated. Several BOOST_CONCEPT_ASSERT in other packages have been updated accordingly.

# Checklist

- [ NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
