### PR TITLE
Fix1168

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -93,6 +93,11 @@
     was wrong on 3d and on closed Khalimsky space.
     (Bertrand Kerautret, [#1156](https://github.com/DGtal-team/DGtal/pull/1156))
   - Add pre-calculated look up tables to speed up Object::isSimple calculations. (Pablo Hernandez-Cerdan, [#1155](https://github.com/DGtal-team/DGtal/pull/1155))
+  - Fix issue [#1168]
+    (https://github.com/DGtal-team/DGtal/issues/1168), related to bad
+    linear interpolation for binary volume data in
+    volMarchingCubes.cpp (Jacques-Olivier Lachaud,
+    [#1167](https://github.com/DGtal-team/DGtal/pull/1167))
 
 - *Shape Package*
   - Fix a tubular mesh construction problem (missing faces) which appears

--- a/examples/topology/volMarchingCubes.cpp
+++ b/examples/topology/volMarchingCubes.cpp
@@ -109,6 +109,8 @@ int main( int argc, char** argv )
     ImageLinearCellEmbedder< KSpace, Image, MyEmbedder > CellEmbedder;
   CellEmbedder cellEmbedder;
   MyEmbedder trivialEmbedder;
+  // The +0.5 is to avoid isosurface going exactly through a voxel
+  // center, especially for binary volumes.
   cellEmbedder.init( ks, image, trivialEmbedder, 
                      ( (double) minThreshold ) + 0.5 );
   ofstream out( "marching-cube.off" );

--- a/examples/topology/volMarchingCubes.cpp
+++ b/examples/topology/volMarchingCubes.cpp
@@ -109,7 +109,8 @@ int main( int argc, char** argv )
     ImageLinearCellEmbedder< KSpace, Image, MyEmbedder > CellEmbedder;
   CellEmbedder cellEmbedder;
   MyEmbedder trivialEmbedder;
-  cellEmbedder.init( ks, image, trivialEmbedder, minThreshold );
+  cellEmbedder.init( ks, image, trivialEmbedder, 
+                     ( (double) minThreshold ) + 0.5 );
   ofstream out( "marching-cube.off" );
   if ( out.good() )
     digSurf.exportEmbeddedSurfaceAs3DOFF( out, cellEmbedder );

--- a/src/DGtal/images/ImageLinearCellEmbedder.h
+++ b/src/DGtal/images/ImageLinearCellEmbedder.h
@@ -119,7 +119,7 @@ namespace DGtal
        @param iso_value the threshold value that defines the linear embedding.
     */
     void init( ConstAlias<KSpace> K, ConstAlias<Image> f, 
-               ConstAlias<Embedder> e, ImageValue iso_value );
+               ConstAlias<Embedder> e, double iso_value );
 
     // ----------------------- Interface --------------------------------------
   public:
@@ -189,7 +189,7 @@ namespace DGtal
     /// A pointer on the digital embedder.
     const Embedder* myPtrEmbedder;
     /// The threshold value for the linear embedding.
-    ImageValue myIsoValue;
+    double myIsoValue;
     
     // ------------------------- Hidden services ------------------------------
   protected:

--- a/src/DGtal/images/ImageLinearCellEmbedder.ih
+++ b/src/DGtal/images/ImageLinearCellEmbedder.ih
@@ -86,7 +86,7 @@ inline
 void
 DGtal::ImageLinearCellEmbedder<TKSpace, TImage, TEmbedder>::
 init( ConstAlias<KSpace> K, ConstAlias<Image> f, ConstAlias<Embedder> e,
-      ImageValue iso_value )
+      double iso_value )
 {
   myPtrK = &K;
   myPtrImage = &f;
@@ -132,7 +132,7 @@ operator()( const Cell & cell ) const
       Point p2( p1 ); --p2[ k ];
       RealPoint x2( embed( p2 ) );
       ImageValue y2 = (*myPtrImage)( p2 );
-      x1[ k ] -= NumberTraits<ImageValue>::castToDouble( y1 - myIsoValue )
+      x1[ k ] -= ( NumberTraits<ImageValue>::castToDouble( y1 ) - myIsoValue )
         * ( x2[ k ] - x1[ k ] )
         / NumberTraits<ImageValue>::castToDouble( y2 - y1 );
     }
@@ -158,7 +158,7 @@ embedSCell( const SCell & scell ) const
       Point p2( p1 ); --p2[ k ];
       RealPoint x2( embed( p2 ) );
       ImageValue y2 = (*myPtrImage)( p2 );
-      x1[ k ] -= NumberTraits<ImageValue>::castToDouble( y1 - myIsoValue )
+      x1[ k ] -= ( NumberTraits<ImageValue>::castToDouble( y1 ) - myIsoValue )
         * ( x2[ k ] - x1[ k ] )
         / NumberTraits<ImageValue>::castToDouble( y2 - y1 );
     }


### PR DESCRIPTION
# PR Description
 Fix issue [#1168] (https://github.com/DGtal-team/DGtal/issues/1168), related to bad
linear interpolation for binary volume data in volMarchingCubes.cpp 

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
