### PR TITLE
Projection star shape

### DIFF
--- a/src/DGtal/shapes/parametric/AccFlower2D.ih
+++ b/src/DGtal/shapes/parametric/AccFlower2D.ih
@@ -99,26 +99,10 @@ DGtal::AccFlower2D<T>::parameter( const RealPoint2D & pp ) const
 {
   RealPoint2D p( pp );
   p -= myCenter;
-  
-  double angle = 0.0;
-  if ( ( p[0] == 0.0 ) && ( p[1] == 0.0 ) )
-    return angle;
 
-  if ( p[0] >= p[1] )
-    {
-      if ( p[0] >= -p[1] )
-  angle = atan( p[1] / p[0] );
-      else
-  angle = 1.5* M_PI + atan( - p[0] / p[1] );
-    }
-  else // ( p[0] >= p[1] )
-    {
-      if ( p[0] >= -p[1] )
-  angle = 0.5*M_PI - atan( p[0] / p[1] );
-      else
-  angle = M_PI + atan( p[1] / p[0] );
-    }
-  angle = ( angle < 0.0 ) ? angle + 2*M_PI : angle;
+  double angle = atan2( p[1], p[0] );
+  angle = ( angle < 0.0 ) ? angle + 2 * M_PI : angle;
+
   return angle;
 }
 

--- a/src/DGtal/shapes/parametric/Ball2D.ih
+++ b/src/DGtal/shapes/parametric/Ball2D.ih
@@ -84,7 +84,7 @@ DGtal::Ball2D<T>::parameter( const RealPoint2D & pp ) const
 {
   RealPoint2D p( pp );
   p -= myCenter;
-  
+
   double angle = atan2( p[1], p[0] );
   angle = ( angle < 0.0 ) ? angle + 2*M_PI : angle;
 

--- a/src/DGtal/shapes/parametric/Flower2D.ih
+++ b/src/DGtal/shapes/parametric/Flower2D.ih
@@ -93,29 +93,10 @@ DGtal::Flower2D<T>::parameter( const RealPoint2D & pp ) const
 {
   RealPoint2D p( pp );
   p -= myCenter;
-  
-  double angle = 0.0;
-  if ( ( p[0] == 0.0 ) && ( p[1] == 0.0 ) )
-    return angle;
 
-/*
-  if ( p[0] >= p[1] )
-    {
-      if ( p[0] >= -p[1] )
-  angle = atan( p[1] / p[0] );
-      else
-  angle = 1.5* M_PI + atan( - p[0] / p[1] );
-    }
-  else // ( p[0] >= p[1] )
-    {
-      if ( p[0] >= -p[1] )
-  angle = 0.5*M_PI - atan( p[0] / p[1] );
-      else
-  angle = M_PI + atan( p[1] / p[0] );
-    }
+  double angle = atan2( p[1], p[0] );
   angle = ( angle < 0.0 ) ? angle + 2*M_PI : angle;
-*/
-  angle = atan2( p[1], p[0] ) + M_PI; 
+
   return angle;
 }
 

--- a/src/DGtal/shapes/parametric/NGon2D.ih
+++ b/src/DGtal/shapes/parametric/NGon2D.ih
@@ -93,26 +93,10 @@ DGtal::NGon2D<T>::parameter( const RealPoint2D & pp ) const
   RealPoint2D p( pp );
   p -= myCenter;
 
-  double t = atan2( p[ 1 ], p[ 0 ] );
-  return ( t < 0.0 ) ? ( t + 2.0 * M_PI ) : t;
-  // double angle = 0.0;
-  // if ( p[0] == 0.0 ) 
-  //   {
-  //     if ( p[1] >0 )
-  //       angle = M_PI/2.0; 
-  //     else 
-  //       angle = 1.5*M_PI; 
-  //   }
-  // else if (  ( p[0] > 0.0 ) && (   p[1] >= 0.0 ) )
-  //   angle = atan(p[1]/p[0]);
-  // else if (  ( p[0] > 0.0 ) && (   p[1] <= 0.0 ) )
-  //   angle = 2*M_PI + atan(p[1]/p[0]);
-  // else if (  ( p[0] < 0.0 ) && (   p[1] >= 0.0 ) )
-  //   angle = atan(p[1]/p[0]) + M_PI;
-  // else // (  ( p[0] < 0.0 ) && (   p[1] <= 0.0 ) )
-  //   angle = atan(p[1]/p[0]) + M_PI;
+  double angle = atan2( p[1], p[0] );
+  angle = ( angle < 0.0 ) ? angle + 2 * M_PI : angle;
 
-  // return angle;
+  return angle;
 }
 
 /**
@@ -126,30 +110,31 @@ inline
 typename DGtal::NGon2D<T>::RealPoint2D 
 DGtal::NGon2D<T>::x( double t ) const
 {
-  double angle = t - myPhi; 
-  while ( angle < 0.0 )
-    angle += 2.0*M_PI;
-  
-  
+  double angle = t - myPhi;
+  angle = (angle < 0.0) ? angle + 2 * M_PI : angle;
+
   // seek the vertices between the point, then compute the vector from one vertex to the next one.
-  
-  unsigned int intervale_lower = static_cast<unsigned int>( floor( ( angle )* myK / (2.0 * M_PI ) ) );
-  unsigned int intervale_upper = intervale_lower == ( myK -1 ) ? 0 : intervale_lower+1;
-  double dist = myRadius*cos ( M_PI / myK );
-  RealPoint2D s1 ( myRadius*cos(myPhi + intervale_lower*2.0*M_PI/myK),
-       myRadius*sin(myPhi + intervale_lower*2.0*M_PI/myK) );
-  RealPoint2D s2 ( myRadius*cos(myPhi + intervale_upper*2.0*M_PI/myK),
-       myRadius*sin(myPhi + intervale_upper*2.0*M_PI/myK) );
-  RealPoint2D s3( s2[0] - s1[0], s2[1] - s1[1]);
-  
-  double line_angle = atan2f( (float)s3[ 1 ], (float)s3[ 0 ]);
-  
-  double rho = dist/(cos (t - line_angle - 0.5*M_PI));
-  
-  RealPoint2D c( rho*cos(t), rho*sin(t) );
-  
+
+  unsigned int intervale_lower = static_cast<unsigned int>( floor( ( angle ) * myK / (2.0 * M_PI ) ) );
+  unsigned int intervale_upper = intervale_lower == ( myK - 1 ) ? 0 : intervale_lower + 1;
+  double dist = myRadius * cos( M_PI / myK );
+  RealPoint2D s1 ( myRadius * cos( myPhi + intervale_lower * 2.0 * M_PI / myK ),
+                   myRadius * sin( myPhi + intervale_lower * 2.0 * M_PI / myK ));
+  RealPoint2D s2 ( myRadius * cos( myPhi + intervale_upper * 2.0 * M_PI / myK ),
+                   myRadius * sin( myPhi + intervale_upper * 2.0 * M_PI / myK ));
+  RealPoint2D s3 ( s2[0] - s1[0],
+                   s2[1] - s1[1]);
+
+  //double line_angle = atan2f( (float)s3[ 1 ], (float)s3[ 0 ]);
+  double line_angle = atan2( s3[1], s3[0] );
+  //line_angle = (line_angle < 0.0) ? angle + 2 * M_PI : line_angle;
+
+  double rho = dist / ( cos(t - line_angle - 0.5 * M_PI) );
+
+  RealPoint2D c( - rho*cos(t), - rho*sin(t) );
+
   c += myCenter;
-  
+
   return c;
 }
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -213,7 +213,7 @@ namespace DGtal
      * @param right a point that is supposed to be projected right of p (regarding the angle)
      * @param step precision of the approximation
      * @param h the grid step
-     * @return a point that lies between the projection of left and right and that is the closest in term of \f$L_2\f$ norm.
+     * @return a point that lies between the projection of left and right and that is the closest regarding the \f$L_2\f$ norm.
      * */
     RealPoint closestPointWithWitnesses( const RealPoint& p, const RealPoint& left, const RealPoint& right, const int step, const double h ) const;
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -203,10 +203,16 @@ namespace DGtal
      * @param outer a point that is outside the shape
      * @param epsilon error parameter
      * @return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
-
      */
     RealPoint segmentProjection( RealPoint& inner, RealPoint& outer, const double epsilon ) const;
 
+    /**
+     * @param inner a point that is inside the shape
+     * @param outer a point that is outside the shape
+     * @param epsilon error parameter
+     * @return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
+     */
+    RealPoint normalProjection( RealPoint& p, RealPoint& left, RealPoint& right, const int step, const double h ) const;
 
     // ----------------------- Interface --------------------------------------
   public:

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -212,10 +212,9 @@ namespace DGtal
      * @param left a point that is supposed to be projected left of p (regarding the angle)
      * @param right a point that is supposed to be projected right of p (regarding the angle)
      * @param step precision of the approximation
-     * @param h the grid step
      * @return a point that lies between the projection of left and right and that is the closest regarding the \f$L_2\f$ norm.
      * */
-    RealPoint closestPointWithWitnesses( const RealPoint& p, const RealPoint& left, const RealPoint& right, const int step, const double h ) const;
+    RealPoint closestPointWithWitnesses( const RealPoint& p, const RealPoint& left, const RealPoint& right, const int step) const;
 
     // ----------------------- Interface --------------------------------------
   public:

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -211,7 +211,7 @@ namespace DGtal
      * @param p the point to be projected
      * @param left a point that is supposed to be projected left of p (regarding the angle)
      * @param right a point that is supposed to be projected right of p (regarding the angle)
-     * @param precision of the approximation
+     * @param step precision of the approximation
      * @param h the grid step
      * @return a point that lies between the projection of left and right and that is the closest in term of \f$L_2\f$ norm.
      * */

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -54,7 +54,7 @@ namespace DGtal
   // template class StarShaped2D
   /**
    * Description of template class 'StarShaped2D' <p>
-   * 
+   *
    * Aim: Abstract class that represents any star-shaped object in
    * dimension 2. Such a shape as a center and any segment from this
    * center to the shape boundary is included in the shape. These
@@ -62,22 +62,22 @@ namespace DGtal
    * the center.
    *
    * StarShaped2D and its derived classes are models of
-   * CEuclideanBoundedShape and CEuclideanOrientedShape. 
+   * CEuclideanBoundedShape and CEuclideanOrientedShape.
    *
    * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
    *
-   *  
+   *
    * @tparam TSpace space in which the shape is defined.
    */
   template <typename TSpace>
   class StarShaped2D
   {
-   
+
   public:
     typedef TSpace Space;
     typedef typename Space::Point Point;
     typedef typename Space::RealPoint RealPoint;
-     
+
    /**
      * Constructor.
      */
@@ -88,7 +88,7 @@ namespace DGtal
      * Destructor.
      */
     ~StarShaped2D();
-    
+
     // ------------------------- Implemented services -------------------------
   public:
     /**
@@ -101,25 +101,25 @@ namespace DGtal
 
     // ------------------------- Abstract services ----------------------------
   public:
-    
+
     /**
      * @return the lower bound of the shape bounding box.
      *
      */
     virtual RealPoint getLowerBound() const = 0;
-    
+
     /**
      * @return the upper bound of the shape bounding box.
      *
      */
     virtual RealPoint getUpperBound() const = 0;
-    
+
 
     /**
      * @return the center of the star-shaped object.
      */
     virtual RealPoint center() const = 0;
-    
+
     /**
      * @param p any point in the plane.
      *
@@ -150,26 +150,26 @@ namespace DGtal
      * @return the vector (x''(t),y''(t)).
      */
     virtual RealPoint xpp( const double t ) const = 0;
-    
+
 
     // ------------------------- star-shaped services -------------------------
   public:
 
-    /** 
+    /**
      * Return the orienatation of a point with respect to a shape.
-     * 
+     *
      * @param p input point
-     * 
-     * @return the orientation of the point (<0 means inside, ...)
+     *
+     * @return the orientation of the point (0 is inside, 1 is on, 2 is outside).
      */
     Orientation orientation( const RealPoint &p) const;
-    
-    
+
+
     /**
      * @param t any angle between 0 and 2*Pi.
      *
      * @return the vector (x'(t),y'(t)) made unitary which is the unit
-     * tangent to the shape boundary.  
+     * tangent to the shape boundary.
      */
     RealPoint tangent( double t ) const;
 
@@ -177,7 +177,7 @@ namespace DGtal
      * @param t any angle between 0 and 2*Pi.
      *
      * @return the vector (x''(t),y''(t)) made unitary which is the unit
-     * normal to the shape boundary looking inside the shape.  
+     * normal to the shape boundary looking inside the shape.
      */
     RealPoint normal( double t ) const;
 
@@ -197,6 +197,15 @@ namespace DGtal
      * @return the estimated arclength.
      */
     double arclength( double t1, double t2, unsigned int nb ) const;
+
+    /**
+     * @param inner a point that is inside the shape
+     * @param outer a point that is outside the shape
+     * @param epsilon error parameter
+     * @return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
+
+     */
+    RealPoint projection( RealPoint& inner, RealPoint& outer, const double epsilon ) const;
 
 
     // ----------------------- Interface --------------------------------------

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -205,7 +205,7 @@ namespace DGtal
      * @return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
 
      */
-    RealPoint projection( RealPoint& inner, RealPoint& outer, const double epsilon ) const;
+    RealPoint segmentProjection( RealPoint& inner, RealPoint& outer, const double epsilon ) const;
 
 
     // ----------------------- Interface --------------------------------------

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -43,6 +43,7 @@
 //////////////////////////////////////////////////////////////////////////////
 // Inclusions
 #include <iostream>
+#include <vector>
 #include "DGtal/base/Common.h"
 #include "DGtal/kernel/NumberTraits.h"
 //////////////////////////////////////////////////////////////////////////////
@@ -207,12 +208,14 @@ namespace DGtal
     RealPoint segmentProjection( RealPoint& inner, RealPoint& outer, const double epsilon ) const;
 
     /**
-     * @param inner a point that is inside the shape
-     * @param outer a point that is outside the shape
-     * @param epsilon error parameter
-     * @return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
-     */
-    RealPoint normalProjection( RealPoint& p, RealPoint& left, RealPoint& right, const int step, const double h ) const;
+     * @param p the point to be projected
+     * @param left a point that is supposed to be projected left of p (regarding the angle)
+     * @param right a point that is supposed to be projected right of p (regarding the angle)
+     * @param precision of the approximation
+     * @param h the grid step
+     * @return a point that lies between the projection of left and right and that is the closest in term of \f$L_2\f$ norm.
+     * */
+    RealPoint normProjection( RealPoint& p, RealPoint& left, RealPoint& right, const int step, const double h ) const;
 
     // ----------------------- Interface --------------------------------------
   public:

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -205,7 +205,7 @@ namespace DGtal
      * @param epsilon error parameter
      * @return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
      */
-    RealPoint segmentProjection( RealPoint& inner, RealPoint& outer, const double epsilon ) const;
+    RealPoint findIntersection( const RealPoint& inner, const RealPoint& outer, const double epsilon ) const;
 
     /**
      * @param p the point to be projected
@@ -215,7 +215,7 @@ namespace DGtal
      * @param h the grid step
      * @return a point that lies between the projection of left and right and that is the closest in term of \f$L_2\f$ norm.
      * */
-    RealPoint normProjection( RealPoint& p, RealPoint& left, RealPoint& right, const int step, const double h ) const;
+    RealPoint closestPointWithWitnesses( const RealPoint& p, const RealPoint& left, const RealPoint& right, const int step, const double h ) const;
 
     // ----------------------- Interface --------------------------------------
   public:

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -161,10 +161,9 @@ namespace DGtal
      *
      * @param p input point
      *
-     * @return the orientation of the point (0 is inside, 1 is on, 2 is outside).
+     * @return the orientation of the point (INSIDE ON or OUTSIDE).
      */
     Orientation orientation( const RealPoint &p) const;
-
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -195,24 +194,31 @@ namespace DGtal
      * @param t1 any angle between 0 and 2*Pi.
      * @param t2 any angle between 0 and 2*Pi, further from [t1].
      * @param nb the number of points used to estimate the arclength between x(t1) and x(t2).
+     *
      * @return the estimated arclength.
      */
     double arclength( double t1, double t2, unsigned int nb ) const;
 
     /**
+     * Return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
+     *
      * @param inner a point that is inside the shape
      * @param outer a point that is outside the shape
      * @param epsilon error parameter
-     * @return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
+     *
+     * @return the intersected point.
      */
     RealPoint findIntersection( const RealPoint& inner, const RealPoint& outer, const double epsilon ) const;
 
     /**
+     * Return a point that lies between the projection of left and right and that is the closest regarding the \f$L_2\f$ norm
+     *
      * @param p the point to be projected
      * @param left a point that is supposed to be projected left of p (regarding the angle)
      * @param right a point that is supposed to be projected right of p (regarding the angle)
      * @param step precision of the approximation
-     * @return a point that lies between the projection of left and right and that is the closest regarding the \f$L_2\f$ norm.
+     *
+     * @return a point.
      * */
     RealPoint closestPointWithWitnesses( const RealPoint& p, const RealPoint& left, const RealPoint& right, const int step) const;
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -163,14 +163,14 @@ inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
 DGtal::StarShaped2D<TSpace>::projection( typename DGtal::StarShaped2D<TSpace>::RealPoint& inner, typename DGtal::StarShaped2D<TSpace>::RealPoint& outer, double epsilon ) const
 {
-    typename DGtal::StarShaped2D<TSpace>::RealPoint mid = RealPoint(0.5 * (inner + outer));
+  typename DGtal::StarShaped2D<TSpace>::RealPoint mid = RealPoint(0.5 * (inner + outer));
 
-    if((inner - outer).norm() < epsilon) return mid; // We found a point that is at distance epsilon from the shape
-    else if(orientation(mid) == 0) return projection( mid, outer, epsilon ); // The point lies inside the shape
-    else if(orientation(mid) == 1) return mid; // The point is right onto the shape
-    else if(orientation(mid) == 2) return projection( inner, mid, epsilon ); // The point lies outside the shape
+  if((inner - outer).norm() < epsilon) return mid; // We found a point that is at distance epsilon from the shape
+  else if(orientation(mid) == 0) return projection( mid, outer, epsilon ); // The point lies inside the shape
+  else if(orientation(mid) == 1) return mid; // The point is right onto the shape
+  else if(orientation(mid) == 2) return projection( inner, mid, epsilon ); // The point lies outside the shape
 
-    return RealPoint(0., 0.);
+  return RealPoint(0., 0.);
 }
 
 /**

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -173,6 +173,46 @@ DGtal::StarShaped2D<TSpace>::segmentProjection( typename DGtal::StarShaped2D<TSp
   return RealPoint(0., 0.);
 }
 
+template <typename TSpace>
+inline
+typename DGtal::StarShaped2D<TSpace>::RealPoint 
+DGtal::StarShaped2D<TSpace>::normalProjection( typename DGtal::StarShaped2D<TSpace>::RealPoint& p, DGtal::StarShaped2D<TSpace>::RealPoint& left, DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
+{
+    auto dotProd = [](RealPoint& a, RealPoint& b) { return a[0] * b[0] + a[1] * b[1]; };
+
+    double left_angl = parameter(left);
+    double right_angl = parameter(right);
+
+    std::vector<typename DGtal::StarShaped2D<TSpace>::RealPoint> points;
+
+    for(int i = 0; i < step; i++)
+    {
+        double arc = fabs(right_angl - left_angl);
+        if(arc > M_PI) arc = 2 * M_PI - arc;
+        const double current_angl = fmod(left_angl + arc / step * i, 2 * M_PI);
+
+        RealPoint temp = x(current_angl);
+        points.push_back(temp);
+    }
+
+    double p_norm = 1e15;
+    RealPoint p_return = Point(0., 0.);
+
+    for(int i = 0; i < points.size(); i++)
+    {
+        const double p_norm_current = (points[i] - p).norm();
+        if(p_norm_current < p_norm)
+        {
+            p_return = points[i];
+            p_norm = p_norm_current;
+        }
+    }
+
+    ASSERT(p_return != Point(0., 0.));
+
+    return p_return;
+}
+
 /**
  * Destructor.
  */

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -176,7 +176,7 @@ DGtal::StarShaped2D<TSpace>::findIntersection( const typename DGtal::StarShaped2
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const DGtal::StarShaped2D<TSpace>::RealPoint& left, const DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
+DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const typename DGtal::StarShaped2D<TSpace>::RealPoint& left, const typename DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
 {
   auto dotProd = [](RealPoint& a, RealPoint& b) { return a[0] * b[0] + a[1] * b[1]; };
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -169,6 +169,8 @@ DGtal::StarShaped2D<TSpace>::projection( typename DGtal::StarShaped2D<TSpace>::R
     else if(orientation(mid) == 0) return projection( mid, outer, epsilon ); // The point lies inside the shape
     else if(orientation(mid) == 1) return mid; // The point is right onto the shape
     else if(orientation(mid) == 2) return projection( inner, mid, epsilon ); // The point lies outside the shape
+
+    return RealPoint(0., 0.);
 }
 
 /**

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -152,7 +152,24 @@ DGtal::StarShaped2D<TSpace>::arclength( double t1, double t2, unsigned int nb ) 
   return l;
 }
 
+/**
+ * @param inner a point that is inside the shape
+ * @param outer a point that is outside the shape
+ * @param epsilon error parameter
+ * @return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
+ */
+template <typename TSpace>
+inline
+typename DGtal::StarShaped2D<TSpace>::RealPoint
+DGtal::StarShaped2D<TSpace>::projection( typename DGtal::StarShaped2D<TSpace>::RealPoint& inner, typename DGtal::StarShaped2D<TSpace>::RealPoint& outer, double epsilon ) const
+{
+    typename DGtal::StarShaped2D<TSpace>::RealPoint mid = RealPoint(0.5 * (inner + outer));
 
+    if((inner - outer).norm() < epsilon) return mid; // We found a point that is at distance epsilon from the shape
+    else if(orientation(mid) == 0) return projection( mid, outer, epsilon ); // The point lies inside the shape
+    else if(orientation(mid) == 1) return mid; // The point is right onto the shape
+    else if(orientation(mid) == 2) return projection( inner, mid, epsilon ); // The point lies outside the shape
+}
 
 /**
  * Destructor.

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -176,7 +176,7 @@ DGtal::StarShaped2D<TSpace>::findIntersection( const typename DGtal::StarShaped2
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const typename DGtal::StarShaped2D<TSpace>::RealPoint& left, const typename DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
+DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const typename DGtal::StarShaped2D<TSpace>::RealPoint& left, const typename DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step) const
 {
   double left_angl = parameter(left);
   double right_angl = parameter(right);

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -161,14 +161,14 @@ DGtal::StarShaped2D<TSpace>::arclength( double t1, double t2, unsigned int nb ) 
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::projection( typename DGtal::StarShaped2D<TSpace>::RealPoint& inner, typename DGtal::StarShaped2D<TSpace>::RealPoint& outer, double epsilon ) const
+DGtal::StarShaped2D<TSpace>::segmentProjection( typename DGtal::StarShaped2D<TSpace>::RealPoint& inner, typename DGtal::StarShaped2D<TSpace>::RealPoint& outer, double epsilon ) const
 {
   typename DGtal::StarShaped2D<TSpace>::RealPoint mid = RealPoint(0.5 * (inner + outer));
 
   if((inner - outer).norm() < epsilon) return mid; // We found a point that is at distance epsilon from the shape
-  else if(orientation(mid) == 0) return projection( mid, outer, epsilon ); // The point lies inside the shape
+  else if(orientation(mid) == 0) return segmentProjection( mid, outer, epsilon ); // The point lies inside the shape
   else if(orientation(mid) == 1) return mid; // The point is right onto the shape
-  else if(orientation(mid) == 2) return projection( inner, mid, epsilon ); // The point lies outside the shape
+  else if(orientation(mid) == 2) return segmentProjection( inner, mid, epsilon ); // The point lies outside the shape
 
   return RealPoint(0., 0.);
 }

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -161,14 +161,14 @@ DGtal::StarShaped2D<TSpace>::arclength( double t1, double t2, unsigned int nb ) 
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::segmentProjection( typename DGtal::StarShaped2D<TSpace>::RealPoint& inner, typename DGtal::StarShaped2D<TSpace>::RealPoint& outer, double epsilon ) const
+DGtal::StarShaped2D<TSpace>::findIntersection( const typename DGtal::StarShaped2D<TSpace>::RealPoint& inner, const typename DGtal::StarShaped2D<TSpace>::RealPoint& outer, double epsilon ) const
 {
   typename DGtal::StarShaped2D<TSpace>::RealPoint mid = RealPoint(0.5 * (inner + outer));
 
   if((inner - outer).norm() < epsilon) return mid; // We found a point that is at distance epsilon from the shape
-  else if(orientation(mid) == 0) return segmentProjection( mid, outer, epsilon ); // The point lies inside the shape
+  else if(orientation(mid) == 0) return findIntersection( mid, outer, epsilon ); // The point lies inside the shape
   else if(orientation(mid) == 1) return mid; // The point is right onto the shape
-  else if(orientation(mid) == 2) return segmentProjection( inner, mid, epsilon ); // The point lies outside the shape
+  else if(orientation(mid) == 2) return findIntersection( inner, mid, epsilon ); // The point lies outside the shape
 
   return RealPoint(0., 0.);
 }
@@ -176,7 +176,7 @@ DGtal::StarShaped2D<TSpace>::segmentProjection( typename DGtal::StarShaped2D<TSp
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::normProjection( typename DGtal::StarShaped2D<TSpace>::RealPoint& p, DGtal::StarShaped2D<TSpace>::RealPoint& left, DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
+DGtal::StarShaped2D<TSpace>::closesPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const DGtal::StarShaped2D<TSpace>::RealPoint& left, const DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
 {
   auto dotProd = [](RealPoint& a, RealPoint& b) { return a[0] * b[0] + a[1] * b[1]; };
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -175,42 +175,40 @@ DGtal::StarShaped2D<TSpace>::segmentProjection( typename DGtal::StarShaped2D<TSp
 
 template <typename TSpace>
 inline
-typename DGtal::StarShaped2D<TSpace>::RealPoint 
-DGtal::StarShaped2D<TSpace>::normalProjection( typename DGtal::StarShaped2D<TSpace>::RealPoint& p, DGtal::StarShaped2D<TSpace>::RealPoint& left, DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
+typename DGtal::StarShaped2D<TSpace>::RealPoint
+DGtal::StarShaped2D<TSpace>::normProjection( typename DGtal::StarShaped2D<TSpace>::RealPoint& p, DGtal::StarShaped2D<TSpace>::RealPoint& left, DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
 {
-    auto dotProd = [](RealPoint& a, RealPoint& b) { return a[0] * b[0] + a[1] * b[1]; };
+  auto dotProd = [](RealPoint& a, RealPoint& b) { return a[0] * b[0] + a[1] * b[1]; };
 
-    double left_angl = parameter(left);
-    double right_angl = parameter(right);
+  double left_angl = parameter(left);
+  double right_angl = parameter(right);
 
-    std::vector<typename DGtal::StarShaped2D<TSpace>::RealPoint> points;
+  std::vector<typename DGtal::StarShaped2D<TSpace>::RealPoint> points;
 
-    for(int i = 0; i < step; i++)
+  for(int i = 0; i < step; i++)
+  {
+    double arc = fabs(right_angl - left_angl);
+    if(arc > M_PI) arc = 2 * M_PI - arc;
+    const double current_angl = fmod(left_angl + arc / step * i, 2 * M_PI);
+
+    RealPoint temp = x(current_angl);
+    points.push_back(temp);
+  }
+
+  double p_norm = 1e15;
+  RealPoint p_return = Point(0., 0.);
+
+  for(int i = 0; i < points.size(); i++)
+  {
+    const double p_norm_current = (points[i] - p).norm();
+    if(p_norm_current < p_norm)
     {
-        double arc = fabs(right_angl - left_angl);
-        if(arc > M_PI) arc = 2 * M_PI - arc;
-        const double current_angl = fmod(left_angl + arc / step * i, 2 * M_PI);
-
-        RealPoint temp = x(current_angl);
-        points.push_back(temp);
+      p_return = points[i];
+      p_norm = p_norm_current;
     }
+  }
 
-    double p_norm = 1e15;
-    RealPoint p_return = Point(0., 0.);
-
-    for(int i = 0; i < points.size(); i++)
-    {
-        const double p_norm_current = (points[i] - p).norm();
-        if(p_norm_current < p_norm)
-        {
-            p_return = points[i];
-            p_norm = p_norm_current;
-        }
-    }
-
-    ASSERT(p_return != Point(0., 0.));
-
-    return p_return;
+  return p_return;
 }
 
 /**

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -176,7 +176,7 @@ DGtal::StarShaped2D<TSpace>::findIntersection( const typename DGtal::StarShaped2
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::closesPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const DGtal::StarShaped2D<TSpace>::RealPoint& left, const DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
+DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const DGtal::StarShaped2D<TSpace>::RealPoint& left, const DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
 {
   auto dotProd = [](RealPoint& a, RealPoint& b) { return a[0] * b[0] + a[1] * b[1]; };
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -153,26 +153,42 @@ DGtal::StarShaped2D<TSpace>::arclength( double t1, double t2, unsigned int nb ) 
 }
 
 /**
- * @param inner a point that is inside the shape
- * @param outer a point that is outside the shape
- * @param epsilon error parameter
- * @return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
- */
+  * Return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
+  *
+  * @param inner a point that is inside the shape
+  * @param outer a point that is outside the shape
+  * @param epsilon error parameter
+  *
+  * @return the intersected point.
+  */
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::findIntersection( const typename DGtal::StarShaped2D<TSpace>::RealPoint& inner, const typename DGtal::StarShaped2D<TSpace>::RealPoint& outer, double epsilon ) const
+DGtal::StarShaped2D<TSpace>::findIntersection( const typename DGtal::StarShaped2D<TSpace>::RealPoint& inner, 
+                                               const typename DGtal::StarShaped2D<TSpace>::RealPoint& outer, 
+                                               double epsilon ) const
 {
   typename DGtal::StarShaped2D<TSpace>::RealPoint mid = RealPoint(0.5 * (inner + outer));
 
   if((inner - outer).norm() < epsilon) return mid; // We found a point that is at distance epsilon from the shape
-  else if(orientation(mid) == 0) return findIntersection( mid, outer, epsilon ); // The point lies inside the shape
-  else if(orientation(mid) == 1) return mid; // The point is right onto the shape
-  else if(orientation(mid) == 2) return findIntersection( inner, mid, epsilon ); // The point lies outside the shape
+  else if(orientation(mid) == Orientation::INSIDE)  return findIntersection( mid, outer, epsilon ); // The point lies inside the shape
+  else if(orientation(mid) == Orientation::ON)      return mid; // The point is right onto the shape
+  else if(orientation(mid) == Orientation::OUTSIDE) return findIntersection( inner, mid, epsilon ); // The point lies outside the shape
 
+  ASSERT( false ); //this should not be reached
   return RealPoint(0., 0.);
 }
 
+/**
+  * Return a point that lies between the projection of left and right and that is the closest regarding the \f$L_2\f$ norm
+  *
+  * @param p the point to be projected
+  * @param left a point that is supposed to be projected left of p (regarding the angle)
+  * @param right a point that is supposed to be projected right of p (regarding the angle)
+  * @param step precision of the approximation
+  *
+  * @return a point.
+  **/
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -178,8 +178,6 @@ inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
 DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const typename DGtal::StarShaped2D<TSpace>::RealPoint& left, const typename DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step, const double h ) const
 {
-  auto dotProd = [](RealPoint& a, RealPoint& b) { return a[0] * b[0] + a[1] * b[1]; };
-
   double left_angl = parameter(left);
   double right_angl = parameter(right);
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -192,7 +192,8 @@ DGtal::StarShaped2D<TSpace>::findIntersection( const typename DGtal::StarShaped2
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const typename DGtal::StarShaped2D<TSpace>::RealPoint& left, const typename DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step) const
+DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const typename DGtal::StarShaped2D<TSpace>::RealPoint& left, 
+    const typename DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step) const
 {
   double left_angl = parameter(left);
   double right_angl = parameter(right);

--- a/tests/shapes/CMakeLists.txt
+++ b/tests/shapes/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(DGTAL_TESTS_SRC
   testBall3DSurface
   testEuclideanShapesDecorator
   testDigitalShapesDecorator
+  testProjection
   )
 
 FOREACH(FILE ${DGTAL_TESTS_SRC})

--- a/tests/shapes/testProjection.cpp
+++ b/tests/shapes/testProjection.cpp
@@ -149,7 +149,7 @@ bool test_shape(Shape& shape, const double h, const double epsilon)
   return true;
 }
 
-int main(int argc, char** argv)
+int main()
 {
   typedef Ball2D<Space> Ball;
   const Ball ball(Point(0,0), 1.0);
@@ -165,7 +165,8 @@ int main(int argc, char** argv)
 
   double h = 1.0;
   
- 	while(h >= 0.001) {
+ 	while(h >= 0.001) 
+  {
   	if(test_shape(ball, h, h * 0.1)) return 0;
   	if(test_shape(flower2D, h, h * 0.1)) return 0;
   	if(test_shape(accFlower2D, h, h * 0.1)) return 0;

--- a/tests/shapes/testProjection.cpp
+++ b/tests/shapes/testProjection.cpp
@@ -137,7 +137,7 @@ bool test_shape(Shape& shape, const double h, const double epsilon)
     outer *= h;
 
     RealPoint q = shape.findIntersection(inner, outer, epsilon);
-    RealPoint p = shape.closestPointWithWitnesses(q, q, q, 100, h);
+    RealPoint p = shape.closestPointWithWitnesses(q, q, q, 100);
 
     const double norm2 = (q - h * canonicSCellEmbedder(sCells0[i])).norm();
 

--- a/tests/shapes/testProjection.cpp
+++ b/tests/shapes/testProjection.cpp
@@ -46,6 +46,9 @@ using namespace std;
 using namespace DGtal;
 using namespace Z2i;
 
+///////////////////////////////////////////////////////////////////////////////
+// Standard services - public :/
+
 double angle(const DGtal::Z2i::RealPoint& point)
 {
   double angle = atan2(point[1], point[0]);
@@ -81,6 +84,7 @@ struct AngleLessCell
 template <typename Shape>
 void digitize(Shape& shape, std::vector<SCell>& sCells0, std::vector<SCell>& sCells1, KSpace& kspace, const double h)
 {
+  // -------------------------------------------------------------------------- Type declaring
   typedef typename DGtal::GaussDigitizer<Space, Shape> Digitizer;
   typedef SurfelAdjacency<2> SurfelAdj;
   typedef Surfaces<KSpace> Surf;
@@ -88,6 +92,7 @@ void digitize(Shape& shape, std::vector<SCell>& sCells0, std::vector<SCell>& sCe
   sCells0.clear();
   sCells1.clear();
 
+  // -------------------------------------------------------------------------- Creating the shape
   Digitizer digitizer;
   digitizer.attach(shape);
   digitizer.init(shape.getLowerBound() + Vector(-1,-1), shape.getUpperBound() + Vector(1,1), h);
@@ -165,10 +170,10 @@ int main()
 
  	while(h >= 0.001)
   {
-  	if(test_shape(ball, h, h * 0.1)) return 0;
-  	if(test_shape(flower2D, h, h * 0.1)) return 0;
+  	if(test_shape(ball, h, h * 0.1))        return 0;
+  	if(test_shape(flower2D, h, h * 0.1))    return 0;
   	if(test_shape(accFlower2D, h, h * 0.1)) return 0;
-  	if(test_shape(ellipse2D, h, h * 0.1)) return 0;
+  	if(test_shape(ellipse2D, h, h * 0.1))   return 0;
 
   	h /= 1.1;
   }

--- a/tests/shapes/testProjection.cpp
+++ b/tests/shapes/testProjection.cpp
@@ -15,11 +15,11 @@
 **/
 
 /**
-* @file testEllipsoid.cpp
+* @file testProjection.cpp
 * @ingroup Tests
-* @author Anis Benyoub (\c anis.benyoub@insa-lyon.fr )
+* @author Thomas Caissard (\c thomas.caissard@liris.cnrs.fr )
 *
-* @date 2012/°6/05
+* @date 2016/05/05
 *
 * Tests of projections functions in starshape.
 *
@@ -48,133 +48,133 @@ using namespace Z2i;
 
 double angle(const DGtal::Z2i::RealPoint& point)
 {
-    double angle = atan2(point[1], point[0]);
-    if(angle < 0.) angle += 2. * M_PI;
-    return angle;
+  double angle = atan2(point[1], point[0]);
+  if(angle < 0.) angle += 2. * M_PI;
+  return angle;
 }
 
 double angle(const DGtal::Z2i::KSpace& kspace, const DGtal::Z2i::SCell& cell, const double h)
 {
-    DGtal::CanonicSCellEmbedder<DGtal::Z2i::KSpace> emb(kspace);
-    return angle(h * emb(cell));
+  DGtal::CanonicSCellEmbedder<DGtal::Z2i::KSpace> emb(kspace);
+  return angle(h * emb(cell));
 }
 
 struct AngleLessCell
 {
-    typedef DGtal::Z2i::KSpace KSpace;
-    typedef KSpace::SCell SCell;
-    typedef KSpace::Point Point;
+  typedef DGtal::Z2i::KSpace KSpace;
+  typedef KSpace::SCell SCell;
+  typedef KSpace::Point Point;
 
-    AngleLessCell(const KSpace& kspace, const double h) : _kspace(kspace), _h(h)
-    {
-    }
+  AngleLessCell(const KSpace& kspace, const double h) : _kspace(kspace), _h(h)
+  {
+  }
 
-    inline bool operator()(const SCell& a, const SCell& b) const
-    {
-        return angle(_kspace, a, _h) < angle(_kspace, b, _h);
-    }
+  inline bool operator()(const SCell& a, const SCell& b) const
+  {
+      return angle(_kspace, a, _h) < angle(_kspace, b, _h);
+  }
 
-    const KSpace& _kspace;
-    const double _h;
+  const KSpace& _kspace;
+  const double _h;
 };
 
 template <typename Shape>
 void digitize(Shape& shape, std::vector<SCell>& sCells0, std::vector<SCell>& sCells1, KSpace& kspace, const double h)
 {
 	typedef typename DGtal::GaussDigitizer<Space, Shape> Digitizer;
-    typedef SurfelAdjacency<2> SurfelAdj;
-    typedef Surfaces<KSpace> Surf;
+  typedef SurfelAdjacency<2> SurfelAdj;
+  typedef Surfaces<KSpace> Surf;
 
-    sCells0.clear();
-    sCells1.clear();
+  sCells0.clear();
+  sCells1.clear();
 
-    Digitizer digitizer;
-    digitizer.attach(shape);
-    digitizer.init(shape.getLowerBound() + Vector(-1,-1), shape.getUpperBound() + Vector(1,1), h);
-    Domain domain;
-    domain = digitizer.getDomain();
+  Digitizer digitizer;
+  digitizer.attach(shape);
+  digitizer.init(shape.getLowerBound() + Vector(-1,-1), shape.getUpperBound() + Vector(1,1), h);
+  Domain domain;
+  domain = digitizer.getDomain();
 
-    kspace.init(digitizer.getLowerBound(), digitizer.getUpperBound(), true);
+  kspace.init(digitizer.getLowerBound(), digitizer.getUpperBound(), true);
 
-    const SurfelAdj surfel_adjacency(true);
-    const KSpace::SCell cell_bel = Surf::findABel(kspace, digitizer);
-    Surf::track2DBoundary(sCells1, kspace, surfel_adjacency, digitizer, cell_bel);
-    {
-        typedef std::vector<Point> Points;
-        Points points;
-        Surf::track2DBoundaryPoints(points, kspace, surfel_adjacency, digitizer, cell_bel);
-        const KSpace::SCell point_ref = kspace.sCell(Point(0,0));
-        for(Points::const_iterator pi = points.begin(), pe = points.end(); pi != pe; ++pi) sCells0.push_back(kspace.sCell(*pi, point_ref));
-    }
+  const SurfelAdj surfel_adjacency(true);
+  const KSpace::SCell cell_bel = Surf::findABel(kspace, digitizer);
+  Surf::track2DBoundary(sCells1, kspace, surfel_adjacency, digitizer, cell_bel);
+  {
+    typedef std::vector<Point> Points;
+    Points points;
+    Surf::track2DBoundaryPoints(points, kspace, surfel_adjacency, digitizer, cell_bel);
+    const KSpace::SCell point_ref = kspace.sCell(Point(0,0));
+    for(Points::const_iterator pi = points.begin(), pe = points.end(); pi != pe; ++pi) sCells0.push_back(kspace.sCell(*pi, point_ref));
+  }
 
-    std::sort(sCells0.begin(), sCells0.end(), AngleLessCell(kspace, h));
-    std::sort(sCells1.begin(), sCells1.end(), AngleLessCell(kspace, h));
+  std::sort(sCells0.begin(), sCells0.end(), AngleLessCell(kspace, h));
+  std::sort(sCells1.begin(), sCells1.end(), AngleLessCell(kspace, h));
 
-    ASSERT(sCells0.size() == sCells1.size());
+  ASSERT(sCells0.size() == sCells1.size());
 }
 
 template <typename Shape>
 bool test_shape(Shape& shape, const double h, const double epsilon)
 {
 
-	std::vector<SCell> sCells0, sCells1;
+  std::vector<SCell> sCells0, sCells1;
 
-	KSpace kspace;
+  KSpace kspace;
 
-	digitize(shape, sCells0, sCells1, kspace, h);
+  digitize(shape, sCells0, sCells1, kspace, h);
 
-	CanonicSCellEmbedder<KSpace> canonicSCellEmbedder(kspace);
+  CanonicSCellEmbedder<KSpace> canonicSCellEmbedder(kspace);
 
-	for(int i = 0; i < sCells0.size(); i++)
-	{
-		functors::SCellToInnerPoint<KSpace> sCellToInnerPoint(kspace);
-	    functors::SCellToOuterPoint<KSpace> sCellToOuterPoint(kspace);
+  for(int i = 0; i < sCells0.size(); i++)
+  {
+  	functors::SCellToInnerPoint<KSpace> sCellToInnerPoint(kspace);
+    functors::SCellToOuterPoint<KSpace> sCellToOuterPoint(kspace);
 
-	    RealPoint inner = sCellToInnerPoint(sCells1[i]);
-	    RealPoint outer = sCellToOuterPoint(sCells1[i]);
+    RealPoint inner = sCellToInnerPoint(sCells1[i]);
+    RealPoint outer = sCellToOuterPoint(sCells1[i]);
 
-	    inner *= h;
-	    outer *= h;
+    inner *= h;
+    outer *= h;
 
-	    RealPoint q = shape.projection(inner, outer, epsilon);
+    RealPoint q = shape.projection(inner, outer, epsilon);
 
-	    //trace.info() << (q - h * canonicSCellEmbedder(sCells0[i])).norm() << std::endl;
+    //trace.info() << (q - h * canonicSCellEmbedder(sCells0[i])).norm() << std::endl;
 
-	    const double norm2 = (q - h * canonicSCellEmbedder(sCells0[i])).norm();
+    const double norm2 = (q - h * canonicSCellEmbedder(sCells0[i])).norm();
 
-	    //if (norm2 > sqrt(2) * h) trace.info() << sqrt(2) * epsilon << " < " << norm2 << std::endl;
-	    if (norm2 > sqrt(2) * h) return 0;
-	}
+    //if (norm2 > sqrt(2) * h) trace.info() << sqrt(2) * epsilon << " < " << norm2 << std::endl;
+    if (norm2 > sqrt(2.0) * h) return false;
+  }
 
-	return 1;
+  return true;
 }
 
 int main(int argc, char** argv)
 {
-    typedef Ball2D<Space> Ball;
-    const Ball ball(Point(0,0), 1.0);
+  typedef Ball2D<Space> Ball;
+  const Ball ball(Point(0,0), 1.0);
 
-    typedef Flower2D<Space> Flower2D;
-    const Flower2D flower2D(Point(0,0), 1., 0.3, 5, 0.);
+  typedef Flower2D<Space> Flower2D;
+  const Flower2D flower2D(Point(0,0), 1., 0.3, 5, 0.);
 
-    typedef AccFlower2D<Space> AccFlower2D;
-    const AccFlower2D accFlower2D(Point(0,0), 1., 0.3, 5, 0.);
+  typedef AccFlower2D<Space> AccFlower2D;
+  const AccFlower2D accFlower2D(Point(0,0), 1., 0.3, 5, 0.);
 
-    typedef Ellipse2D<Space> Ellipse2D;
-    const Ellipse2D ellipse2D(Point(0,0), 1., 0.4, 0.2);
+  typedef Ellipse2D<Space> Ellipse2D;
+  const Ellipse2D ellipse2D(Point(0,0), 1., 0.4, 0.2);
 
-    double h = 1.0;
-    
-   	while(h >= 0.001) {
-    	if(test_shape(ball, h, h * 0.1)) return 0;
-    	if(test_shape(flower2D, h, h * 0.1)) return 0;
-    	if(test_shape(accFlower2D, h, h * 0.1)) return 0;
-    	if(test_shape(ellipse2D, h, h * 0.1)) return 0;
+  double h = 1.0;
+  
+ 	while(h >= 0.001) {
+  	if(test_shape(ball, h, h * 0.1)) return 0;
+  	if(test_shape(flower2D, h, h * 0.1)) return 0;
+  	if(test_shape(accFlower2D, h, h * 0.1)) return 0;
+  	if(test_shape(ellipse2D, h, h * 0.1)) return 0;
 
-    	h /= 1.1;
-    }
+  	h /= 1.1;
+  }
 
-    return 1;
+  return 1;
 }
 
 

--- a/tests/shapes/testProjection.cpp
+++ b/tests/shapes/testProjection.cpp
@@ -81,7 +81,7 @@ struct AngleLessCell
 template <typename Shape>
 void digitize(Shape& shape, std::vector<SCell>& sCells0, std::vector<SCell>& sCells1, KSpace& kspace, const double h)
 {
-	typedef typename DGtal::GaussDigitizer<Space, Shape> Digitizer;
+  typedef typename DGtal::GaussDigitizer<Space, Shape> Digitizer;
   typedef SurfelAdjacency<2> SurfelAdj;
   typedef Surfaces<KSpace> Surf;
 
@@ -136,13 +136,10 @@ bool test_shape(Shape& shape, const double h, const double epsilon)
     inner *= h;
     outer *= h;
 
-    RealPoint q = shape.segmentProjection(inner, outer, epsilon);
-
-    //trace.info() << (q - h * canonicSCellEmbedder(sCells0[i])).norm() << std::endl;
+    RealPoint q = shape.findIntersection(inner, outer, epsilon);
 
     const double norm2 = (q - h * canonicSCellEmbedder(sCells0[i])).norm();
 
-    //if (norm2 > sqrt(2) * h) trace.info() << sqrt(2) * epsilon << " < " << norm2 << std::endl;
     if (norm2 > sqrt(2.0) * h) return false;
   }
 
@@ -164,8 +161,8 @@ int main()
   const Ellipse2D ellipse2D(Point(0,0), 1., 0.4, 0.2);
 
   double h = 1.0;
-  
- 	while(h >= 0.001) 
+
+ 	while(h >= 0.001)
   {
   	if(test_shape(ball, h, h * 0.1)) return 0;
   	if(test_shape(flower2D, h, h * 0.1)) return 0;

--- a/tests/shapes/testProjection.cpp
+++ b/tests/shapes/testProjection.cpp
@@ -137,6 +137,7 @@ bool test_shape(Shape& shape, const double h, const double epsilon)
     outer *= h;
 
     RealPoint q = shape.findIntersection(inner, outer, epsilon);
+    RealPoint p = shape.closestPointWithWitnesses(q, q, q, 100, h);
 
     const double norm2 = (q - h * canonicSCellEmbedder(sCells0[i])).norm();
 

--- a/tests/shapes/testProjection.cpp
+++ b/tests/shapes/testProjection.cpp
@@ -1,0 +1,180 @@
+/**
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+**/
+
+/**
+* @file testEllipsoid.cpp
+* @ingroup Tests
+* @author Anis Benyoub (\c anis.benyoub@insa-lyon.fr )
+*
+* @date 2012/°6/05
+*
+* Tests of projections functions in starshape.
+*
+* This file is part of the DGtal library.
+*/
+
+///////////////////////////////////////////////////////////////////////////////
+#include <iostream>
+
+#include "DGtal/helpers/StdDefs.h"
+
+#include "DGtal/topology/SurfelAdjacency.h"
+#include "DGtal/topology/DigitalSurface.h"
+#include "DGtal/topology/helpers/BoundaryPredicate.h"
+#include "DGtal/topology/SetOfSurfels.h"
+#include "DGtal/topology/SCellsFunctors.h"
+
+#include "DGtal/shapes/Shapes.h"
+#include "DGtal/shapes/ShapeFactory.h"
+#include "DGtal/shapes/GaussDigitizer.h"
+///////////////////////////////////////////////////////////////////////////////
+
+using namespace std;
+using namespace DGtal;
+using namespace Z2i;
+
+double angle(const DGtal::Z2i::RealPoint& point)
+{
+    double angle = atan2(point[1], point[0]);
+    if(angle < 0.) angle += 2. * M_PI;
+    return angle;
+}
+
+double angle(const DGtal::Z2i::KSpace& kspace, const DGtal::Z2i::SCell& cell, const double h)
+{
+    DGtal::CanonicSCellEmbedder<DGtal::Z2i::KSpace> emb(kspace);
+    return angle(h * emb(cell));
+}
+
+struct AngleLessCell
+{
+    typedef DGtal::Z2i::KSpace KSpace;
+    typedef KSpace::SCell SCell;
+    typedef KSpace::Point Point;
+
+    AngleLessCell(const KSpace& kspace, const double h) : _kspace(kspace), _h(h)
+    {
+    }
+
+    inline bool operator()(const SCell& a, const SCell& b) const
+    {
+        return angle(_kspace, a, _h) < angle(_kspace, b, _h);
+    }
+
+    const KSpace& _kspace;
+    const double _h;
+};
+
+template <typename Shape>
+void digitize(Shape& shape, std::vector<SCell>& sCells0, std::vector<SCell>& sCells1, KSpace& kspace, const double h)
+{
+	typedef typename DGtal::GaussDigitizer<Space, Shape> Digitizer;
+    typedef SurfelAdjacency<2> SurfelAdj;
+    typedef Surfaces<KSpace> Surf;
+
+    sCells0.clear();
+    sCells1.clear();
+
+    Digitizer digitizer;
+    digitizer.attach(shape);
+    digitizer.init(shape.getLowerBound() + Vector(-1,-1), shape.getUpperBound() + Vector(1,1), h);
+    Domain domain;
+    domain = digitizer.getDomain();
+
+    kspace.init(digitizer.getLowerBound(), digitizer.getUpperBound(), true);
+
+    const SurfelAdj surfel_adjacency(true);
+    const KSpace::SCell cell_bel = Surf::findABel(kspace, digitizer);
+    Surf::track2DBoundary(sCells1, kspace, surfel_adjacency, digitizer, cell_bel);
+    {
+        typedef std::vector<Point> Points;
+        Points points;
+        Surf::track2DBoundaryPoints(points, kspace, surfel_adjacency, digitizer, cell_bel);
+        const KSpace::SCell point_ref = kspace.sCell(Point(0,0));
+        for(Points::const_iterator pi = points.begin(), pe = points.end(); pi != pe; ++pi) sCells0.push_back(kspace.sCell(*pi, point_ref));
+    }
+
+    std::sort(sCells0.begin(), sCells0.end(), AngleLessCell(kspace, h));
+    std::sort(sCells1.begin(), sCells1.end(), AngleLessCell(kspace, h));
+
+    ASSERT(sCells0.size() == sCells1.size());
+}
+
+template <typename Shape>
+bool test_shape(Shape& shape, const double h, const double epsilon)
+{
+
+	std::vector<SCell> sCells0, sCells1;
+
+	KSpace kspace;
+
+	digitize(shape, sCells0, sCells1, kspace, h);
+
+	CanonicSCellEmbedder<KSpace> canonicSCellEmbedder(kspace);
+
+	for(int i = 0; i < sCells0.size(); i++)
+	{
+		functors::SCellToInnerPoint<KSpace> sCellToInnerPoint(kspace);
+	    functors::SCellToOuterPoint<KSpace> sCellToOuterPoint(kspace);
+
+	    RealPoint inner = sCellToInnerPoint(sCells1[i]);
+	    RealPoint outer = sCellToOuterPoint(sCells1[i]);
+
+	    inner *= h;
+	    outer *= h;
+
+	    RealPoint q = shape.projection(inner, outer, epsilon);
+
+	    //trace.info() << (q - h * canonicSCellEmbedder(sCells0[i])).norm() << std::endl;
+
+	    const double norm2 = (q - h * canonicSCellEmbedder(sCells0[i])).norm();
+
+	    //if (norm2 > sqrt(2) * h) trace.info() << sqrt(2) * epsilon << " < " << norm2 << std::endl;
+	    if (norm2 > sqrt(2) * h) return 0;
+	}
+
+	return 1;
+}
+
+int main(int argc, char** argv)
+{
+    typedef Ball2D<Space> Ball;
+    const Ball ball(Point(0,0), 1.0);
+
+    typedef Flower2D<Space> Flower2D;
+    const Flower2D flower2D(Point(0,0), 1., 0.3, 5, 0.);
+
+    typedef AccFlower2D<Space> AccFlower2D;
+    const AccFlower2D accFlower2D(Point(0,0), 1., 0.3, 5, 0.);
+
+    typedef Ellipse2D<Space> Ellipse2D;
+    const Ellipse2D ellipse2D(Point(0,0), 1., 0.4, 0.2);
+
+    double h = 1.0;
+    
+   	while(h >= 0.001) {
+    	if(test_shape(ball, h, h * 0.1)) return 0;
+    	if(test_shape(flower2D, h, h * 0.1)) return 0;
+    	if(test_shape(accFlower2D, h, h * 0.1)) return 0;
+    	if(test_shape(ellipse2D, h, h * 0.1)) return 0;
+
+    	h /= 1.1;
+    }
+
+    return 1;
+}
+
+

--- a/tests/shapes/testProjection.cpp
+++ b/tests/shapes/testProjection.cpp
@@ -136,7 +136,7 @@ bool test_shape(Shape& shape, const double h, const double epsilon)
     inner *= h;
     outer *= h;
 
-    RealPoint q = shape.projection(inner, outer, epsilon);
+    RealPoint q = shape.segmentProjection(inner, outer, epsilon);
 
     //trace.info() << (q - h * canonicSCellEmbedder(sCells0[i])).norm() << std::endl;
 


### PR DESCRIPTION
# PR Description

Small correction inside documentation of Orientation function in [StarShape2D.h](https://github.com/DGtal-team/DGtal/blob/master/src/DGtal/shapes/parametric/StarShaped2D.h).

Added a projection function in [StarShape2D.h](https://github.com/DGtal-team/DGtal/blob/master/src/DGtal/shapes/parametric/StarShaped2D.h) which takes two R^2 points (one outside the shape, and one inside), an error parameter epsilon and return a point epsilon-close from the shape lying on the segment [inner;outer].

Typical use is for projecting a point on a discretize boundary onto the continuous one. This method ensures that the norm between these two points is less than h \* sqrt(2) (where h is the discretization step).

The two input points are easily computable using SCellToInnerPoint and SCellToOuterPoint in [SCellsFunctors.h](https://github.com/DGtal-team/DGtal/blob/master/src/DGtal/topology/SCellsFunctors.h) on the neighbouring 1-cells.

![starshape](https://cloud.githubusercontent.com/assets/6031237/15111137/7301f7f6-15e5-11e6-9f2b-6d1b4cac6829.png)
# Checklist
- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug `cmake` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
