### PR TITLE
allowing to read noff in importOFFFile

### DIFF
--- a/src/DGtal/io/readers/MeshReader.ih
+++ b/src/DGtal/io/readers/MeshReader.ih
@@ -72,14 +72,18 @@ DGtal::MeshReader<TPoint>::importOFFFile(const std::string & aFilename,
       trace.error() << "MeshReader : can't read " << aFilename << std::endl;
       throw dgtalio;
     }
-  if ( str.substr(0,3) != "OFF")
+  if ( str.substr(0,3) != "OFF" && str.substr(0,4) != "NOFF")
     {
       std::cerr <<"*" <<str<<"*"<< std::endl;
-      trace.error() << "MeshReader : No OFF format in " << aFilename << std::endl;
+      trace.error() << "MeshReader : No OFF or NOFF format in " << aFilename << std::endl;
       throw dgtalio;
     }
-  
-  // Processing comments
+  if ( str.substr(0,4) == "NOFF")
+    {
+      trace.warning() << "MeshReader : reading NOFF format from importOFFFile (normal vectors will be ignored)..." << std::endl; 
+    }
+
+    // Processing comments
   do
     {
       getline( infile, str );


### PR DESCRIPTION
# PR Description
Small PR just to read NOFF format from importOFFFile.

# Checklist

- [na] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [na] Doxygen documentation of the code completed (classes, methods, types, members...)
- [na] Documentation module page added or updated.
- [nn] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
