### PR TITLE
Minor fix in DSS export with Board2D

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -99,6 +99,8 @@
    [#1135](https://github.com/DGtal-team/DGtal/pull/1135))
  - Fix the extension removal in Obj filename export in Board3D. (David
    Coeurjolly,[#1154](https://github.com/DGtal-team/DGtal/pull/1154)))
+ - Fix issue when drawing DSS with both points and bounding box. (David
+   Coeurjolly,[#1186](https://github.com/DGtal-team/DGtal/pull/1186)))
 
 - *Topology Package*
   - Fix wrong starting point for surface tracking in example code

--- a/src/DGtal/io/Display2DFactory.ih
+++ b/src/DGtal/io/Display2DFactory.ih
@@ -345,8 +345,11 @@ void DGtal::Display2DFactory::draw( DGtal::Board2D & board,
     drawAsDigitalPoints( board, a );
   else if ( ( mode == "" ) )
     {
+      auto style = new DefaultDrawStyleBB_ArithmeticalDSS();
       drawAsDigitalPoints( board, a );
+      Style2DFactory::draw( board,  style);
       drawAsBoundingBox( board, a );
+      delete style;
     }
   else
     ASSERT(false && ("draw( DGtal::Board2D & board, const DGtal::ArithmeticalDSS<TCoordinate,TInteger,adjacency> & a ): Unknown mode "+mode)==""  );


### PR DESCRIPTION
# PR Description

Fixes an issue when you want the DSS to be exported both with points and boundingbox (style was not applied).


# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
