### PR TITLE
rendering mode saving and setter for double rendering

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -50,6 +50,9 @@
    (https://github.com/DGtal-team/DGtal/pull/1164))
 
 - *IO Package*
+ - Viewer3D: improvement of the viewer state record by saving the rendering 
+   mode. A new setter was also added to desable/enable double face rendering.
+   (Bertrand Kerautret [#1166](https://github.com/DGtal-team/DGtal/pull/1162))
  - Viewer3D: add a mode to display ball primitive with OpenGL point instead of
    quadrangulated mesh.
    (Bertrand Kerautret [#1162](https://github.com/DGtal-team/DGtal/pull/1162))

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -302,7 +302,7 @@ namespace DGtal
      * @param[in] displayState if true (default) the viewer will display the current rendering mode.
      * 
      **/
-    void updateRenderingCoefficients(const RenderingMode aRenderMode, bool diplayState=true);
+    void updateRenderingCoefficients(const RenderingMode aRenderMode, bool displayState=true);
     
     
     /// the 3 possible axes for the image direction

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -227,6 +227,20 @@ namespace DGtal
 
 
     /**
+     * Changes the light rendering mode (GL_LIGHT_MODEL_TWO_SIDE) for
+     * single face primitives (polygons, quads or triangles). It will have no
+     * effect for cube or ball primitive which will be always rendered with
+     * single face.
+     *
+     * @param[in] doubleSidedRendering if true (resp. false) the
+     * double (resp. single) rendering mode will be activated for
+     * polygons, quads and triangles.
+     * 
+     **/
+    void setGLDoubleRenderingMode(bool doubleSidedRendering);
+
+    
+    /**
      * Change the light shininess coefficients used in opengl
      * rendering (used in glMaterialf with GL_SPECULAR parameters). 
      *
@@ -285,9 +299,10 @@ namespace DGtal
      * Change the current rendering mode of the viewer.
      * 
      * @param[in] aRenderMode the mode of the rendering.
+     * @param[in] displayState if true (default) the viewer will display the current rendering mode.
      * 
      **/
-    void updateRenderingCoefficients(const RenderingMode aRenderMode);
+    void updateRenderingCoefficients(const RenderingMode aRenderMode, bool diplayState=true);
     
     
     /// the 3 possible axes for the image direction
@@ -1312,6 +1327,7 @@ namespace DGtal
      **/
     
     void glUpdateLightRenderingMode() const;
+
     
     /**
      * Updates the light source coordinates (myLightPosition) from the
@@ -1421,8 +1437,8 @@ namespace DGtal
     /// list of the images textures in this viewer
     std::vector<GLTextureImage> myVectTextureImage;
 
-    bool myIsDoubleFaceRendering; ///< true if is double face rendering
-
+    bool myIsDoubleFaceRendering = true; ///< true if is double face rendering
+    
     double camera_position[3]; ///< camera position
     double camera_direction[3]; ///< camera direction
     double camera_upVector[3]; ///< camera up-vector

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -1954,7 +1954,7 @@ DGtal::Viewer3D<Space, KSpace>::setUseGLPointForBalls(const bool useOpenGLPt)
 
 template< typename Space, typename KSpace>
 void 
-DGtal::Viewer3D<Space, KSpace>::updateRenderingCoefficients(const RenderingMode aRenderMode, bool diplayState)
+DGtal::Viewer3D<Space, KSpace>::updateRenderingCoefficients(const RenderingMode aRenderMode, bool displayState)
 {
   stringstream ss; 
   ss << "Rendering mode ";

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -1989,7 +1989,7 @@ DGtal::Viewer3D<Space, KSpace>::updateRenderingCoefficients(const RenderingMode 
   for (unsigned int i = 0; i<3; i++) 
     myLightSpecularCoeffs[i] = newCoefSpec;
   myLightSpecularCoeffs[3] = 1.0;
-  if (diplayState)
+  if (displayState)
     {
       displayMessage(QString(ss.str().c_str()), 3000);
     }

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -851,7 +851,7 @@ DGtal::Viewer3D<Space, KSpace>::init()
   myViewWire=false;
   setBackgroundColor ( QColor ( 217, 228, 255 ) );
   setForegroundColor ( QColor ( 217, 22, 25 ) );
-  myIsDoubleFaceRendering=true;
+  
   Viewer3D<Space, KSpace>::createNewCubeList ( );
   vector<typename Viewer3D<Space, KSpace>::LineD3D> listeLine;
   Viewer3D<Space, KSpace>::myLineSetList.push_back ( listeLine );
@@ -1837,6 +1837,8 @@ QDomElement
 DGtal::Viewer3D<Space, KSpace>::domElement(const QString& name, QDomDocument& document) const
 {
   // Creates a custom node for a light  position
+  QDomElement deRendering = document.createElement("Rendering");
+  deRendering.setAttribute("mode", myRenderingMode);
   QDomElement de = document.createElement("Light");
   de.setAttribute("pos_light_x", myLightPosition[0]);
   de.setAttribute("pos_light_y", myLightPosition[1]);
@@ -1844,6 +1846,7 @@ DGtal::Viewer3D<Space, KSpace>::domElement(const QString& name, QDomDocument& do
   // Get default state domElement and append custom node
   QDomElement res = QGLViewer::domElement(name, document);
   res.appendChild(de);
+  res.appendChild(deRendering);
   return res;
 }
 
@@ -1858,25 +1861,32 @@ DGtal::Viewer3D<Space, KSpace>::initFromDOMElement(const QDomElement& element)
   QDomElement child=element.firstChild().toElement();
   while (!child.isNull())
   {
+    if (child.tagName() == "Rendering")
+      {
+        myRenderingMode = (RenderingMode)(child.attribute("mode").toInt());
+      }
     if (child.tagName() == "Light")
     {
-      if (child.hasAttribute("pos_light_x")){
-        myLightPosition[0] = child.attribute("pos_light_x").toDouble();
-      }
+      if (child.hasAttribute("pos_light_x"))
+        {
+          myLightPosition[0] = child.attribute("pos_light_x").toDouble();
+        }
       
-      if (child.hasAttribute("pos_light_y")){
-        myLightPosition[1] = child.attribute("pos_light_y").toDouble();
-      }
-      if (child.hasAttribute("pos_light_z")){
-        myLightPosition[2] = child.attribute("pos_light_z").toDouble();
-      }
+      if (child.hasAttribute("pos_light_y"))
+        {
+          myLightPosition[1] = child.attribute("pos_light_y").toDouble();
+        }
+      if (child.hasAttribute("pos_light_z"))
+        {
+          myLightPosition[2] = child.attribute("pos_light_z").toDouble();
+        }
     }
     child = child.nextSibling().toElement();
   }
   if(myLightPositionFixToCamera){
     updateRelativeCameraFromLightPosition();
   }
-
+  updateRenderingCoefficients(myRenderingMode, false);
   updateGL();
 }
 
@@ -1889,6 +1899,14 @@ DGtal::Viewer3D<Space, KSpace>::closeEvent	(	QCloseEvent * 	e	){
     saveStateToFile();
   }
   QGLWidget::closeEvent(e);
+}
+
+template< typename Space, typename KSpace>
+void
+DGtal::Viewer3D<Space, KSpace>::setGLDoubleRenderingMode(bool doubleSidedRendering)
+{
+  myIsDoubleFaceRendering = doubleSidedRendering;
+  glUpdateLightRenderingMode();
 }
 
 
@@ -1936,7 +1954,7 @@ DGtal::Viewer3D<Space, KSpace>::setUseGLPointForBalls(const bool useOpenGLPt)
 
 template< typename Space, typename KSpace>
 void 
-DGtal::Viewer3D<Space, KSpace>::updateRenderingCoefficients(const RenderingMode aRenderMode)
+DGtal::Viewer3D<Space, KSpace>::updateRenderingCoefficients(const RenderingMode aRenderMode, bool diplayState)
 {
   stringstream ss; 
   ss << "Rendering mode ";
@@ -1971,8 +1989,11 @@ DGtal::Viewer3D<Space, KSpace>::updateRenderingCoefficients(const RenderingMode 
   for (unsigned int i = 0; i<3; i++) 
     myLightSpecularCoeffs[i] = newCoefSpec;
   myLightSpecularCoeffs[3] = 1.0;
-  displayMessage(QString(ss.str().c_str()), 3000);
- updateGL();
+  if (diplayState)
+    {
+      displayMessage(QString(ss.str().c_str()), 3000);
+    }
+  updateGL();
 }
 
 


### PR DESCRIPTION
# PR Description
Improvement of the viewer state record by saving the rendering mode. A new setter was also added to desable/enable double face rendering.

# Checklist
- [na] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [na] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
