### PR TITLE
Explicit M_PI definition

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 - *Configuration/General*
  - Fixing errors and warnings raised by g++ 4.7.x.
    (Roland Denis, [#1202](https://github.com/DGtal-team/DGtal/pull/1202))
+ - Explicit M_PI definition if needed.
+   (David Coeurjolly, [#1208](https://github.com/DGtal-team/DGtal/pull/1208))
 
 # DGtal 0.9.2
 

--- a/src/DGtal/base/Common.h
+++ b/src/DGtal/base/Common.h
@@ -66,6 +66,7 @@
 #ifdef M_PI
 #undef M_PI
 #endif
+
 //C++ exception specification ignored except
 //to indicate a function is not __declspec(nothrow)
 #pragma warning(disable : 4290)
@@ -80,6 +81,15 @@
 #else
 #include <cmath>
 #endif //win32
+
+// Explicit M_PI definition if needed
+// (issue https://github.com/DGtal-team/DGtal/issues/1204)
+#ifndef M_PI
+#define M_PI           3.14159265358979323846
+#endif
+#ifndef M_PI_2
+#define M_PI_2         1.57079632679489661923
+#endif
 
 
 #if defined( WIN32 )
@@ -99,9 +109,6 @@
 #include "DGtal/base/BasicFunctors.h"
 #include "DGtal/base/BasicArchetypes.h"
 #include "DGtal/base/Exceptions.h"
-
-
-//////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////
 namespace DGtal

--- a/src/DGtal/base/Common.h
+++ b/src/DGtal/base/Common.h
@@ -85,10 +85,10 @@
 // Explicit M_PI definition if needed
 // (issue https://github.com/DGtal-team/DGtal/issues/1204)
 #ifndef M_PI
-#define M_PI           3.14159265358979323846
+#define M_PI           (3.14159265358979323846)
 #endif
 #ifndef M_PI_2
-#define M_PI_2         1.57079632679489661923
+#define M_PI_2         (1.57079632679489661923)
 #endif
 
 


### PR DESCRIPTION
# PR Description

Explicit definition of M_PI is not defined in ```cmath``` or ```math.h```. (see https://github.com/DGtal-team/DGtal/issues/1204)

# Checklist

- [n.a.] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [n.a.] Doxygen documentation of the code completed (classes, methods, types, members...)
- [n.a.] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)