### PR TITLE
Installing tables now reads ENV{DESTDIR} variable.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,8 @@
  - The project has a now a unique compiled library: DGtal. The DGtalIO
    target has been removed. (David Coeurjolly,
    [#1226](https://github.com/DGtal-team/DGtal/pull/1226))
-
+ - Installation of tables is able to use DESTDIR env variable if provided by user.
+   (Pablo H Cerdan, [#1230](https://github.com/DGtal-team/DGtal/pull/1230))
 
 - *Geometry Package*
  - VoronoiMap, PowerMap, (Reverse)DistanceTransformation and ReducedMedialAxis

--- a/cmake/NeighborhoodTablesConfig.cmake
+++ b/cmake/NeighborhoodTablesConfig.cmake
@@ -27,7 +27,7 @@ install(CODE "
 set(TABLE_DIR ${INSTALL_INCLUDE_DIR}/DGtal/topology/tables)
 configure_file(
   ${PROJECT_SOURCE_DIR}/src/DGtal/topology/tables/NeighborhoodTables.h.in
-  ${INSTALL_INCLUDE_DIR}/DGtal/topology/tables/NeighborhoodTables.h) " )
+  $ENV{DESTDIR}/${INSTALL_INCLUDE_DIR}/DGtal/topology/tables/NeighborhoodTables.h) " )
 
 #--- specific install for uncompressed tables.
 set(unzip_folder_install ${INSTALL_INCLUDE_DIR}/DGtal/topology/tables)


### PR DESCRIPTION
# PR Description
`make DESTDIR=/home/joe install` didn't work for installing LU tables. This approach is used for linux packagers. Fix #1229

CMake uses DESTDIR at install time, but because the installation of the LU tables uses manual `CODE`, CMake does not prepend DESTDIR to `CMAKE_INSTALL_PREFIX` in this case. At least that is my interpretation from:  https://gitlab.kitware.com/cmake/cmake/issues/11704#note_212469

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
