### PR TITLE
Qt5 mac os

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: cpp
 sudo: false
 
 compiler:
-#  - gcc
+  - gcc
   - clang
 
 os:
-#  - linux
+  - linux
   - osx
 
 cache: apt

--- a/.travis/install_deps_macos.sh
+++ b/.travis/install_deps_macos.sh
@@ -8,4 +8,4 @@ brew install qt5 doxygen homebrew/science/hdf5 graphviz graphicsmagick fftw eige
 
 ## Temporary HDF5 build issue
 export BTYPE="$BTYPE -DWITH_HDF5=false" && echo "Disabling HDF5 on MacOS";
-export BTYPE="$BTYPE -DWITH_QT5=true -DQt5_DIR=$(brew --prefix qt5)" && echo "Forcing Qt5 on MacOS";
+export BTYPE="$BTYPE -DWITH_QT5=true -DCMAKE_PREFIX_PATH=$(brew --prefix qt5)" && echo "Forcing Qt5 on MacOS";

--- a/.travis/install_deps_macos.sh
+++ b/.travis/install_deps_macos.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
+#
+# Note: gmp and boost already installed
+#
+brew update
+brew install qt5 doxygen homebrew/science/hdf5 graphviz graphicsmagick fftw eigen homebrew/boneyard/libqglviewer
 
 ## Temporary HDF5 build issue
 export BTYPE="$BTYPE -DWITH_HDF5=false" && echo "Disabling HDF5 on MacOS";
 export BTYPE="$BTYPE -DWITH_QT5=true -DQt5_DIR=$(brew --prefix qt5)" && echo "Forcing Qt5 on MacOS";
-
-#
-# Note: gmp and boost already installed
-#
-
-brew update
-brew install qt5 doxygen homebrew/science/hdf5 graphviz graphicsmagick fftw eigen homebrew/boneyard/libqglviewer

--- a/.travis/install_deps_macos.sh
+++ b/.travis/install_deps_macos.sh
@@ -4,7 +4,7 @@
 # Note: gmp and boost already installed
 #
 brew update
-brew install qt5 doxygen homebrew/science/hdf5 graphviz graphicsmagick fftw eigen homebrew/boneyard/libqglviewer
+brew install qt5 doxygen  graphviz graphicsmagick fftw eigen homebrew/boneyard/libqglviewer
 
 ## Temporary HDF5 build issue
 export BTYPE="$BTYPE -DWITH_HDF5=false" && echo "Disabling HDF5 on MacOS";

--- a/.travis/install_deps_macos.sh
+++ b/.travis/install_deps_macos.sh
@@ -2,7 +2,8 @@
 
 
 ## Temporary HDF5 build issue
-export BTYPE="$BTYPE -DWITH_HDF5=false" && echo "Disabling HDF5 on MacOS"; 
+export BTYPE="$BTYPE -DWITH_HDF5=false" && echo "Disabling HDF5 on MacOS";
+export BTYPE="$BTYPE -DWITH_QT5=true" && echo "Forcing Qt5 on MacOS"; 
 
 #
 # Note: gmp and boost already installed
@@ -10,4 +11,3 @@ export BTYPE="$BTYPE -DWITH_HDF5=false" && echo "Disabling HDF5 on MacOS";
 
 brew update
 brew install doxygen homebrew/science/hdf5 graphviz graphicsmagick fftw eigen homebrew/boneyard/libqglviewer
-

--- a/cmake/CheckDGtalOptionalDependencies.cmake
+++ b/cmake/CheckDGtalOptionalDependencies.cmake
@@ -315,6 +315,12 @@ if (WITH_QGLVIEWER)
     endif (Qt5Widgets_FOUND AND Qt5OpenGL_FOUND AND Qt5Xml_FOUND)
 
   else (WITH_QT5)
+    if (APPLE)
+      message(STATUS "Warning: on recent MacOs Sierra, Qt4 is no longer supported.")
+      message(STATUS "         Please consider switching to Qt5 and define WITH_QT5.")
+      message(STATUS "         Otherwise you may have cmake errors while generating the project.")
+    endif (APPLE)
+
     find_package(Qt4 COMPONENTS QtCore QtGUI QtXml QtOpenGL REQUIRED)
 
     if (QT4_FOUND)


### PR DESCRIPTION
# PR Description

On recent MacOS, Qt4 is no longer supported. This PR update the travis script to force the Qt5 flag and display a warning is the flag is missing on Mac.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
-~~ [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.~~
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)