### PR TITLE
Fix missing template parameter for overloaded functions that use PointVector.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,9 @@
    (I. Sivignon, [#1187](https://github.com/DGtal-team/DGtal/pull/1187))
 
 - *IO Package*
+ - Missing TContainer template parameter for overloaded functions/methods that
+   rely on PointVector.
+   (Roland Denis, [#1232](https://github.com/DGtal-team/DGtal/pull/1232))
  - Viewer3D: fix bad rendering when changing the scale.
    (Bertrand Kerautret, [#1217](https://github.com/DGtal-team/DGtal/pull/1217))
 

--- a/src/DGtal/io/Display2DFactory.h
+++ b/src/DGtal/io/Display2DFactory.h
@@ -380,20 +380,20 @@ template < typename TKSpace, typename TCellContainer >
     
     
 // PointVector
-template<Dimension dim, typename TComponent>
-  static void drawAsPaving( DGtal::Board2D & board, const DGtal::PointVector<dim,TComponent> & );
+template<Dimension dim, typename TComponent, typename TContainer>
+  static void drawAsPaving( DGtal::Board2D & board, const DGtal::PointVector<dim, TComponent, TContainer> & );
 
-template<Dimension dim, typename TComponent>
-  static void drawAsGrid( DGtal::Board2D & board, const DGtal::PointVector<dim,TComponent> & );
+template<Dimension dim, typename TComponent, typename TContainer>
+  static void drawAsGrid( DGtal::Board2D & board, const DGtal::PointVector<dim, TComponent, TContainer> & );
 
-template<Dimension dim, typename TComponent>
-  static void draw( DGtal::Board2D & board, const DGtal::PointVector<dim,TComponent> & );
+template<Dimension dim, typename TComponent, typename TContainer>
+  static void draw( DGtal::Board2D & board, const DGtal::PointVector<dim, TComponent, TContainer> & );
 
 //arrow drawing
-template<Dimension dim, typename TComponent>
+template<Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, typename TContainer2>
   static void draw( DGtal::Board2D & board, 
-	     const DGtal::PointVector<dim,TComponent> & shift,
-	     const DGtal::PointVector<dim,TComponent> & basepoint);
+	     const DGtal::PointVector<dim, TComponent1, TContainer1> & shift,
+	     const DGtal::PointVector<dim, TComponent2, TContainer2> & basepoint);
 // PointVector
     
     

--- a/src/DGtal/io/Display2DFactory.ih
+++ b/src/DGtal/io/Display2DFactory.ih
@@ -1539,7 +1539,7 @@ void DGtal::Display2DFactory::draw( DGtal::Board2D & board,
 {
   std::string mode = board.getMode( p.className() );
   FATAL_ERROR( (mode=="Paving" || mode=="Grid" || mode=="Both" || mode=="") ||
-    ("draw( DGtal::Board2D & board, const DGtal::PointVector<dim,TComponent> & p ): Unknown mode "+mode)==""  );
+    ("draw( DGtal::Board2D & board, const DGtal::PointVector<dim, TComponent, TContainer> & p ): Unknown mode "+mode)==""  );
 
   if ( mode == "Paving"  || ( mode == "" )  )
     drawAsPaving( board, p );

--- a/src/DGtal/io/Display2DFactory.ih
+++ b/src/DGtal/io/Display2DFactory.ih
@@ -1512,30 +1512,30 @@ DGtal::Display2DFactory::draw( DGtal::Board2D & board,
 
 
 // PointVector
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void DGtal::Display2DFactory::drawAsPaving( DGtal::Board2D & board,
-           const DGtal::PointVector<dim,TComponent> & p )
+           const DGtal::PointVector<dim, TComponent, TContainer> & p )
 {
   FATAL_ERROR(dim == 2);
   board.drawRectangle( (float) NumberTraits<TComponent>::castToDouble(p[0]) - 0.5f,
                        (float) NumberTraits<TComponent>::castToDouble(p[1]) + 0.5f, 1, 1 );
 }
 
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void DGtal::Display2DFactory::drawAsGrid( DGtal::Board2D & board,
-           const DGtal::PointVector<dim,TComponent> & p )
+           const DGtal::PointVector<dim, TComponent, TContainer> & p )
 {
   FATAL_ERROR(dim == 2);
   board.fillCircle((float) NumberTraits<TComponent>::castToDouble(p[0]),
                    (float) NumberTraits<TComponent>::castToDouble(p[1]),0.1);
 }
 
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void DGtal::Display2DFactory::draw( DGtal::Board2D & board,
-           const DGtal::PointVector<dim,TComponent> & p )
+           const DGtal::PointVector<dim,TComponent, TContainer> & p )
 {
   std::string mode = board.getMode( p.className() );
   FATAL_ERROR( (mode=="Paving" || mode=="Grid" || mode=="Both" || mode=="") ||
@@ -1552,11 +1552,11 @@ void DGtal::Display2DFactory::draw( DGtal::Board2D & board,
     }
 }
 
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, typename TContainer2>
 inline
 void DGtal::Display2DFactory::draw( DGtal::Board2D & board,
-          const DGtal::PointVector<dim,TComponent> & shift,
-          const DGtal::PointVector<dim,TComponent> & basepoint )
+          const DGtal::PointVector<dim, TComponent1, TContainer1> & shift,
+          const DGtal::PointVector<dim, TComponent2, TContainer2> & basepoint )
 {
   FATAL_ERROR(dim == 2);
 

--- a/src/DGtal/io/Display3DFactory.h
+++ b/src/DGtal/io/Display3DFactory.h
@@ -523,48 +523,48 @@ namespace DGtal
      * @param anObject the object to draw
      * @return the dyn. alloc. default style for this object.
      */
-    template<Dimension dim, typename TComponent>
-    static DGtal::DrawableWithDisplay3D * defaultStyle( std::string str, const DGtal::PointVector<dim,TComponent> & anObject );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static DGtal::DrawableWithDisplay3D * defaultStyle( std::string str, const DGtal::PointVector<dim, TComponent, TContainer> & anObject );
 
     /**
      * @brief drawAsGrid
      * @param display the display where to draw
      * @param anObject the object to draw
      */
-    template<Dimension dim, typename TComponent>
-    static void drawAsGrid( Display & display, const DGtal::PointVector<dim,TComponent> & anObject );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static void drawAsGrid( Display & display, const DGtal::PointVector<dim, TComponent, TContainer> & anObject );
 
     /**
      * @brief drawAsPaving
      * @param display the display where to draw
      * @param anObject the object to draw
      */
-    template<Dimension dim, typename TComponent>
-    static void drawAsPaving( Display & display, const DGtal::PointVector<dim,TComponent> & anObject );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static void drawAsPaving( Display & display, const DGtal::PointVector<dim, TComponent, TContainer> & anObject );
 
     /**
      * @brief drawAsPavingWired
      * @param display the display where to draw
      * @param anObject the object to draw
      */
-    template<Dimension dim, typename TComponent>
-    static void drawAsPavingWired( Display & display, const DGtal::PointVector<dim,TComponent> & anObject );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static void drawAsPavingWired( Display & display, const DGtal::PointVector<dim, TComponent, TContainer> & anObject );
 
     /**
      * @brief draw
      * @param display the display where to draw
      * @param anObject the object to draw
      */
-    template<Dimension dim, typename TComponent>
-    static void draw( Display & display, const DGtal::PointVector<dim,TComponent> & anObject );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static void draw( Display & display, const DGtal::PointVector<dim, TComponent, TContainer> & anObject );
 
     /**
      * @brief draw
      * @param display the display where to draw
      * @param anObject the object to draw
      */
-    template<Dimension dim, typename TComponent>
-    static void draw( Display & display, const DGtal::PointVector<dim,TComponent> & , const DGtal::PointVector<dim,TComponent> & anObject );
+    template<Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, typename TContainer2>
+    static void draw( Display & display, const DGtal::PointVector<dim, TComponent1, TContainer1> & , const DGtal::PointVector<dim, TComponent2, TContainer2> & anObject );
     // PointVector
 
     // GridCurve

--- a/src/DGtal/io/Display3DFactory.ih
+++ b/src/DGtal/io/Display3DFactory.ih
@@ -1516,10 +1516,10 @@ void DGtal::Display3DFactory<Space,KSpace>::draw( Display & display,
 
 // PointVector
 template <typename Space, typename KSpace>
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void DGtal::Display3DFactory<Space,KSpace>::drawAsGrid( Display & display,
-							const DGtal::PointVector<dim,TComponent> & p )
+							const DGtal::PointVector<dim, TComponent, TContainer> & p )
 {
   DGtal::Color fillColorSave = display.getFillColor();
   ASSERT(dim == 3);
@@ -1530,10 +1530,10 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsGrid( Display & display,
 }
 
 template <typename Space, typename KSpace>
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void DGtal::Display3DFactory<Space,KSpace>::drawAsPaving( Display & display,
-							  const DGtal::PointVector<dim,TComponent> & p )
+							  const DGtal::PointVector<dim, TComponent, TContainer> & p )
 {
   ASSERT(dim == 3);
 
@@ -1542,10 +1542,10 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsPaving( Display & display,
 }
 
 template <typename Space, typename KSpace>
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void DGtal::Display3DFactory<Space,KSpace>::drawAsPavingWired( Display & display,
-							       const DGtal::PointVector<dim,TComponent> & p )
+							       const DGtal::PointVector<dim, TComponent, TContainer> & p )
 {
   DGtal::Color lineColorSave = display.getLineColor();
   ASSERT(dim == 3);
@@ -1583,10 +1583,10 @@ void DGtal::Display3DFactory<Space,KSpace>::drawAsPavingWired( Display & display
 }
 
 template <typename Space, typename KSpace>
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void DGtal::Display3DFactory<Space,KSpace>::draw( Display & display,
-						  const DGtal::PointVector<dim,TComponent> & p )
+						  const DGtal::PointVector<dim, TComponent, TContainer> & p )
 {
   DGtal::Color fillColorSave = display.getFillColor();
   ASSERT(dim == 3);
@@ -1611,11 +1611,11 @@ void DGtal::Display3DFactory<Space,KSpace>::draw( Display & display,
 }
 
 template <typename Space, typename KSpace>
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, typename TContainer2>
 inline
 void DGtal::Display3DFactory<Space,KSpace>::draw( Display & display,
-						  const DGtal::PointVector<dim,TComponent> & p,
-						  const DGtal::PointVector<dim,TComponent> & aPoint )
+						  const DGtal::PointVector<dim, TComponent1, TContainer1> & p,
+						  const DGtal::PointVector<dim, TComponent2, TContainer2> & aPoint )
 {
   ASSERT(dim == 3);
 

--- a/src/DGtal/io/Style2DFactory.ih
+++ b/src/DGtal/io/Style2DFactory.ih
@@ -952,9 +952,9 @@ DGtal::DrawableWithBoard2D* defaultStyle(const DGtal::CubicalComplex<TKSpace, TC
 
 
 // PointVector
-template<DGtal::Dimension dim, typename TComponent>
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
-DGtal::DrawableWithBoard2D* defaultStyle(const DGtal::PointVector<dim,TComponent> & /*p*/, std::string mode = "")
+DGtal::DrawableWithBoard2D* defaultStyle(const DGtal::PointVector<dim, TComponent, TContainer> & /*p*/, std::string mode = "")
 {
   if ( ( mode == "" ) || ( mode == "Paving" ) )
     return new DGtal::DefaultDrawStylePaving_PointVector;

--- a/src/DGtal/io/boards/Board3DTo2DFactory.h
+++ b/src/DGtal/io/boards/Board3DTo2DFactory.h
@@ -500,45 +500,45 @@ namespace DGtal
    * @param aPoint the point to draw
    * @return the dyn. alloc. default style for this object.
    */
-  template<Dimension dim, typename TComponent>
+  template<Dimension dim, typename TComponent, typename TContainer>
   static DGtal::DrawableWithBoard3DTo2D *
-  defaultStyle( std::string str, const DGtal::PointVector<dim,TComponent> & aPoint );
+  defaultStyle( std::string str, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
   /**
    * @brief drawAsGrid
    * @param board the board where to draw
    * @param aPoint the point to draw
    */
-  template<Dimension dim, typename TComponent>
+  template<Dimension dim, typename TComponent, typename TContainer>
   static void
-  drawAsGrid( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint );
+  drawAsGrid( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
   /**
    * @brief drawAsPaving
    * @param board the board where to draw
    * @param aPoint the point to draw
    */
-  template<Dimension dim, typename TComponent>
+  template<Dimension dim, typename TComponent, typename TContainer>
   static void
-  drawAsPaving( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint );
+  drawAsPaving( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
   /**
    * @brief drawAsPavingWired
    * @param board the board where to draw
    * @param aPoint the point to draw
    */
-  template<Dimension dim, typename TComponent>
+  template<Dimension dim, typename TComponent, typename TContainer>
   static void
-  drawAsPavingWired( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint );
+  drawAsPavingWired( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
   /**
    * @brief draw
    * @param board the board where to draw
    * @param aPoint the point to draw
    */
-  template<Dimension dim, typename TComponent>
+  template<Dimension dim, typename TComponent, typename TContainer>
   static void
-  draw( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint );
+  draw( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
   /**
    * @brief draw
@@ -546,9 +546,9 @@ namespace DGtal
    * @param aPoint the point to draw
    * @param aPoint2 the point to draw
    */
-  template<Dimension dim, typename TComponent>
+  template<Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, typename TContainer2>
   static void
-  draw( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint, const DGtal::PointVector<dim,TComponent> & aPoint2 );
+  draw( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent1, TContainer1> & aPoint, const DGtal::PointVector<dim, TComponent2, TContainer2> & aPoint2 );
   // PointVector
 
 

--- a/src/DGtal/io/boards/Board3DTo2DFactory.ih
+++ b/src/DGtal/io/boards/Board3DTo2DFactory.ih
@@ -487,55 +487,55 @@ DGtal::Board3DTo2DFactory<Space,KSpace>::draw( Board3DTo2D<Space, KSpace> & boar
    * @return the dyn. alloc. default style for this object.
    */
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 DGtal::DrawableWithBoard3DTo2D *
-DGtal::Board3DTo2DFactory<Space,KSpace>::defaultStyle( std::string str, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Board3DTo2DFactory<Space,KSpace>::defaultStyle( std::string str, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   return DGtal::Display3DFactory<Space,KSpace>::defaultStyle( str, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void
-DGtal::Board3DTo2DFactory<Space,KSpace>::drawAsGrid( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Board3DTo2DFactory<Space,KSpace>::drawAsGrid( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   DGtal::Display3DFactory<Space,KSpace>::drawAsGrid( board, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void
-DGtal::Board3DTo2DFactory<Space,KSpace>::drawAsPaving( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Board3DTo2DFactory<Space,KSpace>::drawAsPaving( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   DGtal::Display3DFactory<Space,KSpace>::drawAsPaving( board, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void
-DGtal::Board3DTo2DFactory<Space,KSpace>::drawAsPavingWired( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Board3DTo2DFactory<Space,KSpace>::drawAsPavingWired( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   DGtal::Display3DFactory<Space,KSpace>::drawAsPavingWired( board, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void
-DGtal::Board3DTo2DFactory<Space,KSpace>::draw( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Board3DTo2DFactory<Space,KSpace>::draw( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   DGtal::Display3DFactory<Space,KSpace>::draw( board, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, typename TContainer2>
 inline
 void
-DGtal::Board3DTo2DFactory<Space,KSpace>::draw( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim,TComponent> & aPoint, const DGtal::PointVector<dim,TComponent> & aPoint2 )
+DGtal::Board3DTo2DFactory<Space,KSpace>::draw( Board3DTo2D<Space, KSpace> & board, const DGtal::PointVector<dim, TComponent1, TContainer1> & aPoint, const DGtal::PointVector<dim, TComponent2, TContainer2> & aPoint2 )
 {
   DGtal::Display3DFactory<Space,KSpace>::draw( board, aPoint, aPoint2);
 }

--- a/src/DGtal/io/doc/moduleBoard2D.dox
+++ b/src/DGtal/io/doc/moduleBoard2D.dox
@@ -430,9 +430,9 @@ Here, the DrawableWithBoard2D is just an interface that specifies a virtual meth
 
   The dynamically allocated instance of the default style for the drawable element may eventually be tuned for a specific mode given as a string.
  \code
-  template<Dimension dim, typename TComponent>
+  template<Dimension dim, typename TComponent, typename TContainer>
   inline
-  DGtal::DrawableWithBoard2D* defaultStyle(const DGtal::PointVector<dim,TComponent> & p, std::string mode = "")
+  DGtal::DrawableWithBoard2D* defaultStyle(const DGtal::PointVector<dim, TComponent, TContainer> & p, std::string mode = "")
   {
   if ( ( mode == "" ) || ( mode == "Paving" ) ) 
  return new DefaultDrawStylePaving_PointVector;
@@ -446,11 +446,11 @@ Here, the DrawableWithBoard2D is just an interface that specifies a virtual meth
 
   This method draws the drawable element on the given Board2D instance. The style has been applied automatically before.
  \code
-  template<Dimension dim, typename TComponent>
+  template<Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, typename TContainer2>
   inline
   void draw( DGtal::Board2D & board, 
-const DGtal::PointVector<dim,TComponent> & p, 
-const DGtal::PointVector<dim,TComponent> & apoint )
+const DGtal::PointVector<dim, TComponent1, TContainer1> & p, 
+const DGtal::PointVector<dim, TComponent2, TContainer2> & apoint )
   {
   ASSERT(dim == 2);
 

--- a/src/DGtal/io/viewers/Viewer3D.h
+++ b/src/DGtal/io/viewers/Viewer3D.h
@@ -787,8 +787,8 @@ namespace DGtal
      * @param angleRotation the angle of rotation.
      * @param dirRotation the rotation will be applied around this direction.
      **/
-
-    void  rotateLineD3D(typename DGtal::Display3D<Space, KSpace>::LineD3D &aLine, DGtal::PointVector<3, int> pt,
+    template < typename TContainer >
+    void  rotateLineD3D(typename DGtal::Display3D<Space, KSpace>::LineD3D &aLine, DGtal::PointVector<3, int, TContainer> pt,
       double angleRotation, ImageDirection dirRotation);
 
 

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -110,10 +110,11 @@ DGtal::Viewer3D<Space, KSpace>::rotatePoint(TValues &x, TValues &y, TValues &z,
 
 
 template < typename Space ,typename KSpace >
+template < typename TContainer >
 inline
 void
 DGtal::Viewer3D<Space, KSpace>::rotateLineD3D(typename DGtal::Display3D<Space, KSpace>::LineD3D &aLine,
-                                              DGtal::PointVector<3, int> pt,
+                                              DGtal::PointVector<3, int, TContainer> pt,
                                               double angleRotation, ImageDirection dirRotation){
   double dx1 = aLine.point1[0] - pt[0]; double dy1 = aLine.point1[1] - pt[1]; double dz1 = aLine.point1[2] - pt[2];
   double dx2 = aLine.point2[0] - pt[0]; double dy2 = aLine.point2[1] - pt[1]; double dz2 = aLine.point2[2] - pt[2];

--- a/src/DGtal/io/viewers/Viewer3DFactory.h
+++ b/src/DGtal/io/viewers/Viewer3DFactory.h
@@ -464,40 +464,40 @@ namespace DGtal
      * @param aPoint the point to draw
      * @return the dyn. alloc. default style for this object.
      */
-    template<Dimension dim, typename TComponent>
-    static DGtal::DrawableWithViewer3D * defaultStyle( std::string str, const DGtal::PointVector<dim,TComponent> & aPoint );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static DGtal::DrawableWithViewer3D * defaultStyle( std::string str, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
     /**
      * Method to draw PointVector as Grid.
      * @param viewer the viewer where to draw
      * @param aPoint the point to draw
      */
-    template<Dimension dim, typename TComponent>
-    static void drawAsGrid( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static void drawAsGrid( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
-    template<Dimension dim, typename TComponent>
     /**
      * Method to draw PointVector as Paving.
      * @param viewer the viewer where to draw
      * @param aPoint the point to draw
      */
-    static void drawAsPaving( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static void drawAsPaving( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
     /**
      * Method to draw PointVector as Paving Wired.
      * @param viewer the viewer where to draw
      * @param aPoint the point to draw
      */
-    template<Dimension dim, typename TComponent>
-    static void drawAsPavingWired( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static void drawAsPavingWired( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
     /**
      * Method to draw PointVector.
      * @param viewer the viewer where to draw
      * @param aPoint the point to draw
      */
-    template<Dimension dim, typename TComponent>
-    static void draw( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint );
+    template<Dimension dim, typename TComponent, typename TContainer>
+    static void draw( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint );
 
     /**
      * Method to draw PointVector.
@@ -505,8 +505,8 @@ namespace DGtal
      * @param aPoint the point to draw
      * @param aPoint2 the point to draw
      */
-    template<Dimension dim, typename TComponent>
-    static void draw( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint, const DGtal::PointVector<dim,TComponent> & aPoint2 );
+    template<Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, TContainer2>
+    static void draw( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim, TComponent1, TContainer1> & aPoint, const DGtal::PointVector<dim, TComponent2, TContainer2> & aPoint2 );
     // PointVector
 
 

--- a/src/DGtal/io/viewers/Viewer3DFactory.h
+++ b/src/DGtal/io/viewers/Viewer3DFactory.h
@@ -505,7 +505,7 @@ namespace DGtal
      * @param aPoint the point to draw
      * @param aPoint2 the point to draw
      */
-    template<Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, TContainer2>
+    template<Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, typename TContainer2>
     static void draw( Viewer3D<Space,KSpace> & viewer, const DGtal::PointVector<dim, TComponent1, TContainer1> & aPoint, const DGtal::PointVector<dim, TComponent2, TContainer2> & aPoint2 );
     // PointVector
 

--- a/src/DGtal/io/viewers/Viewer3DFactory.ih
+++ b/src/DGtal/io/viewers/Viewer3DFactory.ih
@@ -743,55 +743,55 @@ DGtal::Viewer3DFactory<Space,KSpace>::draw( Viewer3D<Space, KSpace> & viewer, co
 
 // PointVector
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 DGtal::DrawableWithViewer3D *
-DGtal::Viewer3DFactory<Space,KSpace>::defaultStyle( std::string str, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Viewer3DFactory<Space,KSpace>::defaultStyle( std::string str, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   return DGtal::Display3DFactory<Space,KSpace>::defaultStyle( str, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void
-DGtal::Viewer3DFactory<Space,KSpace>::drawAsGrid( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Viewer3DFactory<Space,KSpace>::drawAsGrid( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   DGtal::Display3DFactory<Space,KSpace>::drawAsGrid( viewer, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void
-DGtal::Viewer3DFactory<Space,KSpace>::drawAsPaving( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Viewer3DFactory<Space,KSpace>::drawAsPaving( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   DGtal::Display3DFactory<Space,KSpace>::drawAsPaving( viewer, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void
-DGtal::Viewer3DFactory<Space,KSpace>::drawAsPavingWired( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Viewer3DFactory<Space,KSpace>::drawAsPavingWired( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   DGtal::Display3DFactory<Space,KSpace>::drawAsPavingWired( viewer, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
 void
-DGtal::Viewer3DFactory<Space,KSpace>::draw( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint )
+DGtal::Viewer3DFactory<Space,KSpace>::draw( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim, TComponent, TContainer> & aPoint )
 {
   DGtal::Display3DFactory<Space,KSpace>::draw( viewer, aPoint);
 }
 
 template <typename Space, typename KSpace>
-template< DGtal::Dimension dim, typename TComponent>
+template< DGtal::Dimension dim, typename TComponent1, typename TComponent2, typename TContainer1, typename TContainer2>
 inline
 void
-DGtal::Viewer3DFactory<Space,KSpace>::draw( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim,TComponent> & aPoint, const DGtal::PointVector<dim,TComponent> & aPoint2 )
+DGtal::Viewer3DFactory<Space,KSpace>::draw( Viewer3D<Space, KSpace> & viewer, const DGtal::PointVector<dim, TComponent1, TContainer1> & aPoint, const DGtal::PointVector<dim, TComponent2, TContainer2> & aPoint2 )
 {
   DGtal::Display3DFactory<Space,KSpace>::draw( viewer, aPoint, aPoint2);
 }


### PR DESCRIPTION
:tada: :beers: **Happy New Year to all the DGtal team !** :beers: :tada:

# PR Description

The hint comes from a compilation test of DGtal using Intel Compiler 17. It raises errors in display-related classes (`Display[23]DFactory`, `Viewer3DFactory`, ...) about overloaded functions/methods not found.

A minimal example is:
```C++
template < unsigned int N >
struct Container {};

template < int N, typename TContainer = Container<N> >
struct Dummy {};

template < int N >
void f( Dummy<N> const & )
{
}

int main()
{
    Dummy<2> toto;
    f(toto);
    return 0;
}
```
that fails to compile with error:
```
test.cpp(15): error: no instance of function template "f" matches the argument list
            argument types are: (Dummy<2, Container<2U>>)
      f(toto);
      ^
test.cpp(8): note: this candidate was rejected because at least one template argument could not be deduced
  void f( Dummy<N> const & )
```

The problem comes from the different integer type in template parameters (`int` versus `unsigned int`) that leads `icpc` to ignore the default `TContainer` type when searching for overloaded functions/methods.

In DGtal, it corresponds to the `Dimension` typedef that is a signed integer versus the unsigned `std::size_t` that is used to specify the size of a `std::array` (the default container for `PointVector`).

It is probably a bug since `g++` and `clang++` doesn't matter about this issue, **but anyway**, the `TContainer` template parameter is actually missing from those overloaded functions/methods in order to accept `PointVector` with non-standard value container, thus leading to this PR submission.

Intel Compiler 17 now compiles without error, but still some warnings about deprecated use of `std::binder2nd` (see #1221) and another warning about an invalid usage of `auto` (probably another bug). Version 16 still fails to compile DGtal (default options) but on a clearly valid `C++11` syntax.

# Checklist

- ~~[ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).~~
- ~~[ ] Doxygen documentation of the code completed (classes, methods, types, members...)~~
- ~~[ ] Documentation module page added or updated.~~
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
