### PR TITLE
Fix configure_file installing tables

### DIFF
--- a/cmake/NeighborhoodTablesConfig.cmake
+++ b/cmake/NeighborhoodTablesConfig.cmake
@@ -13,12 +13,12 @@ configure_file(
 
 # ------ Install Tree ------ #
 #--- Configuration of the src/topology/tables/NeighborhoodTables.h.in for the install tree. Save to tmp file.
-# dev note: The variables are expanded before they are passed to install(CODE). We have to scape TABLE_DIR inside configure_file if we want it to be updated with the value set inside the install script.
+# dev note: scaping \${TABLE_DIR} in configure_file not really working.
 install(CODE "
 set(TABLE_DIR $ENV{DESTDIR}${INSTALL_INCLUDE_DIR}/DGtal/topology/tables)
 configure_file(
   ${PROJECT_SOURCE_DIR}/src/DGtal/topology/tables/NeighborhoodTables.h.in
-  \${TABLE_DIR}/NeighborhoodTables.h @ONLY)")
+  $ENV{DESTDIR}${INSTALL_INCLUDE_DIR}/DGtal/topology/tables/NeighborhoodTables.h @ONLY)")
 
 #--- Install compressed tables and the header pointing to them ---#
 set(table_folder_install ${INSTALL_INCLUDE_DIR}/DGtal/topology/tables)


### PR DESCRIPTION
Escaping \${TABLE_DIR} in configure_file not getting the right value when using DESTDIR:
`make -j4 DESTDIR=~/dgtal_install install`
Revert to hard type the content of TABLE_DIR inside configure_file.

Follow on #1233 #1228 

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
