### PR TITLE
Fix DESTDIR behavior at install time.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,8 @@
    (David Coeurjolly, [#1208](https://github.com/DGtal-team/DGtal/pull/1208))
  - Continuous integration Travis bots are now based on ubunutu/trusty containers.
    (David Coeurjolly, [#1227](https://github.com/DGtal-team/DGtal/pull/1208))
+ - Fix usage of DESTDIR at install time for linux packagers.
+   (Pablo Hernandez, [#1235](https://github.com/DGtal-team/DGtal/pull/1235))
 
 - *Geometry Package*
  - ArithDSSIterator: fix missing postfix ++.

--- a/cmake/NeighborhoodTablesConfig.cmake
+++ b/cmake/NeighborhoodTablesConfig.cmake
@@ -13,9 +13,11 @@ configure_file(
 
 # ------ Install Tree ------ #
 #--- Configuration of the src/topology/tables/NeighborhoodTables.h.in for the install tree. Save to tmp file.
-# dev note: The variables are expanded before they are passed to install(CODE). We have to scape TABLE_DIR inside configure_file if we want it to be updated with the value set inside the install script.
+# dev note: we escape \$ENV{DESTDIR} because we want DESTDIR to be read at
+#  install time, not at configure time. The same with TABLE_DIR inside configure_file.
+#  Read more: https://cmake.org/pipermail/cmake-developers/2013-January/017810.html
 install(CODE "
-set(TABLE_DIR $ENV{DESTDIR}${INSTALL_INCLUDE_DIR}/DGtal/topology/tables)
+set(TABLE_DIR \$ENV{DESTDIR}${INSTALL_INCLUDE_DIR}/DGtal/topology/tables)
 configure_file(
   ${PROJECT_SOURCE_DIR}/src/DGtal/topology/tables/NeighborhoodTables.h.in
   \${TABLE_DIR}/NeighborhoodTables.h @ONLY)")


### PR DESCRIPTION
We have to read DESTDIR at install time, not at configure time.
so we escape the `$` symbol.
`\$ENV{DESTDIR}`

The same with TABLE_DIR inside configure_file.

Read more: https://cmake.org/pipermail/cmake-developers/2013-January/017810.html

Fix #1229 
# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
