### PR TITLE
[FIX] Let CMake handle DESTDIR instead.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,8 @@
    (David Coeurjolly, [#1227](https://github.com/DGtal-team/DGtal/pull/1208))
  - Fix usage of DESTDIR at install time for linux packagers.
    (Pablo Hernandez, [#1235](https://github.com/DGtal-team/DGtal/pull/1235))
+ - Fix, let CMake handle DESTDIR instead of manual manipulation.
+   (Pablo Hernandez, [#1238](https://github.com/DGtal-team/DGtal/pull/1238))
 
 - *Geometry Package*
  - ArithDSSIterator: fix missing postfix ++.

--- a/cmake/NeighborhoodTablesConfig.cmake
+++ b/cmake/NeighborhoodTablesConfig.cmake
@@ -13,17 +13,17 @@ configure_file(
 
 # ------ Install Tree ------ #
 #--- Configuration of the src/topology/tables/NeighborhoodTables.h.in for the install tree. Save to tmp file.
-# dev note: we escape \$ENV{DESTDIR} because we want DESTDIR to be read at
-#  install time, not at configure time. The same with TABLE_DIR inside configure_file.
-#  Read more: https://cmake.org/pipermail/cmake-developers/2013-January/017810.html
-install(CODE "
-set(TABLE_DIR \$ENV{DESTDIR}${INSTALL_INCLUDE_DIR}/DGtal/topology/tables)
+set(TABLE_DIR ${INSTALL_INCLUDE_DIR}/DGtal/topology/tables)
 configure_file(
   ${PROJECT_SOURCE_DIR}/src/DGtal/topology/tables/NeighborhoodTables.h.in
-  \${TABLE_DIR}/NeighborhoodTables.h @ONLY)")
+  ${PROJECT_BINARY_DIR}/InstallFiles/NeighborhoodTables.h @ONLY)
 
 #--- Install compressed tables and the header pointing to them ---#
 set(table_folder_install ${INSTALL_INCLUDE_DIR}/DGtal/topology/tables)
+
+#--- Install header pointing to tables. ---#
+install(FILES ${PROJECT_BINARY_DIR}/InstallFiles/NeighborhoodTables.h
+        DESTINATION "${table_folder_install}")
 #--- Select all the tables and install ---#
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/src/DGtal/topology/tables/"
         DESTINATION "${table_folder_install}"


### PR DESCRIPTION
Install a temporary file in InstallFiles at build time, and then use regular
install(FILES), which takes into account any DESTDIR logic.

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
