### PR TITLE
Added the configuration file .clang-format to use with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,109 @@
+# .clang-format
+#
+# Alignment
+# ---------
+#
+# Align:
+# - fonction parameters on the open bracket,
+# - trailing comments.
+# Don't align:
+# - consecutive assignments or declarations,
+# - operands of binary and ternary expressions.
+#
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands: false
+AlignTrailingComments: true
+#
+# Short statements
+# ----------------
+#
+# Forbid short
+# - blocks
+# - case labels
+# - functions
+# - if statements
+# - loops
+# on a single line.
+#
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+#
+# Line breaks
+# -----------
+#
+# Insert line breaks:
+# - before braces (Allman style),
+# - after the function definition return type,
+# - after template declarations,
+# - before multiline string literals,
+# - before ternary operators,
+# - constructor initializers before commas and align the commas with the colon.
+#
+# Limit the length of a line to 80 characters.
+#
+# If the constructor initializers don't fit on a line, put each initializer on
+# its own line.
+#
+# Keep empty lines at the start of blocks.
+#
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit: 80
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+#
+# Indentation
+# -----------
+#
+# Use 2 spaces for indentations. Don't further indent continued lines.  Outdent
+# access modifiers (e.g. public:). Indent in all namespaces.
+#
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 0
+IndentWidth: 2
+NamespaceIndentation: All
+#
+# Alignments
+# ----------
+#
+# Align pointer and reference symbol in the middle.
+#
+PointerAlignment: Middle
+#
+# Tabs and spaces
+# ------
+#
+# Put a space after opening of before closing a square bracket or a parenthesis
+# except for empty parentheses and type casts.
+# Put a space before opening parentheses only after control statement keywords
+# (for/if/while...).
+# Put a space before trailing comments (after `//`).
+#
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpacesBeforeTrailingComments: 1
+SpacesInParentheses: true
+SpacesInSquareBrackets: true
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceBeforeParens: ControlStatements
+SpacesInAngles: false
+TabWidth: 4
+UseTab: Never
+#
+# Other
+# -----
+#
+# Don't reorder includes
+#
+SortIncludes: false

--- a/.clang-format
+++ b/.clang-format
@@ -5,16 +5,17 @@
 #
 # Align:
 # - fonction parameters on the open bracket,
+# - consecutive assignments,
+# - operands of binary and ternary expressions,
 # - trailing comments.
 # Don't align:
-# - consecutive assignments or declarations,
-# - operands of binary and ternary expressions.
+# - consecutive declarations.
 #
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignOperands: false
+AlignConsecutiveAssignments: true
+AlignOperands: true
 AlignTrailingComments: true
+AlignConsecutiveDeclarations: false
 #
 # Short statements
 # ----------------
@@ -38,7 +39,7 @@ AllowShortLoopsOnASingleLine: false
 #
 # Insert line breaks:
 # - before braces (Allman style),
-# - after the function definition return type,
+# - after the function definition return type only if needed (cf 80col),
 # - after template declarations,
 # - before multiline string literals,
 # - before ternary operators,
@@ -51,7 +52,7 @@ AllowShortLoopsOnASingleLine: false
 #
 # Keep empty lines at the start of blocks.
 #
-AlwaysBreakAfterReturnType: All
+AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true
 BreakBeforeBraces: Allman
@@ -64,10 +65,10 @@ KeepEmptyLinesAtTheStartOfBlocks: true
 # Indentation
 # -----------
 #
-# Use 2 spaces for indentations. Don't further indent continued lines.  Outdent
-# access modifiers (e.g. public:). Indent in all namespaces.
+# Use 2 spaces for indentations. Don't further indent continued lines.
+# Indent in all namespaces.
 #
-AccessModifierOffset: -2
+AccessModifierOffset: 0
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 0
 IndentWidth: 2


### PR DESCRIPTION
# PR Description

This PR adds the configuration file `.clang-format` for `clang-format`. The standalone tool `clang-format` can be used to format C++. It is documented [here](http://clang.llvm.org/docs/ClangFormat.html#standalone-tool) and can be installed from the clang distribution ([clang homepage](http://clang.llvm.org)). Once installed, `clang-format` is fairly easy to use:
`clang-format file` (output on the standard output) or `clang-format -i file` (inline formatting of `file`) with `.clang-file` in the directory or a a parent directory of the input file.

The set of rules were derived from DGtal [coding style](https://github.com/DGtal-team/DGtal/blob/master/CONTRIBUTING.md#coding-style) and from the DGtal source code base. `clang-rules` rules are available [here](http://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options). Also note that `clang-format` doesn't address all DGtal coding style instructions (_e.g._ variable naming) but can help creating a reasonably formatted code base.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)