### PR TITLE
Citing DGtalTools doc in the DGtal doc mainpage

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,9 @@
  - Upgrading the benchmarks to match with the new google-benchmark API
    (David Coeurjolly,
    [#1244]((https://github.com/DGtal-team/DGtal/pull/1244))
+ - The documentation mainpage now refers to the DGtalTools documentation
+   (David Coeurjolly,
+   [#12XX]((https://github.com/DGtal-team/DGtal/pull/12XX))
    
 - *Kernel Package*
  - Fix testBasicPointFunctor. (Bertrand Kerautret

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@
    [#1244]((https://github.com/DGtal-team/DGtal/pull/1244))
  - The documentation mainpage now refers to the DGtalTools documentation
    (David Coeurjolly,
-   [#12XX]((https://github.com/DGtal-team/DGtal/pull/12XX))
+   [#1249]((https://github.com/DGtal-team/DGtal/pull/1249))
    
 - *Kernel Package*
  - Fix testBasicPointFunctor. (Bertrand Kerautret

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,14 +46,14 @@ before_build:
 
   # install zlib
   - cmd: mkdir c:\zlib
-  - appveyor DownloadFile "https://github.com/madler/zlib/archive/v1.2.9.zip" -FileName zlib.zip
+  - appveyor DownloadFile "http://ker.iutsd.univ-lorraine.fr/zlib-1.2.11.zip" -FileName zlib.zip
   - 7z x zlib.zip -oC:\zlib
   - cmd: cd C:\zlib
   - cmd: mkdir C:\zlib-install
   - cmd: mkdir C:\zlib-build
   - cmd: cd C:\zlib-build
   - cmd: dir C:\zlib
-  - cmake -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG%  -DCMAKE_INSTALL_PREFIX:PATH=c:\zlib-install C:\zlib\zlib-1.2.9
+  - cmake -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG%  -DCMAKE_INSTALL_PREFIX:PATH=c:\zlib-install C:\zlib\zlib-1.2.11
   - msbuild zlib.sln /m
   - cmd: msbuild INSTALL.vcxproj
 
@@ -65,10 +65,6 @@ before_build:
   - IF %CACHEOK%==FALSE qmake -t vclib QGLViewer.pro -spec win32-msvc2013 -o  qglviewer.vcxproj
   - IF %CACHEOK%==FALSE msbuild /m /p:Configuration=%CONFIGQGL% /p:Platform=%B_NAME% qglviewer.vcxproj
   - cd %APPVEYOR_BUILD_FOLDER%
-  - appveyor DownloadFile "http://www.winimage.com/zLibDll/zlib123dll.zip" -FileName zlib-dll.zip
-  - 7z x zlib-dll.zip -oC:\zlib-dll
-  - appveyor DownloadFile "http://www.winimage.com/zLibDll/zlib123.zip" -FileName zlib123.zip
-  - 7z x zlib123.zip -oC:\zlib
   - cmake -Wno-dev -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG% -DWITH_QGLVIEWER:BOOL=ON -DQGLVIEWER_INCLUDE_DIR=%QGLDIR%\libQGLViewer -DQGLVIEWER_LIBRARIES=%QGLDIR%\libQGLViewer\QGLViewer\QGLViewer2.lib -DWITH_QT5:BOOL=ON -DBUILD_EXAMPLES:BOOL=ON -DBUILD_TESTING:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=FALSE   -DZLIB_LIBRARY=c:/zlib-install/lib/zlibd.lib -DZLIB_INCLUDE_DIR=c:/zlib-install/include/ -DBOOST_ROOT=C:\Libraries\boost .
 
   

--- a/src/DGtal/doc/mainpage.dox
+++ b/src/DGtal/doc/mainpage.dox
@@ -40,6 +40,15 @@ many promises to be the common basis for future developments made by
 the digital geometry community.
 
 
+DGtal is associated with some [DGtalTools](http://dgtal.org/tools/)
+and [DGtalTools-contrib](http://dgtal.org/tools/). Please have a look
+to the [DGtalTools online
+documentation](http://dgtal.org/doc/tools/nightly) for additional 
+information.
+
+
+
+
 @section package_description DGtal Packages
 
   - \ref packageIntroduction

--- a/src/DGtal/doc/mainpage.dox
+++ b/src/DGtal/doc/mainpage.dox
@@ -40,7 +40,7 @@ many promises to be the common basis for future developments made by
 the digital geometry community.
 
 
-DGtal is associated with some [DGtalTools](http://dgtal.org/tools/)
+DGtal is associated with the projects [DGtalTools](http://dgtal.org/tools/)
 and [DGtalTools-contrib](http://dgtal.org/tools/). Please have a look
 to the [DGtalTools online
 documentation](http://dgtal.org/doc/tools/nightly) for additional 

--- a/tests/shapes/CMakeLists.txt
+++ b/tests/shapes/CMakeLists.txt
@@ -7,10 +7,10 @@ SET(QGLVIEWER_BASED_TESTS_SRC
 
 if (  WITH_VISU3D_QGLVIEWER )
 
-  FOREACH(FILE ${QGLVIEWER_BASED_TESTS_SRC}) 
+  FOREACH(FILE ${QGLVIEWER_BASED_TESTS_SRC})
    add_executable(${FILE} ${FILE})
     target_link_libraries ( ${FILE}  DGtal
-                            ${DGtalLibDependencies})   
+                            ${DGtalLibDependencies})
     #add_test(${FILE} ${FILE})
     #not a test since IHM
   ENDFOREACH(FILE)
@@ -40,7 +40,7 @@ ENDFOREACH(FILE)
 ##### Shapes with viewer.
 
 SET(QGLVIEWER_SHAPES_TESTS_SRC
-  testPolynomial
+//  testPolynomial
   testBall3D
   )
 

--- a/tests/shapes/CMakeLists.txt
+++ b/tests/shapes/CMakeLists.txt
@@ -40,7 +40,7 @@ ENDFOREACH(FILE)
 ##### Shapes with viewer.
 
 SET(QGLVIEWER_SHAPES_TESTS_SRC
-//  testPolynomial
+#  testPolynomial
   testBall3D
   )
 


### PR DESCRIPTION
# PR Description

This PR cites the DGtalTools doc in the DGtal doc main page.

# Checklist

- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] All continuous integration tests pass (Travis & appveyor)