### PR TITLE
fix missing doc Generic Reader

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,8 +20,9 @@
 - *Documentation*
  - Add import with functors in GenericReader in main default reader.
    (mainly motivated to show documentation of specialized version of
-   importWithValueFunctor and importWithColorFunctor). (Bertrand Kerautret
-   [1251](https://github.com/DGtal-team/DGtal/pull/1245))
+   importWithValueFunctor and importWithColorFunctor). The tiff format
+   was also added to the generic readers when ITK is present (Bertrand
+   Kerautret [1251](https://github.com/DGtal-team/DGtal/pull/1245))
   
 # DGtal 0.9.3
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,7 +18,7 @@
    [#1245](https://github.com/DGtal-team/DGtal/pull/1245))
 
 - *Documentation*
- - Add import with functors in GenericReader in main default reader.
+ - Add import with functors in GenericReader in the main default reader.
    (mainly motivated to show documentation of specialized version of
    importWithValueFunctor and importWithColorFunctor). The tiff format
    was also added to the generic readers when ITK is present (Bertrand

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,12 @@
  - Fix testBasicPointFunctor. (Bertrand Kerautret
    [#1245](https://github.com/DGtal-team/DGtal/pull/1245))
 
+- *Documentation*
+ - Add import with functors in GenericReader in main default reader.
+   (mainly motivated to show documentation of specialized version of
+   importWithValueFunctor and importWithColorFunctor). (Bertrand Kerautret
+   [1251](https://github.com/DGtal-team/DGtal/pull/1245))
+  
 # DGtal 0.9.3
 
 ## New Features / Critical Changes

--- a/src/DGtal/io/readers/GenericReader.h
+++ b/src/DGtal/io/readers/GenericReader.h
@@ -104,7 +104,9 @@ namespace DGtal
 
     /**
      * Import a volume nd image file.  For the special format of raw
-     * image, the default parameter of the image size must be given in the optional function vector parameter (dimSpace) .
+     * image, the default parameter of the image size must be given in
+     * the optional function vector parameter (dimSpace).
+     *
      * @param filename the image filename to imported.
      * @param dimSpace a vector containing the n dimensional image size.
      *
@@ -117,9 +119,13 @@ namespace DGtal
     /**
      * Import  a volume nd image file by specifying a value functor.
      *
-     * @tparam TFunctor The type of the functor (should verify the concept CUnaryFunctor<TFunctor, TValue , TContainer::Value > )     * @param dimSpace a vector containing the n dimensional image size..
+     * @tparam TFunctor The type of the functor (should verify the
+     * concept CUnaryFunctor<TFunctor, TValue , TContainer::Value > )
+     *
+     * @param dimSpace a vector containing the n dimensional image size..
      * @param filename the image filename to be imported.
-     * @param aFunctor to transform input type of image value (TValue) into the given image type (TContainer::Value).
+     * @param aFunctor to transform the input type of image value (TValue)
+     * into the given image type (TContainer::Value).
      *
      **/
     template<typename TFunctor>
@@ -144,15 +150,21 @@ namespace DGtal
         
         trace.error() << "Extension " << extension<< " not yet implemented in DGtal GenericReader." << std::endl;
         throw dgtalio;
-      }
+    }
 
     
     /**
      * Import  a volume nd image file by specifying a value functor.
      *
-     * @tparam TFunctor The type of the functor (should verify the concept CUnaryFunctor<TFunctor, TValue , TContainer::Value > )     * @param dimSpace a vector containing the n dimensional image size..
+     * @tparam TFunctor The type of the functor (should verify the
+     * concept CUnaryFunctor<TFunctor, TValue , TContainer::Value > )
+     
+     * @param dimSpace a vector containing the n dimensional image
+     * size.
      * @param filename the image filename to be imported.
-     * @param aFunctor an ColorRGBEncoder. The type of the functor (should verify the concept CUnaryFunctor<TFunctor, TContainer::Value, DGtal::Color > ).
+     * @param aFunctor an ColorRGBEncoder. The type of the functor
+     * (should verify the concept CUnaryFunctor<TFunctor,
+     * TContainer::Value, DGtal::Color >).
      *
      **/
         

--- a/src/DGtal/io/readers/GenericReader.h
+++ b/src/DGtal/io/readers/GenericReader.h
@@ -263,7 +263,7 @@ namespace DGtal
           {
             return DicomReader<TContainer, TFunctor>::importDicom(filename, aFunctor);
           }
-        else if ( extension == "mha" || extension == "mhd" || extension =="tiff"  || extension =="tif")
+        else if (extension=="nii" || extension == "mha" || extension == "mhd" || extension =="tiff"  || extension =="tif")
           {
             return ITKReader<TContainer, TFunctor>::importITK(filename, aFunctor);
           }

--- a/src/DGtal/io/readers/GenericReader.h
+++ b/src/DGtal/io/readers/GenericReader.h
@@ -112,6 +112,78 @@ namespace DGtal
 
     static TContainer import(const std::string &filename,
                              std::vector<unsigned int> dimSpace= std::vector<unsigned int > () )  throw(DGtal::IOException);
+
+    
+    /**
+     * Import  a volume nd image file by specifying a value functor.
+     *
+     * @tparam TFunctor The type of the functor (should verify the concept CUnaryFunctor<TFunctor, TValue , TContainer::Value > )     * @param dimSpace a vector containing the n dimensional image size..
+     * @param filename the image filename to be imported.
+     * @param aFunctor to transform input type of image value (TValue) into the given image type (TContainer::Value).
+     *
+     **/
+    template<typename TFunctor>
+    static TContainer importWithValueFunctor(const std::string &filename,
+                                             const TFunctor &aFunctor,
+                                             std::vector<unsigned int> dimSpace= std::vector<unsigned int > ())  throw( DGtal::IOException )
+    {
+      BOOST_CONCEPT_ASSERT((  concepts::CUnaryFunctor<TFunctor, TValue, typename TContainer::Value > )) ;
+      DGtal::IOException dgtalio;
+        const std::string extension = filename.substr( filename.find_last_of(".") + 1 );
+
+        if ( extension == "raw" )
+          {
+            for ( unsigned int i = 0; i < dimSpace.size(); i++)
+              ASSERT( dimSpace[i] != 0  );
+            typename TContainer::Point const pt;
+            for ( unsigned int i = 0; i < dimSpace.size(); i++)
+              pt[i] = dimSpace[i];
+ 
+            return  RawReader< TContainer, TFunctor >::template importRaw<TValue>( filename, pt, aFunctor  );
+          }
+        
+        trace.error() << "Extension " << extension<< " not yet implemented in DGtal GenericReader." << std::endl;
+        throw dgtalio;
+      }
+
+    
+    /**
+     * Import  a volume nd image file by specifying a value functor.
+     *
+     * @tparam TFunctor The type of the functor (should verify the concept CUnaryFunctor<TFunctor, TValue , TContainer::Value > )     * @param dimSpace a vector containing the n dimensional image size..
+     * @param filename the image filename to be imported.
+     * @param aFunctor an ColorRGBEncoder. The type of the functor (should verify the concept CUnaryFunctor<TFunctor, TContainer::Value, DGtal::Color > ).
+     *
+     **/
+        
+    template<typename TFunctor>
+    static TContainer importWithColorFunctor(const std::string &filename,
+                                             const TFunctor &aFunctor,
+                                             std::vector<unsigned int> dimSpace= std::vector<unsigned int > ())  throw( DGtal::IOException )
+
+    {
+      BOOST_CONCEPT_ASSERT((  concepts::CUnaryFunctor<TFunctor, DGtal::Color, typename TContainer::Value> )) ;
+      
+      DGtal::IOException dgtalio;
+        const std::string extension = filename.substr( filename.find_last_of(".") + 1 );
+
+        if ( extension == "raw" )
+          {
+            for ( unsigned int i = 0; i < dimSpace.size(); i++)
+              ASSERT( dimSpace[i] != 0  );
+            typename TContainer::Point const pt;
+            for ( unsigned int i = 0; i < dimSpace.size(); i++)
+              pt[i] = dimSpace[i];
+            return RawReader< TContainer, TFunctor >::template importRaw<DGtal::Color>( filename, pt, aFunctor);
+          }
+        
+        trace.error() << "Extension " << extension<< " not yet implemented in DGtal GenericReader." << std::endl;
+        throw dgtalio;
+      }
+
+
+    
+
   };
 
 

--- a/src/DGtal/io/readers/GenericReader.h
+++ b/src/DGtal/io/readers/GenericReader.h
@@ -263,7 +263,7 @@ namespace DGtal
           {
             return DicomReader<TContainer, TFunctor>::importDicom(filename, aFunctor);
           }
-        else if ( extension == "mha" || extension == "mhd" )
+        else if ( extension == "mha" || extension == "mhd" || extension =="tiff"  || extension =="tif")
           {
             return ITKReader<TContainer, TFunctor>::importITK(filename, aFunctor);
           }

--- a/src/DGtal/io/readers/GenericReader.ih
+++ b/src/DGtal/io/readers/GenericReader.ih
@@ -83,7 +83,7 @@ import( const std::string & filename,
     {
       return LongvolReader<TContainer>::importLongvol( filename );
     }
-  else if ( extension == "pgm3d" || extension == "pgm3D" || extension == "p3d" || extension == "pgm" )
+  else if ( extension == "pgm3d" || extension == "pgm3D" || extension == "p3d" || extension == "pgm"  || extension =="tiff"  || extension =="tif" )
     {
       return PGMReader<TContainer>::importPGM3D( filename );
     }


### PR DESCRIPTION
# PR Description

Add import with functors in GenericReader in main default reader  (mainly motivated to show documentation of specialized version of  importWithValueFunctor and importWithColorFunctor).

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)