### PR TITLE
typo in PGMReader.h doc

### DIFF
--- a/src/DGtal/io/readers/PGMReader.h
+++ b/src/DGtal/io/readers/PGMReader.h
@@ -73,7 +73,7 @@ namespace DGtal
  *  ...
  *  string filename = "test.pgm";
  *  typedef ImageSelector < Z2i::Domain, uint>::Type Image;
- *  Image image = PGMReader<Image>::importPGMImage( filename ); 
+ *  Image image = PGMReader<Image>::importPGM( filename ); 
  *   @endcode
  *  You can then for instance display a threshold part of the image:
  *  @code 


### PR DESCRIPTION

*Thanks a lot for contributing to DGtal, before submitting your PR, please fill up the description and make sure that all checkboxes are checked. Please remove these lines in your PR.*

# PR Description

Change "Image image = PGMReader<Image>::importPGMImage( filename );"
to 
"Image image = PGMReader<Image>::importPGM( filename );"

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
