### PR TITLE
Fix dss3 d

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,11 @@
  - Fix testBasicPointFunctor. (Bertrand Kerautret
    [#1245](https://github.com/DGtal-team/DGtal/pull/1245))
 
+- *Documentation*
+ - Fix exampleArithDSS3d compilation (which was not activated).
+   (Bertrand Kerautret [#1254](https://github.com/DGtal-team/DGtal/pull/1254))
+   
+
 # DGtal 0.9.3
 
 ## New Features / Critical Changes

--- a/examples/geometry/curves/CMakeLists.txt
+++ b/examples/geometry/curves/CMakeLists.txt
@@ -41,7 +41,7 @@ ENDIF(MAGICK++_FOUND)
 ### Test with QGLViewer
 if (  WITH_VISU3D_QGLVIEWER )
    SET(DGTAL_EXAMPLES_QGL_SRC
-
+      exampleArithDSS3d
      exampleGridCurve3d
      exampleGridCurve3d-2
    )

--- a/examples/geometry/curves/CMakeLists.txt
+++ b/examples/geometry/curves/CMakeLists.txt
@@ -44,14 +44,10 @@ if (  WITH_VISU3D_QGLVIEWER )
       exampleArithDSS3d
      exampleGridCurve3d
      exampleGridCurve3d-2
-   )
-### Test with QGLViewer and CAIRO
-   IF( WITH_CAIRO)
-     SET(DGTAL_EXAMPLES_QGL_CAIRO_SRC
-     exampleArithDSS3d
-   )
-   endif(WITH_CAIRO)
-  FOREACH(FILE ${DGTAL_EXAMPLES_QGL_SRC} ${DGTAL_EXAMPLES_QGL_CAIRO_SRC}) 
+     
+     )
+ 
+  FOREACH(FILE ${DGTAL_EXAMPLES_QGL_SRC} ) 
    add_executable(${FILE} ${FILE})
     target_link_libraries ( ${FILE}  DGtal)   
   ENDFOREACH(FILE)

--- a/examples/geometry/curves/exampleArithDSS3d.cpp
+++ b/examples/geometry/curves/exampleArithDSS3d.cpp
@@ -48,7 +48,9 @@ $ ./examples/geometry/curves/exampleArithDSS3d
 #include <iostream>
 
 #include "DGtal/io/viewers/Viewer3D.h"
+#ifdef WITH_CAIRO   
 #include "DGtal/io/boards/Board3DTo2D.h"
+#endif
 
 #include "DGtal/io/DrawWithDisplay3DModifier.h"
 #include "DGtal/io/readers/PointListReader.h"


### PR DESCRIPTION
# PR Description
Fix exampleArithDSS3d compilation (which was not activated).

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)