### PR TITLE
fix light source move in Viewer3D

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@
     for instance to add callbacks to key or mouse events, or to modify
     what is drawn on the window.
     (Jacques-Olivier Lachaud, [#1259](https://github.com/DGtal-team/DGtal/pull/1259))
-
+    
 ## Changes
 
 - *IO*
@@ -15,7 +15,7 @@
    with the new method getLinesElementsFromFile().
    (Bertrand Kerautret, [#1260](https://github.com/DGtal-team/DGtal/pull/1260))
 
-
+ 
 ## Bug Fixes
 
 - *Configuration/General*
@@ -31,7 +31,9 @@
    handle 32/16 bits images. Also includes a new testITKReader and ITK tests in
    GenericReader.
    (Bertrand Kerautret, [#1255](https://github.com/DGtal-team/DGtal/pull/1255))
-
+ - Viewer3D: fix bad light source move according X/Y mouse move.
+   (Bertrand Kerautret, [#1262](https://github.com/DGtal-team/DGtal/pull/1262))
+   
 - *Kernel Package*
  - Fix testBasicPointFunctor. (Bertrand Kerautret
    [#1245](https://github.com/DGtal-team/DGtal/pull/1245))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,7 +31,8 @@
    handle 32/16 bits images. Also includes a new testITKReader and ITK tests in
    GenericReader.
    (Bertrand Kerautret, [#1255](https://github.com/DGtal-team/DGtal/pull/1255))
- - Viewer3D: fix bad light source move according X/Y mouse move.
+ - Viewer3D: fix bad light source move according X/Y mouse move and new Key_Z to 
+   move away/closer the light source.
    (Bertrand Kerautret, [#1262](https://github.com/DGtal-team/DGtal/pull/1262))
    
 - *Kernel Package*

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -1215,8 +1215,8 @@ DGtal::Viewer3D<TSpace, TKSpace>::mouseMoveEvent ( QMouseEvent *e )
   if(e->modifiers() == (Qt::ControlModifier|Qt::ShiftModifier)){
     int varX = e->x() - myRefMouseXPos; 
     int varY = e->y() - myRefMouseYPos; 
-    myLightPhi += varX*myLigthRotationStep;
-    myLightTheta += varY*myLigthRotationStep/2.0;
+    myLightPhi -= varY*myLigthRotationStep;
+    myLightTheta -= varX*myLigthRotationStep/2.0;
     myLightPosition[0] = myLightR*cos(myLightTheta)*cos(myLightPhi);
     myLightPosition[1] = myLightR*cos(myLightTheta)*sin(myLightPhi);
     myLightPosition[2] = myLightR*sin(myLightTheta);

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -890,6 +890,9 @@ DGtal::Viewer3D<TSpace, TKSpace>::init()
   setKeyDescription ( Qt::Key_O, "Switch the ball display mode (quad ball display (default) or OpenGL point)." );
   setKeyDescription ( Qt::Key_M, "Switch the rendering mode bewteen Default, Metallic and Plastic mode." );
   setKeyDescription ( Qt::Key_P, "Switch the light source position mode between the camera mode (default: the light source position is fixed according to the camera position) and scene mode (the light source position is fixed according the scene coordinate system)." );
+  setKeyDescription ( Qt::Key_Z, "Move away the light source according to the scence center (move closer with  SHIFT+Z)");
+  setKeyDescription ( Qt::ShiftModifier+Qt::Key_Z, "Move closer the light source according to the scence center (move awya with key  Z)" );
+  
 #if !defined (QGLVIEWER_VERSION) || QGLVIEWER_VERSION < 0x020500
   setMouseBindingDescription((Qt::ControlModifier|Qt::ShiftModifier) + Qt::LeftButton, "move light source position defined in the main coordinate system (an x-axis (resp. y-axis) mouse move changes the azimuth (resp. inclination) angle of the light source). Note that light source is always looking at the center point (0,0,0).");
 #else
@@ -1288,7 +1291,43 @@ DGtal::Viewer3D<TSpace, TKSpace>::keyPressEvent ( QKeyEvent *e )
       updateList(false);
       updateGL();
     }
+  if( e->key() == Qt::Key_Z)
+    {
+      if( myLightPositionFixToCamera )
+        {
+          updateLightCoordsFromCamera();
+        }
+      myLightR = sqrt( myLightPosition[0]* myLightPosition[0]+
+                       myLightPosition[1]* myLightPosition[1]+
+                       myLightPosition[2]* myLightPosition[2]);
+      myLightTheta = asin( myLightPosition[2]/myLightR);
+      myLightPhi = atan2( myLightPosition[1], myLightPosition[0]);
+      
+      stringstream ss; 
+      if(e->modifiers()==Qt::ShiftModifier)
+        {
+          myLightR += 5.0;
+          ss << "Move away light source at distance: " << myLightR;
+        }
+      else
+        {
+           myLightR -= 5.0;
+           ss << "Move closer light source at distance: " << myLightR;
+        }
+      displayMessage(QString(ss.str().c_str()), 3000);
+      myLightPosition[0] = myLightR*cos(myLightTheta)*cos(myLightPhi);
+      myLightPosition[1] = myLightR*cos(myLightTheta)*sin(myLightPhi);
+      myLightPosition[2] = myLightR*sin(myLightTheta);
+      if(myLightPositionFixToCamera)
+        {
+          updateRelativeCameraFromLightPosition();
+        }
+      myIsMovingLight=true;
+      glLightfv(GL_LIGHT0, GL_POSITION, myLightPosition);
+      updateGL();
+    }
 
+  
   if ( ( e->key() ==Qt::Key_P ) )
     {
       myLightPositionFixToCamera =! myLightPositionFixToCamera;


### PR DESCRIPTION
# PR Description
Very small PR just to fix light source direction which very difficult to set from mouse move.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
