### PR TITLE
Fix true estimators

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,12 @@
  
 ## Bug Fixes
 
+- *Shapes Package*
+ - Fix ImplicitPolynomial3Shape and TrueDigitalSurfaceLocalEstimator.
+   Improves projection operator on implicit surface and curvature
+   computations. (Jacques-Olivier Lachaud,
+   [#1279](https://github.com/DGtal-team/DGtal/pull/1279))
+
 - *Configuration/General*
  - Upgrading the benchmarks to match with the new google-benchmark API
    (David Coeurjolly,

--- a/src/DGtal/geometry/surfaces/estimation/TrueDigitalSurfaceLocalEstimator.h
+++ b/src/DGtal/geometry/surfaces/estimation/TrueDigitalSurfaceLocalEstimator.h
@@ -166,9 +166,9 @@ namespace DGtal
      */
     void setParams( ConstAlias<KSpace> ks, 
                     Clone<GeometricFunctor> fct,
-                    const int maxIter = 0, 
-                    const Scalar accuracy = 0.1, 
-                    const Scalar gamma = 0.01 );
+                    const int maxIter = 20, 
+                    const Scalar accuracy = 0.0001, 
+                    const Scalar gamma = 0.5 );
 
     /**
      * Model of CDigitalSurfaceLocalEstimator. Initialisation.

--- a/src/DGtal/geometry/surfaces/estimation/TrueDigitalSurfaceLocalEstimator.ih
+++ b/src/DGtal/geometry/surfaces/estimation/TrueDigitalSurfaceLocalEstimator.ih
@@ -52,7 +52,7 @@ DGtal::TrueDigitalSurfaceLocalEstimator<TKSpace, TShape, TGeometricFunctor>::
 TrueDigitalSurfaceLocalEstimator()
   : myKSpace( 0 ), myFct( 0 ), myEmbedder(),
     myShape( 0 ), myH( 1.0 ),
-    myMaxIter( 0 ), myAccuracy( 0.1 ), myGamma( 0.01 )
+    myMaxIter( 20 ), myAccuracy( 0.0001 ), myGamma( 0.5 )
 {
 }
 //-----------------------------------------------------------------------------

--- a/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.h
+++ b/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.h
@@ -189,9 +189,9 @@ namespace DGtal
     */
     inline
     RealPoint  nearestPoint(  const RealPoint &aPoint, 
-                              const double accuracy, 
-                              const int maxIter  , 
-                              const double gamma ) const;
+                              const double accuracy = 0.0001, 
+                              const int maxIter     = 20, 
+                              const double gamma    = 0.5 ) const;
 
 
 

--- a/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.h
+++ b/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.h
@@ -157,6 +157,12 @@ namespace DGtal
        Gaussian curvature estimation at @a aPoint 
        @pre @a aPoint must be close to the surface. 
 
+       Uses the formula \f$ G = -det(M) / \|\nabla f\|^4 \f$, 
+       where \f$ M := \left[ \begin{array}{cccc} f_{xx}& f_{xy} & f_{xz} & f_x \\
+       f_{xy}& f_{yy} & f_{yz} & f_y \\
+       f_{xz}& f_{yz} & f_{zz} & f_z \\
+       f_x& f_y & f_z & 0 \end{array} \right] \f$.
+
        @param aPoint any point in the Euclidean space.
        @return the gaussian curvature value of the polynomial at \a aPoint.
     */
@@ -176,10 +182,9 @@ namespace DGtal
 
     /**
        Perform a gradient descent in order to move a point @a aPoint
-       closer to the implicit surface. More precisely, we use a
-       sequence: x_n = x_(n-1) - gamma.gradient(x_(n-1).
-       The descent is stopped if @a maxIter is reached or if |x_n -
-       x_(n-1)| < accuracy. 
+       closer to the implicit surface f(x)=0. More precisely, we use a
+       sequence: x_n = x_(n-1) - gamma * f(x) * gradient(x_(n-1))/ ||gradient(x_(n-1))||^2
+       The descent is stopped if @a maxIter is reached or if | f(x_n) | < accuracy. 
        
        @param aPoint any point in the Euclidean space.
        @param accuracy distance criterion to stop the descent.

--- a/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.ih
+++ b/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.ih
@@ -109,14 +109,13 @@ init( const Polynomial3 & poly )
   myFzy= derivative<1>( myFz );
   myFzz= derivative<2>( myFz );
 
+  // These two polynomials are used for mean curvature estimation.
   myUpPolynome = myFx*(myFx*myFxx+myFy*myFyx+myFz*myFzx)+
 				myFy*(myFx*myFxy+myFy*myFyy+myFz*myFzy)+
 				myFz*(myFx*myFxz+myFy*myFyz+myFz*myFzz)-
 				( myFx*myFx +myFy*myFy+myFz*myFz )*(myFxx+myFyy+myFzz);
 
   myLowPolynome = myFx*myFx +myFy*myFy+myFz*myFz;
-  // trace.info() << "myUpPolynome=" << myUpPolynome << std::endl;
-  // trace.info() << "myLowPolynome=" << myLowPolynome << std::endl;
 }
 //-----------------------------------------------------------------------------
 template <typename TSpace>
@@ -205,7 +204,7 @@ DGtal::ImplicitPolynomial3Shape<TSpace>::
 gaussianCurvature( const RealPoint &aPoint ) const
 {
   /*
-    JOL: new Gaussian curvature formula
+    JOL: new Gaussian curvature formula (in sage)
     var('Fx','Fy','Fz','Fxx','Fxy','Fxz','Fyy','Fyz','Fzz')
     M=Matrix(4,4,[[Fxx,Fxy,Fxz,Fx],[Fxy,Fyy,Fyz,Fy],[Fxz,Fyz,Fzz,Fz],[Fx,Fy,Fz,0]])
     det(M)
@@ -236,37 +235,6 @@ gaussianCurvature( const RealPoint &aPoint ) const
   const double Ayz = ( Fxx * Fyz - Fxy * Fxz ) * Fy * Fz;
   const double det = Ax2 + Ay2 + Az2 + 2 * ( Axy + Axz + Ayz );
   return - det / ( G2*G2 );
-
-  /*
-  double vFx= myFx( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-  double vFy= myFy( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-  double vFz= myFz( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-
-  double vFxx= myFxx( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-  double vFxy= myFxy( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-  double vFxz= myFxz( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-
-  double vFyy= myFyy( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-  double vFyz= myFyz( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-
-  
-  double vFzz = myFzz( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
- 
-
-  double A = vFz*(vFxx*vFz-2.0*vFx*vFxz)+vFx*vFx*vFzz;
-
-  double B = vFz*(vFyy*vFz-2.0*vFy*vFyz)+vFy*vFy*vFzz;
-
-  double C = vFz*(-vFx*vFyz+vFxy*vFz-vFxz*vFy)+vFx*vFy*vFzz;
-
-  double D = vFz*(vFx*vFx+vFy*vFy+vFz*vFz);
-
-  //ASSERT ( D != 0.0 );
-
-  double G= ( fabs( D ) < 1e-8 ) ? 0.0 : (A*B-C*C)/(D*D);
-
-  return G;
-  */
 }
 
 template< typename TSpace >

--- a/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.ih
+++ b/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.ih
@@ -290,51 +290,26 @@ DGtal::ImplicitPolynomial3Shape<TSpace>::principalCurvatures
  *@param accuracy refers to the precision 
  *@param maxIter refers to the maximum iterations the fonction user authorises
  *@param gamma refers to the step
- * This function is very useful for mean and gaussian curvature computation (If the set step is big) .For a small one ( <0.5) it's less
- * usefull
  *@return the nearest point on the surface to the one given in parameter.
  */
 template <typename TSpace>
 inline
 typename DGtal::ImplicitPolynomial3Shape<TSpace>::RealPoint 
-DGtal::ImplicitPolynomial3Shape<TSpace>::nearestPoint( const RealPoint &aPoint, const double accuracy, 
-                                                       const int maxIter, const double gamma ) const
+DGtal::ImplicitPolynomial3Shape<TSpace>::nearestPoint
+( const RealPoint &aPoint, const double accuracy, 
+  const int maxIter, const double gamma ) const
 {
    RealPoint X = aPoint;
    for ( int numberIter = 0; numberIter < maxIter; numberIter++ )
      {
        double val_X = (*this)( X );
-       // trace.info() << "[" << numberIter << "] vX=" << val_X << " X=" << X;
        if ( fabs( val_X ) < accuracy ) break;
        RealVector grad_X = (*this).gradient( X );
        double  n2_grad_X = grad_X.dot( grad_X );
        if ( n2_grad_X > 0.000001 ) grad_X /= n2_grad_X;
-       // std::cout << " gX=" << grad_X << std::endl;
        X -= val_X * gamma * grad_X ;
      }
    return X;
-   // RealPoint agradient= (*this).gradient(aPoint);
-   // RealPoint X=aPoint;
-   // int numberIter=0;
-   // while((fabs((*this)(X))>=accuracy) && (numberIter<maxIter))
-   // {
-   //      double norm=agradient.norm();
-   // 	RealPoint normalizedGradient= RealPoint(agradient[0]/norm,agradient[1]/norm,agradient[2]/norm);
-   //      double alpha =gamma;
-   // 	if((*this)(X)>0)
-   // 	{
-   // 		alpha=-alpha;
-   // 	}
-   // 	else
-   // 	{
-
-   // 	}
-	
-   // 	X=X+normalizedGradient*alpha;
-   // 	agradient=  (*this).gradient(X);
-   // 	numberIter++;
-   // }
-   // 	return X;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.ih
+++ b/src/DGtal/shapes/implicit/ImplicitPolynomial3Shape.ih
@@ -115,6 +115,8 @@ init( const Polynomial3 & poly )
 				( myFx*myFx +myFy*myFy+myFz*myFz )*(myFxx+myFyy+myFzz);
 
   myLowPolynome = myFx*myFx +myFy*myFy+myFz*myFz;
+  // trace.info() << "myUpPolynome=" << myUpPolynome << std::endl;
+  // trace.info() << "myLowPolynome=" << myLowPolynome << std::endl;
 }
 //-----------------------------------------------------------------------------
 template <typename TSpace>
@@ -202,7 +204,40 @@ double
 DGtal::ImplicitPolynomial3Shape<TSpace>::
 gaussianCurvature( const RealPoint &aPoint ) const
 {
+  /*
+    JOL: new Gaussian curvature formula
+    var('Fx','Fy','Fz','Fxx','Fxy','Fxz','Fyy','Fyz','Fzz')
+    M=Matrix(4,4,[[Fxx,Fxy,Fxz,Fx],[Fxy,Fyy,Fyz,Fy],[Fxz,Fyz,Fzz,Fz],[Fx,Fy,Fz,0]])
+    det(M)
+# Fxz^2*Fy^2 - 2*Fx*Fxz*Fy*Fyz + Fx^2*Fyz^2 - 2*Fxy*Fxz*Fy*Fz + 2*Fx*Fxz*Fyy*Fz - 2*Fx*Fxy*Fyz*Fz + 2*Fxx*Fy*Fyz*Fz + Fxy^2*Fz^2 - Fxx*Fyy*Fz^2 + 2*Fx*Fxy*Fy*Fzz - Fxx*Fy^2*Fzz - Fx^2*Fyy*Fzz
+    G = -det(M) / ( Fx^2 + Fy^2 + Fz^2 )^2
+   */
+  const double   x = aPoint[ 0 ];
+  const double   y = aPoint[ 1 ];
+  const double   z = aPoint[ 2 ];
+  const double  Fx = myFx( x )( y )( z );
+  const double  Fy = myFy( x )( y )( z );
+  const double  Fz = myFz( x )( y )( z );
+  const double Fx2 = Fx * Fx;
+  const double Fy2 = Fy * Fy;
+  const double Fz2 = Fz * Fz;
+  const double  G2 = Fx2 + Fy2 + Fz2;
+  const double Fxx = myFxx( x )( y )( z );
+  const double Fxy = myFxy( x )( y )( z );
+  const double Fxz = myFxz( x )( y )( z );
+  const double Fyy = myFyy( x )( y )( z );
+  const double Fyz = myFyz( x )( y )( z );
+  const double Fzz = myFzz( x )( y )( z );
+  const double Ax2 = ( Fyz * Fyz - Fyy * Fzz ) * Fx2;
+  const double Ay2 = ( Fxz * Fxz - Fxx * Fzz ) * Fy2; 
+  const double Az2 = ( Fxy * Fxy - Fxx * Fyy ) * Fz2;
+  const double Axy = ( Fxy * Fzz - Fxz * Fyz ) * Fx * Fy;
+  const double Axz = ( Fxz * Fyy - Fxy * Fyz ) * Fx * Fz;
+  const double Ayz = ( Fxx * Fyz - Fxy * Fxz ) * Fy * Fz;
+  const double det = Ax2 + Ay2 + Az2 + 2 * ( Axy + Axz + Ayz );
+  return - det / ( G2*G2 );
 
+  /*
   double vFx= myFx( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
   double vFy= myFy( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
   double vFz= myFz( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
@@ -211,14 +246,10 @@ gaussianCurvature( const RealPoint &aPoint ) const
   double vFxy= myFxy( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
   double vFxz= myFxz( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
 
-  //double vFyx= myFyx( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
   double vFyy= myFyy( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
   double vFyz= myFyz( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
 
   
-  /*double vFzx = myFzx( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-  double vFzy = myFzy( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
-  */
   double vFzz = myFzz( aPoint[ 0 ] )( aPoint[ 1 ] )( aPoint[ 2 ] );
  
 
@@ -232,10 +263,10 @@ gaussianCurvature( const RealPoint &aPoint ) const
 
   //ASSERT ( D != 0.0 );
 
-  double G= (A*B-C*C)/(D*D);
+  double G= ( fabs( D ) < 1e-8 ) ? 0.0 : (A*B-C*C)/(D*D);
 
   return G;
-
+  */
 }
 
 template< typename TSpace >
@@ -269,28 +300,41 @@ typename DGtal::ImplicitPolynomial3Shape<TSpace>::RealPoint
 DGtal::ImplicitPolynomial3Shape<TSpace>::nearestPoint( const RealPoint &aPoint, const double accuracy, 
                                                        const int maxIter, const double gamma ) const
 {
-   RealPoint agradient= (*this).gradient(aPoint);
-   RealPoint X=aPoint;
-   int numberIter=0;
-   while((fabs((*this)(X))>=accuracy) && (numberIter<maxIter))
-   {
-        double norm=agradient.norm();
-	RealPoint normalizedGradient= RealPoint(agradient[0]/norm,agradient[1]/norm,agradient[2]/norm);
-        double alpha =gamma;
-	if((*this)(X)>0)
-	{
-		alpha=-alpha;
-	}
-	else
-	{
+   RealPoint X = aPoint;
+   for ( int numberIter = 0; numberIter < maxIter; numberIter++ )
+     {
+       double val_X = (*this)( X );
+       // trace.info() << "[" << numberIter << "] vX=" << val_X << " X=" << X;
+       if ( fabs( val_X ) < accuracy ) break;
+       RealVector grad_X = (*this).gradient( X );
+       double  n2_grad_X = grad_X.dot( grad_X );
+       if ( n2_grad_X > 0.000001 ) grad_X /= n2_grad_X;
+       // std::cout << " gX=" << grad_X << std::endl;
+       X -= val_X * gamma * grad_X ;
+     }
+   return X;
+   // RealPoint agradient= (*this).gradient(aPoint);
+   // RealPoint X=aPoint;
+   // int numberIter=0;
+   // while((fabs((*this)(X))>=accuracy) && (numberIter<maxIter))
+   // {
+   //      double norm=agradient.norm();
+   // 	RealPoint normalizedGradient= RealPoint(agradient[0]/norm,agradient[1]/norm,agradient[2]/norm);
+   //      double alpha =gamma;
+   // 	if((*this)(X)>0)
+   // 	{
+   // 		alpha=-alpha;
+   // 	}
+   // 	else
+   // 	{
 
-	}
+   // 	}
 	
-	X=X+normalizedGradient*alpha;
-	agradient=  (*this).gradient(X);
-	numberIter++;
-   }
-	return X;
+   // 	X=X+normalizedGradient*alpha;
+   // 	agradient=  (*this).gradient(X);
+   // 	numberIter++;
+   // }
+   // 	return X;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
*Thanks a lot for contributing to DGtal, before submitting your PR, please fill up the description and make sure that all checkboxes are checked. Please remove these lines in your PR.*

# PR Description

This PR improves the method ImplicitPolynomial3Shape::nearestPoint as well as the computations of mean and Gaussian curvatures. NearestPoint was bugged, and Gaussian curvature was not stable. Fixes also partly https://github.com/DGtal-team/DGtalTools/issues/261
I am a bit puzzled at the validity of our comparison of former estimators with ground truth. 


# Checklist

- [NA ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)