### PR TITLE
Fix try_compile for ITK.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,9 @@
  - The documentation mainpage now refers to the DGtalTools documentation
    (David Coeurjolly,
    [#1249]((https://github.com/DGtal-team/DGtal/pull/1249))
+ - Fix ITK related try_compile command to work for non-default locations.
+   (Pablo Hernandez,
+   [#1286]((https://github.com/DGtal-team/DGtal/pull/1286))
 
 - *IO*
 - Fix for compilation with 2.7.0 QGLViewer version.

--- a/cmake/CheckDGtalOptionalDependencies.cmake
+++ b/cmake/CheckDGtalOptionalDependencies.cmake
@@ -216,6 +216,7 @@ IF(WITH_ITK)
       ${CMAKE_BINARY_DIR}/CMakeTmp
       ${CMAKE_SOURCE_DIR}/cmake/src/ITKcpp11Bug/
       ITKCPP11BUG
+      CMAKE_FLAGS "-DITK_DIR=${ITK_DIR}"
       OUTPUT_VARIABLE OUTPUT )
     if ( CPP11_ITK )
       message(STATUS "ITK accepts [c++11]" )


### PR DESCRIPTION
Add -DITK_DIR for cases when ITK is not in a default path.

# PR Description

When ITK wasn't in a default path, the try_compile for the ITKCPP11Bug was always failing. This is solved passing the ITK_DIR cmake flag to the try_compile command.

Extra: is that bug still relevant? I have tried with a c++98 ITK (from ITK:master), and there was no problem. maybe the whole try_compile can be removed?

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
