### PR TITLE
Remove deprecated std::unary_function and std::binary_function

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -74,6 +74,8 @@
    (David Coeurjolly, [#1228](https://github.com/DGtal-team/DGtal/pull/1228))
  - Remove cpp11 deprecated usage of std::binder1st and std::binder2nd --generates error with c++17 flag.
    (Pablo Hernandez, [#1287](https://github.com/DGtal-team/DGtal/pull/1287))
+ - Remove cpp11 deprecated usage of std::unary_function and std::binary_function --generates error with c++17 flag.
+   (Pablo Hernandez, [#1291](https://github.com/DGtal-team/DGtal/pull/1291))
 
 - *Topology Package*
  -  Implementation of ParDirCollapse with CollapseSurface and CollapseIsthmus.

--- a/src/DGtal/base/BasicFunctors.h
+++ b/src/DGtal/base/BasicFunctors.h
@@ -60,7 +60,7 @@ namespace functors
 /// Duplicated STL functors
 /////////////////////////////////////////////////////////////////////////////
   template<typename T>
-  struct Min : std::binary_function <T,T,T>
+  struct Min
   {
     inline
     T operator() (const T&a, const T&b) const
@@ -68,7 +68,7 @@ namespace functors
   };
 
   template<typename T>
-  struct Max : std::binary_function <T,T,T>
+  struct Max
   {
     inline
     T operator() (const T&a, const T&b) const
@@ -79,7 +79,7 @@ namespace functors
    * Copy of the std::minus binary operator (not implemented on MS-VS)
    */
   template <class T>
-  struct Minus : std::binary_function <T,T,T>
+  struct Minus
   {
     T operator() (const T& x, const T& y) const
     {return x-y;}
@@ -89,7 +89,7 @@ namespace functors
    * Abs functor.
    */
   template <class T>
-  struct Abs : std::unary_function<T,T>
+  struct Abs
   {
     inline
     T operator() (const T &x) const
@@ -105,7 +105,7 @@ namespace functors
    * Unary minus functor.
    */
   template <class T>
-  struct UnaryMinus : std::unary_function<T,T>
+  struct UnaryMinus
   {
     /**
        @param x any value.
@@ -122,7 +122,7 @@ namespace functors
    * Unary minus functor.
    */
   template <class T>
-  struct MultiplicationByScalar : std::unary_function<T,T>
+  struct MultiplicationByScalar
   {
     inline
     MultiplicationByScalar( const T & aValue )
@@ -174,7 +174,7 @@ namespace functors
    * @tparam TValue type of the value
    */
   template <typename TValue>
-  class ConstValue : std::unary_function <TValue,TValue>
+  class ConstValue
   {
   public:
     typedef TValue Value;
@@ -217,7 +217,7 @@ namespace functors
    * @tparam TCell type of the cell
    */
   template <typename TQuantity, typename TCell>
-  class ConstValueCell : std::unary_function <TQuantity,TQuantity>
+  class ConstValueCell
   {
   public:
     typedef TCell Cell;
@@ -366,7 +366,6 @@ namespace functors
  */
 template <typename T, bool isLower = true, bool isEqual = true >
 class Thresholder
-   : public std::unary_function <T,bool>
  {
   public:
     BOOST_CONCEPT_ASSERT(( boost::EqualityComparable<T> ));
@@ -398,7 +397,6 @@ class Thresholder
 //specializations
 template <typename T>
 struct Thresholder<T,false,false>
-   : public std::unary_function <T,bool>
 {
 
   public:
@@ -419,7 +417,6 @@ struct Thresholder<T,false,false>
 };
 template <typename T>
 struct Thresholder<T,false,true>
-  : public std::unary_function <T,bool>
  {
   public:
     BOOST_CONCEPT_ASSERT(( boost::EqualityComparable<T> ));
@@ -439,7 +436,6 @@ struct Thresholder<T,false,true>
 
 template <typename T>
 struct Thresholder<T,true,false>
-  : public std::unary_function <T,bool>
   {
   public:
     BOOST_CONCEPT_ASSERT(( boost::EqualityComparable<T> ));
@@ -460,7 +456,6 @@ struct Thresholder<T,true,false>
 
 template <typename T>
 struct Thresholder<T,true,true>
-   : public std::unary_function <T,bool>
  {
   public:
     BOOST_CONCEPT_ASSERT(( boost::EqualityComparable<T> ));
@@ -571,7 +566,6 @@ struct Thresholder<T,true,true>
  */
 template <typename T>
 class IntervalThresholder
-   : public std::unary_function <T,bool>
 {
 public:
   BOOST_CONCEPT_ASSERT(( boost::EqualityComparable<T> ));

--- a/src/DGtal/geometry/curves/estimation/FunctorsLambdaMST.h
+++ b/src/DGtal/geometry/curves/estimation/FunctorsLambdaMST.h
@@ -62,7 +62,7 @@ namespace functors
    * \f$ 64 ( -x^6 + 3 x^5 - 3 x^4 + x^3 ) \f$
    * 
    */
-  struct Lambda64Function : std::unary_function < double, double >
+  struct Lambda64Function
   {
       double operator() (double x) const
       {
@@ -76,7 +76,7 @@ namespace functors
    * \f$ \sin x \pi \f$
    * 
    */
-  struct LambdaSinFromPiFunction : std::unary_function < double, double >
+  struct LambdaSinFromPiFunction
   {
       double operator() (double x) const
       {
@@ -89,7 +89,7 @@ namespace functors
    * \f$ \frac{2}{\exp ( 15 (x- \frac{1}{2} ) ) + \exp(15(\frac{1}{2}-x)) } \f$
    * 
    */
-  struct LambdaExponentialFunction : std::unary_function < double, double >
+  struct LambdaExponentialFunction
   {
       double operator() (double x) const
       {

--- a/src/DGtal/geometry/volumes/distance/ExactPredicateLpSeparableMetric.h
+++ b/src/DGtal/geometry/volumes/distance/ExactPredicateLpSeparableMetric.h
@@ -85,15 +85,9 @@ namespace DGtal
   template <typename TSpace, DGtal::uint32_t p,
             typename TRawValue=DGtal::int64_t>
   class ExactPredicateLpSeparableMetric
-    : public std::binary_function< typename TSpace::Point, typename TSpace::Point, double >
   {
     // ----------------------- Standard services ------------------------------
   public:
-    typedef std::binary_function< typename TSpace::Point, typename TSpace::Point, double > Base;
-    typedef typename Base::first_argument_type first_argument_type;
-    typedef typename Base::second_argument_type second_argument_type;
-    typedef typename Base::result_type result_type;
-
     ///Copy the space type
     typedef TSpace Space;
     BOOST_CONCEPT_ASSERT(( concepts::CSpace<TSpace> ));
@@ -265,7 +259,6 @@ namespace DGtal
  template <typename TSpace,
            typename TRawValue>
  class ExactPredicateLpSeparableMetric<TSpace, 2, TRawValue>
-   : public std::binary_function< typename TSpace::Point, typename TSpace::Point, double >
   {
     // ----------------------- Standard services ------------------------------
   public:

--- a/src/DGtal/geometry/volumes/distance/InexactPredicateLpSeparableMetric.h
+++ b/src/DGtal/geometry/volumes/distance/InexactPredicateLpSeparableMetric.h
@@ -79,7 +79,6 @@ namespace DGtal
  */
   template <typename TSpace, typename TValue = double>
   class InexactPredicateLpSeparableMetric
-    : public std::binary_function< typename TSpace::Point, typename TSpace::Point, TValue >
   {
     // ----------------------- Standard services ------------------------------
   public:

--- a/src/DGtal/images/RigidTransformation2D.h
+++ b/src/DGtal/images/RigidTransformation2D.h
@@ -65,7 +65,7 @@ namespace functors
      * @see exampleRigidtransformation2d.cpp
      */
 template <typename TSpace>
-class ForwardRigidTransformation2D : std::unary_function <typename TSpace::Point, typename TSpace::Point>
+class ForwardRigidTransformation2D
 {
     ///Checking concepts
     BOOST_CONCEPT_ASSERT(( concepts::CSpace<TSpace> ));
@@ -129,7 +129,7 @@ protected:
      * @see exampleRigidtransformation2d.cpp
      */
 template <typename TSpace>
-class BackwardRigidTransformation2D : std::unary_function <typename TSpace::Point, typename TSpace::Point>
+class BackwardRigidTransformation2D
 {
     ///Checking concepts
     BOOST_CONCEPT_ASSERT(( concepts::CSpace<TSpace> ));
@@ -193,8 +193,7 @@ protected:
      * @see exampleRigidtransformation2d.cpp
      */
 template <typename TDomain, typename TRigidTransformFunctor >
-class DomainRigidTransformation2D :
-        std::unary_function < std::pair < typename TDomain::Point, typename TDomain::Point >, TDomain>
+class DomainRigidTransformation2D
 {
     ///Checking concepts
     BOOST_STATIC_ASSERT(( TDomain::dimension == 2 ));

--- a/src/DGtal/images/RigidTransformation3D.h
+++ b/src/DGtal/images/RigidTransformation3D.h
@@ -67,7 +67,7 @@ namespace functors
      * @see exampleRigidtransformation3d.cpp
      */
 template <typename TSpace>
-class ForwardRigidTransformation3D : std::unary_function <typename TSpace::Point, typename TSpace::Point>
+class ForwardRigidTransformation3D
 {
     ///Checking concepts
     BOOST_CONCEPT_ASSERT(( concepts::CSpace<TSpace> ));
@@ -148,7 +148,7 @@ protected:
      * @see exampleRigidtransformation3d.cpp
      */
 template <typename TSpace>
-class BackwardRigidTransformation3D : std::unary_function <typename TSpace::Point, typename TSpace::Point>
+class BackwardRigidTransformation3D
 {
     ///Checking concepts
     BOOST_CONCEPT_ASSERT(( concepts::CSpace<TSpace> ));
@@ -225,8 +225,7 @@ private:
      * @see exampleRigidtransformation3d.cpp
      */
 template <typename TDomain, typename TRigidTransformFunctor >
-class DomainRigidTransformation3D :
-        std::unary_function < std::pair < typename TDomain::Point, typename TDomain::Point >, TDomain>
+class DomainRigidTransformation3D
 {
     ///Checking concepts
     BOOST_STATIC_ASSERT(( TDomain::dimension == 3 ));


### PR DESCRIPTION
# PR Description

We follow [boost mail-list
conversation](http://boost.2283326.n4.nabble.com/What-to-do-about-std-binary-function-and-std-unary-function-td4685873.html) and remove any typedef.

We choose the recommended solution 4: Remove inheritance and typedefs. The `operator()` gives the class the `unary` or `binary` behavior. 

Read #1288 for more context.

FIX #1288 

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
