### PR TITLE
Fixing #1296 : invalid cell coordinates in ctopo-fillContours.cpp

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,6 +59,10 @@
  - Fix SternBrocot and variants static instanciations. (Jacques-Olivier Lachaud
    [#1293](https://github.com/DGtal-team/DGtal/pull/1293))
 
+- *Topology Package*
+ - Fix invalid KhalimskyCell coordinates in ctopo-fillContours.cpp example.
+   (Roland Denis, [#1296](https://github.com/DGtal-team/DGtal/pull/1296))
+
 - *Documentation*
  - Add import with functors in GenericReader in the main default reader.
    (mainly motivated to show documentation of specialized version of

--- a/examples/topology/ctopo-fillContours.cpp
+++ b/examples/topology/ctopo-fillContours.cpp
@@ -116,7 +116,7 @@ int main( int /*argc*/, char** /*argv*/ )
                                                               interiorCellImage, 1, false);  
   //! [ctopoFillContoursFillRegion]
 
-  aBoard << CustomStyle(K.uSpel(Z2i::Point(0,0)).className(),  new CustomColors(DGtal::Color::None, Color(200, 200, 200)) );
+  aBoard << CustomStyle(K.lowerCell().className(),  new CustomColors(DGtal::Color::None, Color(200, 200, 200)) );
   for(BoolImage2D::Domain::ConstIterator it = interiorCellImage.domain().begin(); 
       it!=interiorCellImage.domain().end(); it++){
     if(interiorCellImage(*it)){
@@ -137,7 +137,7 @@ int main( int /*argc*/, char** /*argv*/ )
                                                               exteriorCellHoleImage, 1,  false);  
   //! [ctopoFillContoursFillRegionHoles]  
 
-  aBoard2 << CustomStyle(K.uSpel(Z2i::Point(0,0)).className(),  
+  aBoard2 << CustomStyle(K.lowerCell().className(),
                           new CustomColors(DGtal::Color::None, Color(200, 200, 200)) );
   for(BoolImage2D::Domain::ConstIterator it = interiorCellHoleImage.domain().begin();
       it!=interiorCellHoleImage.domain().end(); it++){
@@ -145,7 +145,7 @@ int main( int /*argc*/, char** /*argv*/ )
       aBoard2 << K.uSpel(*it);
     }
   }
-  aBoard2 << CustomStyle(K.uSpel(Z2i::Point(0,0)).className(),  
+  aBoard2 << CustomStyle(K.lowerCell().className(),
                          new CustomColors(DGtal::Color::None, Color(100, 100, 100)) );
   for(BoolImage2D::Domain::ConstIterator it = exteriorCellHoleImage.domain().begin(); 
       it!=exteriorCellHoleImage.domain().end(); it++){


### PR DESCRIPTION
# PR Description

The invalid `KhalimskyCell` is only used to get his `className` in order to define a `CustomStyle` for the `Board2D`. This fix replaces the invalid cell by the `lowerCell` of the `KhalimskySpace`.

I'm wondering if `lowerCell` methods shouldn’t be `static` instead ?

See #1296

# Checklist

- ~~[ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).~~
- ~~[ ] Doxygen documentation of the code completed (classes, methods, types, members...)~~
- ~~[ ] Documentation module page added or updated.~~
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
