### PR TITLE
Magick reader Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,12 @@ addons:
     - libqglviewer-dev
     - libinsighttoolkit3-dev
     - libfftw3-dev
-
+     - g++-5
+     - gcc-5
+     
 before_install:
   - source .travis/before_global.sh
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
   - echo "C++ ===> $CXXCOMPILER"
   - if [ $CONFIG == "Debug,Cairo,QGLviewer,HDF5,EIGEN" ]; then source .travis/install_eigen.sh  ; cd $TRAVIS_BUILD_DIR; fi
   - echo $EIGEN_ROOT

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,10 @@ addons:
     - libfftw3-dev
      - g++-5
      - gcc-5
-     
+
 before_install:
-  - source .travis/before_global.sh
   - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
+  - source .travis/before_global.sh
   - echo "C++ ===> $CXXCOMPILER"
   - if [ $CONFIG == "Debug,Cairo,QGLviewer,HDF5,EIGEN" ]; then source .travis/install_eigen.sh  ; cd $TRAVIS_BUILD_DIR; fi
   - echo $EIGEN_ROOT

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,7 +38,9 @@
    (Bertrand Kerautret, [#1260](https://github.com/DGtal-team/DGtal/pull/1260))
  - SimpleDistanceColorMap new colormap to easily display distance maps.
      (David Coeurjolly, [#1302](https://github.com/DGtal-team/DGtal/pull/1302))
-
+ - Fix in MagicReader allowing to load colored images. (David
+   Coeurjolly, [#13xx](https://github.com/DGtal-team/DGtal/pull/13xx))
+ 
 ## Bug Fixes
 
 - *Build*

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,7 +39,7 @@
  - SimpleDistanceColorMap new colormap to easily display distance maps.
      (David Coeurjolly, [#1302](https://github.com/DGtal-team/DGtal/pull/1302))
  - Fix in MagicReader allowing to load colored images. (David
-   Coeurjolly, [#13xx](https://github.com/DGtal-team/DGtal/pull/13xx))
+   Coeurjolly, [#1305](https://github.com/DGtal-team/DGtal/pull/1305))
  
 ## Bug Fixes
 

--- a/src/DGtal/base/BasicFunctors.h
+++ b/src/DGtal/base/BasicFunctors.h
@@ -48,13 +48,14 @@
 #include <algorithm>
 #include <functional>
 #include <cmath>
+#include "DGtal/io/Color.h"
 #include "DGtal/base/Common.h"
 #include "DGtal/base/BasicBoolFunctors.h"
 //////////////////////////////////////////////////////////////////////////////
 
 namespace DGtal
 {
-namespace functors
+  namespace functors
 {
 /////////////////////////////////////////////////////////////////////////////
 /// Duplicated STL functors
@@ -271,7 +272,6 @@ namespace functors
       return static_cast<TOutput>(aInput);
     }
   };
-
 
   /**
    * Description of template class 'Composer' <p>

--- a/src/DGtal/geometry/helpers/ContourHelper.ih
+++ b/src/DGtal/geometry/helpers/ContourHelper.ih
@@ -42,24 +42,24 @@
 
 
 
-template <typename TPoint> 
+template <typename TPoint>
 inline
-DGtal::PointVector<TPoint::dimension, double> 
+DGtal::PointVector<TPoint::dimension, double>
 DGtal::ContourHelper::getBarycenter(const std::vector<TPoint> & aSet)
 {
   DGtal::PointVector<TPoint::dimension, double> ptMean;
   for(unsigned int i =0; i<aSet.size(); i++)
     {
       for(typename TPoint::Dimension j=0; j < TPoint::dimension; j++)
-        {          
+        {
           ptMean[j] +=  static_cast<double>(aSet.at(i)[j]);
         }
     }
   for(unsigned int j=0; j < TPoint::dimension; j++)
-    {          
+    {
       ptMean[j] /= aSet.size();
-    }      
-  return ptMean; 
+    }
+  return ptMean;
 }
 
 
@@ -69,7 +69,7 @@ DGtal::ContourHelper::getBarycenter(const std::vector<TPoint> & aSet)
 
 template <typename TIterator, typename TOutputIterator>
 inline
-void 
+void
 DGtal::ContourHelper::pixels2pixels8C(const TIterator &itb, const TIterator &ite,
                                       TOutputIterator out)
 {
@@ -77,7 +77,7 @@ DGtal::ContourHelper::pixels2pixels8C(const TIterator &itb, const TIterator &ite
   *out++ = *it;
   unsigned int size = std::distance(itb, ite);
   int i=0;
-  while(i<size-1)
+  while(i<(int)size-1)
     {
 
       short code = FreemanChain<int>::freemanCode4C((*(it+1))[0]-(*it)[0],(*(it+1))[1]-(*it)[1]);
@@ -86,9 +86,9 @@ DGtal::ContourHelper::pixels2pixels8C(const TIterator &itb, const TIterator &ite
         {
           it++;
           i++;
-        } 
+        }
       it++;
-      *out++ = *it;     
+      *out++ = *it;
       i++;
     }
 }
@@ -96,7 +96,7 @@ DGtal::ContourHelper::pixels2pixels8C(const TIterator &itb, const TIterator &ite
 
 
 
-template <typename TPoint> 
+template <typename TPoint>
 inline
 bool
 DGtal::ContourHelper::isCounterClockWise(const std::vector<TPoint> & aCurve)
@@ -144,5 +144,3 @@ DGtal::operator<< ( std::ostream & out,
 
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
-
-

--- a/src/DGtal/io/readers/MagickReader.h
+++ b/src/DGtal/io/readers/MagickReader.h
@@ -57,9 +57,14 @@ namespace DGtal
    * Description of template class 'MagickReader' <p>
    * \brief Aim: implements methods to read a 2D image using the ImageMagick library.
    *
+   * The functor cast colors (DGtal::Color) to the image value type (@a TimageContainer::Value).
+   *
+   * Typical examples of functor are:
+   *   - Color to scalar values (e.g. unsigned char) for "grayscale" images
+   *   - Identity functor but the image needs to have DGtal::Color as value type.
    *
    * @tparam TImageContainer the image container to use. 
-   * @tparam TFunctor the type of functor used in the import (by default set to functors::Cast< TImageContainer::Value>) .
+   * @tparam TFunctor the type of functor used in the import to cast color to image values (by default set to functors::Cast< TImageContainer::Value>) .
    */
   template <typename TImageContainer, typename TFunctor=  functors::Cast< typename TImageContainer::Value > >
   struct MagickReader

--- a/src/DGtal/io/readers/MagickReader.h
+++ b/src/DGtal/io/readers/MagickReader.h
@@ -50,7 +50,28 @@
 
 namespace DGtal
 {
-
+  namespace functors
+  {
+    template<typename TValue>
+    struct MagickCast
+    {
+      Cast<TValue> myCast;
+      TValue operator()(const Color &col) const
+      {
+        return myCast( col.red() + col.green() + col.blue() );
+      }
+    };
+    
+    template<>  
+    struct MagickCast<Color>
+    {
+      Color operator()(const Color &col) const
+      {
+        return col;
+      }
+    };
+  } 
+  
   /////////////////////////////////////////////////////////////////////////////
   // template class MagickReader
   /**
@@ -64,9 +85,9 @@ namespace DGtal
    *   - Identity functor but the image needs to have DGtal::Color as value type.
    *
    * @tparam TImageContainer the image container to use. 
-   * @tparam TFunctor the type of functor used in the import to cast color to image values (by default set to functors::Cast< TImageContainer::Value>) .
+   * @tparam TFunctor the type of functor used in the import to cast color to image values (by default set to functors::MagickCast< TImageContainer::Value>) .
    */
-  template <typename TImageContainer, typename TFunctor=  functors::Cast< typename TImageContainer::Value > >
+  template <typename TImageContainer, typename TFunctor=  functors::MagickCast< typename TImageContainer::Value > >
   struct MagickReader
   {
     // ----------------------- Standard services ------------------------------

--- a/src/DGtal/io/readers/MagickReader.ih
+++ b/src/DGtal/io/readers/MagickReader.ih
@@ -87,8 +87,8 @@ DGtal::MagickReader<TImageContainer, TFunctor>::importImage(const std::string & 
   for(; it != itend; ++it)
     {
       const Magick::PixelPacket *pixel = cacheRead + w * ((topbotomOrder)? ( h - 1 - (*it)[1] ): (*it)[1] ) + (*it)[0];
-      val = (pixel->red + pixel->green + pixel->blue) % 256;
-      image.setValue( (*it),  aFunctor(val)  );
+      Color col(pixel->red,pixel->green,pixel->blue);
+      image.setValue( (*it),  aFunctor(col)  );
     }
 
   return image;

--- a/tests/io/readers/testMagickReader.cpp
+++ b/tests/io/readers/testMagickReader.cpp
@@ -50,15 +50,15 @@ using namespace DGtal;
 
 struct Color2Gray{
   Color2Gray(){}
-  unsigned char operator()(const Color &c)
+  unsigned char operator()(const Color &c) const
   {
-    return (c.red() + c+green() + c.blue())%256;
+    return (c.red() + c.green() + c.blue())%256;
   }
 };
 
 TEST_CASE( "Magick Reader" )
 {
-  SECTION("Color->grayscale");
+  SECTION("Color->grayscale")
   {
     //Default image selector = STLVector
     typedef ImageSelector<Z2i::Domain, unsigned char>::Type Image;
@@ -78,12 +78,12 @@ TEST_CASE( "Magick Reader" )
     board.saveSVG("testMagick-export.svg");
     
     REQUIRE(img.isValid());
-    REQUIRE(img.extent() == Image::Vector(64,64));
+    REQUIRE(img.extent() == Z2i::Vector(64,64));
   }
   
   SECTION("Color->Color")
   {
-    typedef ImageSelector<Z2i::Domain, Color::Type ImageColor;
+    typedef ImageSelector<Z2i::Domain, Color>::Type ImageColor;
     
     std::string filename = testPath + "samples/color64.png";
     
@@ -92,13 +92,14 @@ TEST_CASE( "Magick Reader" )
     MagickReader<ImageColor> reader;
     ImageColor img = reader.importImage( filename );
     
-    Color a = img( Point(1,1));
+    Color a = img( Z2i::Point(1,1));
     CAPTURE( a );
-    img.setValue( Point(1,1), Color(13,13,13));
+    img.setValue( Z2i::Point(1,1), Color(13,13,13));
+    a = img( Z2i::Point(1,1));
     CAPTURE( a );
     
     REQUIRE(img.isValid());
-    REQUIRE(img.extent() == Image::Vector(64,64));
+    REQUIRE(img.extent() == Z2i::Vector(64,64));
   }
 }
 


### PR DESCRIPTION
# PR Description

MagickReader can now read colored images (and store them in a `Image<Domain, Color>` container).
If the reader image container has scalar type, red+green+blue is computed.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
