### PR TITLE
Fill buffer of itk image to zero in ImageContainerByITKImage.ih

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -86,6 +86,9 @@
  - Viewer3D: fix bad light source move according X/Y mouse move and new Key_Z to
    move away/closer the light source.
    (Bertrand Kerautret, [#1262](https://github.com/DGtal-team/DGtal/pull/1262))
+ - Fix ImageContainerByITKImage, fill the itk image buffer with 0 when using the
+   domain constructor.
+   (Pablo Hernandez, [#1307](https://github.com/DGtal-team/DGtal/pull/1307))
 
 - *Kernel Package*
  - Fix testBasicPointFunctor. (Bertrand Kerautret

--- a/src/DGtal/images/ImageContainerByITKImage.ih
+++ b/src/DGtal/images/ImageContainerByITKImage.ih
@@ -75,6 +75,7 @@ namespace DGtal
 
       myITKImagePointer->SetRegions(region);
       myITKImagePointer->Allocate();
+      myITKImagePointer->FillBuffer(0);
     }
 
     template <typename TDomain, typename TValue>


### PR DESCRIPTION
# PR Description

When creating an ImageContainerByITKImage using the `domain` constructor, fill to zero the itk image buffer.

Discovered using:
```
    using Domain = Z3i::Domain ;
    using Image = ImageContainerByITKImage<Domain, unsigned char> ;
    unsigned int foreground_value = 255;
    auto thin_image = ImageFromSet<Image>::create(thin_set, foreground_value);
    typedef itk::ImageFileWriter<Image::ITKImage> ITKImageWriter;
    typename ITKImageWriter::Pointer writer = ITKImageWriter::New();
    writer->SetFileName("my_image.nrrd");
    writer->SetInput(thin_image.getITKImagePointer());
    writer->Update();
```

ImageFromSet::create uses the domain constructor, and the image isn't initialized to zero in the case of ImageContainerByITKImage.

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
