### PR TITLE
new url ?

### DIFF
--- a/.travis/publish_doc.sh
+++ b/.travis/publish_doc.sh
@@ -4,7 +4,7 @@ set -ev
 
 cd build/
 echo $HOME
-rsync -azv --delete --delete-after -e 'ssh -oStrictHostKeyChecking=no -i  /home/travis/build/DGtal-team/DGtal/.travis/dgtal_rsa' html/ dgtal@connect.liris.cnrs.fr:/home/dgtal/public_html/doc/nightly/
+rsync -azv --delete --delete-after -e 'ssh -oStrictHostKeyChecking=no -i  /home/travis/build/DGtal-team/DGtal/.travis/dgtal_rsa' html/ dgtal@connect.liris.cnrs.fr:/home-projets/dgtal/public_html/doc/nightly/
 
 
 ##DOCSET build
@@ -16,9 +16,9 @@ tar zcvf DGtal-devel.tgz org.dgtal.docset
 
 cd ..
 
-rsync  -azv --delete --delete-after -e 'ssh -oStrictHostKeyChecking=no -i  .travis/dgtal_rsa' html/DGtal-devel.tgz dgtal@connect.liris.cnrs.fr:/home/dgtal/public_html/doc/docset
+rsync  -azv --delete --delete-after -e 'ssh -oStrictHostKeyChecking=no -i  .travis/dgtal_rsa' html/DGtal-devel.tgz dgtal@connect.liris.cnrs.fr:/home-projets/dgtal/public_html/doc/docset
 
 
 ###TAGS for DGtalTools
-scp -i  /home/travis/build/DGtal-team/DGtal/.travis/dgtal_rsa  DGtal-tagfile dgtal@connect.liris.cnrs.fr:/home/dgtal/public_html/doc/tags/
-scp -i  /home/travis/build/DGtal-team/DGtal/.travis/dgtal_rsa  Board-tagfile dgtal@connect.liris.cnrs.fr:/home/dgtal/public_html/doc/tags/
+scp -i  /home/travis/build/DGtal-team/DGtal/.travis/dgtal_rsa  DGtal-tagfile dgtal@connect.liris.cnrs.fr:/home-projets/dgtal/public_html/doc/tags/
+scp -i  /home/travis/build/DGtal-team/DGtal/.travis/dgtal_rsa  Board-tagfile dgtal@connect.liris.cnrs.fr:/home-projets/dgtal/public_html/doc/tags/


### PR DESCRIPTION
# PR Description
by trying to fix the DGtalTools doc update, I wondering if we need to update the path since it is no more on the new one...
# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
