### PR TITLE
fixing mathjax URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ ENDIF()
 # Define variables and cmake parameters, and display some information
 # -----------------------------------------------------------------------------
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
-SET(DGtal_VERSION_MAJOR 1)
-SET(DGtal_VERSION_MINOR 0)
-SET(DGtal_VERSION_PATCH 0beta)
+SET(DGtal_VERSION_MAJOR 0)
+SET(DGtal_VERSION_MINOR 9)
+SET(DGtal_VERSION_PATCH 4.1)
 SET(DGTAL_VERSION "${DGtal_VERSION_MAJOR}.${DGtal_VERSION_MINOR}.${DGtal_VERSION_PATCH}")
 SET(PROJECT_VERSION "${DGtal_VERSION_MAJOR}.${DGtal_VERSION_MINOR}.${DGtal_VERSION_PATCH}")
 SET(VERSION ${DGtal_VERSION_MAJOR}.${DGtal_VERSION_MINOR}.${DGtal_VERSION_PATCH})

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # DGtal 1.0.0
 
+## Bug Fixes
+
+- *Documentation*
+  - Fixing path to Mathjax CDN in documentation (David Coeurjolly,
+    [#1222](https://github.com/DGtal-team/DGtal/pull/1209))
 
 # DGtal 0.9.4
 
@@ -67,7 +72,7 @@
   - Fix HDF5 link missing in compilation (Bertrand Kerautret,
      [#1301](https://github.com/DGtal-team/DGtal/pull/1301))
   - Fix compilation with QGLViewer (2.7.x) and Qt5 (Boris Mansencal,
-     [#1300](https://github.com/DGtal-team/DGtal/pull/1300)) 
+     [#1300](https://github.com/DGtal-team/DGtal/pull/1300))
 
 - *Shapes Package*
   - Fix ImplicitPolynomial3Shape and TrueDigitalSurfaceLocalEstimator.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 - *Documentation*
   - Fixing path to Mathjax CDN in documentation (David Coeurjolly,
-    [#1222](https://github.com/DGtal-team/DGtal/pull/1209))
+    [#1318](https://github.com/DGtal-team/DGtal/pull/1318))
 
 # DGtal 0.9.4
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-# DGtal 1.0.0
+# DGtal 0.9.4.1
 
 ## Bug Fixes
 
@@ -19,7 +19,7 @@
   - Adding the half-edge data structure to represent arbitrary
     two-dimensional combinatorial surfaces with or without boundary
     (Jacques-Olivier Lachaud
-     [#1266](https://github.com/DGtal-team/DGtal/pull/1266))    
+     [#1266](https://github.com/DGtal-team/DGtal/pull/1266))
   - Add VoxelComplex, an extension for CubicalComplex, implementing the Critical-Kernels
     framework, based on the work of M.Couprie and G.Bertrand on isthmus.
     (Pablo Hernandez, [#1147](https://github.com/DGtal-team/DGtal/pull/1147))

--- a/doc/doxy.config.Board.in
+++ b/doc/doxy.config.Board.in
@@ -1484,7 +1484,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js?config=TeX-MML-AM_CHTML
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example

--- a/doc/doxy.config.dox.in
+++ b/doc/doxy.config.dox.in
@@ -1497,7 +1497,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js?config=TeX-MML-AM_CHTML
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example

--- a/doc/doxy.config.in
+++ b/doc/doxy.config.in
@@ -1501,7 +1501,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js?config=TeX-MML-AM_CHTML
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example


### PR DESCRIPTION
# PR Description

Fixing the path to mathjax.js in the doc

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
