### PR TITLE
Change float for double type in the switch case

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,10 @@
 - *Base*
   - Fixes wrong members in PredicateCombiner (David Coeurjolly,
     [#1321](https://github.com/DGtal-team/DGtal/pull/1321))
-  
+
+- *IO*
+  - Fix wrong typedef for double case in ITKReader (Adrien Krähenbühl,
+    [#1259](https://github.com/DGtal-team/DGtal/pull/1322))
 
 # DGtal 0.9.4.1
 

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -120,7 +120,7 @@ namespace DGtal {
     }
     case itk::ImageIOBase::DOUBLE:
     {
-      typedef ImageContainerByITKImage<Domain, float> DGtalITKImage;
+      typedef ImageContainerByITKImage<Domain, double> DGtalITKImage;
       Domain d;
       DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );


### PR DESCRIPTION
# PR Description

Probably a bad copy/past in the switch case with all ITK defined types.

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
