### PR TITLE
fixing doc for Hull2D namespace

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,13 @@
   - Fix wrong typedef for double case in ITKReader (Adrien Krähenbühl,
     [#1259](https://github.com/DGtal-team/DGtal/pull/1322))
 
+## Documentation
+
+- *geometry*
+  - Fix doc bug with Hull2D namespace, (Tristan Roussillon,
+    [#1330](https://github.com/DGtal-team/DGtal/pull/1330))
+
+
 # DGtal 0.9.4.1
 
 ## Bug Fixes

--- a/src/DGtal/geometry/tools/Hull2DHelpers.h
+++ b/src/DGtal/geometry/tools/Hull2DHelpers.h
@@ -66,7 +66,7 @@ namespace DGtal
   namespace functions
   {
   /**
-   * @namespace Hull2D gathers useful functions to compute 
+   * @brief Hull2D namespace gathers useful functions to compute 
    * and return the convex hull or the alpha-shape of a range 
    * of 2D points. 
    */


### PR DESCRIPTION
*Thanks a lot for contributing to DGtal, before submitting your PR, please fill up the description and make sure that all checkboxes are checked. Please remove these lines in your PR.*

# PR Description

The documentation has been fixed for Hull2D namespace, which appears now only in namespaces DGtal::functions with a brief description.  

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)

Other items are not relevant 