### PR TITLE
Fix compilation warning: type qualifier ignored

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@
     [#1321](https://github.com/DGtal-team/DGtal/pull/1321))
   - Add assignment operator to ImageContainerByITKImage (Pablo Hernandez,
     [#1336](https://github.com/DGtal-team/DGtal/pull/1336))
+  - Fix compilation warning: const qualifier ignored in cast (Pablo Hernandez,
+    [#1337](https://github.com/DGtal-team/DGtal/pull/1337))
 
 - *IO*
   - Fix wrong typedef for double case in ITKReader (Adrien Krähenbühl,

--- a/src/DGtal/base/OrderedAlphabet.ih
+++ b/src/DGtal/base/OrderedAlphabet.ih
@@ -591,7 +591,7 @@ DGtal::OrderedAlphabet::nextEdge( size_t & nb_a1,
             index_t & s,
             bool & cvx )
 {
-  ModuloComputer< Integer > mc( (const unsigned int)w.size() );
+  ModuloComputer< Integer > mc( (unsigned int)w.size() );
   size_t l;
   size_t len;
   size_t nb;


### PR DESCRIPTION
```cpp
Software/DGtal/DGtal-src/src/DGtal/base/OrderedAlphabet.ih:594:60: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
   ModuloComputer< Integer > mc( (const unsigned int)w.size() );
```


- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)