### PR TITLE
Ignoring doxygen warning when a reference starts with a digit

### DIFF
--- a/.travis/checkDoxygenDocumentation.sh
+++ b/.travis/checkDoxygenDocumentation.sh
@@ -8,16 +8,33 @@ DOXYGENLOG=${BUILD_DIR}/doxygen.log
 ## We first check that the doxygen.log is empty
 if [[ -f "$DOXYGENLOG" ]]
 then
-    if [[ -s "$DOXYGENLOG" ]]
+
+    # Filtering doxygen log (e.g. to ignore some bugs)
+    # See https://github.com/doxygen/doxygen/issues/6352
+    rm -f /tmp/doxygen.*.log
+    awk '/unexpected token TK_EOF as the argument of ref/ \
+        {print $0 > "/tmp/doxygen.ignored.log"; next} \
+        {print $0 > "/tmp/doxygen.kept.log"}' \
+        "$DOXYGENLOG"
+
+    if [[ -s "/tmp/doxygen.kept.log" ]]
     then
         return_code=1
         echo "Doxygen log file not empty !"
         echo "====================================="
-        cat "$DOXYGENLOG"
+        cat "/tmp/doxygen.kept.log"
         echo "====================================="
     else
         echo "Doxygen log OK"
         return_code=0
+    fi
+
+    if [[ -s "/tmp/doxygen.ignored.log" ]]
+    then
+        echo "Ignored doxygen log messages:"
+        echo "====================================="
+        cat "/tmp/doxygen.ignored.log"
+        echo "====================================="
     fi
 else
   return_code=1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,9 @@
     [#1259](https://github.com/DGtal-team/DGtal/pull/1322))
 
 - *Documentation*
+  - Replacing html internal links by ref command in Digital Topology module
+    documentation. Also ignoring doxygen warning when ref begins with a digit.
+    (Roland Denis, [#1340](https://github.com/DGtal-team/DGtal/pull/1340))
   - Fix examples' filenames in Digital Topology module documentation (Isabelle
     Sivignon, [#1331](https://github.com/DGtal-team/DGtal/pull/1331))
   - Fix doc bug with Hull2D namespace, (Tristan Roussillon,

--- a/src/DGtal/topology/doc/moduleDigitalTopology.dox
+++ b/src/DGtal/topology/doc/moduleDigitalTopology.dox
@@ -286,7 +286,7 @@ namespace DGtal {
   
  
  The resulting border can be visualized for instance by: 
- (see <a href="3dBorderExtraction_8cpp_source.html" >  3dBorderExtraction.cpp</a>)
+ (see @ref 3dBorderExtraction.cpp)
 @code 
 Viewer3D<> viewer;
  viewer.show(); 
@@ -298,11 +298,11 @@ Viewer3D<> viewer;
  
 @image html visuBorderExtraction.png  "Border extraction visualisation" 
 @image latex visuBorderExtraction.png  "Border extraction visualisation" width=5cm
-see example <a href="3dBorderExtraction_8cpp_source.html" >  3dBorderExtraction.cpp</a>
+see example @ref 3dBorderExtraction.cpp
 
 @image html visuBorderExtraction2.png  "Border extraction visualisation from imported volume " 
 @image latex visuBorderExtraction2.png  "Border extraction visualisation" width=5cm
-see example: <a href="3dBorderExtractionImg_8cpp_source.html"> 3dBorderExtractionImg.cpp</a>
+see example: @ref 3dBorderExtractionImg.cpp
    
    
    \subsection dgtal_topology_sec3_4   Connectedness and connected components
@@ -354,8 +354,7 @@ see example: <a href="3dBorderExtractionImg_8cpp_source.html"> 3dBorderExtractio
    we give the full code for the homotopic thinning of a shape in 2D
    and 3D.
   
-   The file <a href="homotopicThinning3D_8cpp_source.html" >
-   homotopicThinning3D.cpp </a> illustrates the homotopic thinning on
+   The file @ref homotopicThinning3D.cpp illustrates the homotopic thinning on
    a 26_6 object. 
   
  First a digital object (with 6_26 adjacency) is defined from a digital set representing two rings :


### PR DESCRIPTION
# PR Description

- Ignoring doxygen warning when a reference starts with a digit (see https://github.com/doxygen/doxygen/issues/6352)
- Replacing html internal links in the documentation by the `@ref` command.

The only way I found in order to fix those warnings is to filter the log of Doxygen ...

# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
