### PR TITLE
Testing other url for libqglviewer MacOS package

### DIFF
--- a/.travis/install_deps_macos.sh
+++ b/.travis/install_deps_macos.sh
@@ -10,7 +10,7 @@ brew update
 #brew install qt5 doxygen homebrew/science/hdf5 graphviz graphicsmagick fftw eigen
 brew install qt5 graphicsmagick fftw eigen
 # Explicit install of libqglviewer
-brew install http://liris.cnrs.fr/david.coeurjolly/misc/libqglviewer.rb
+brew install https://perso.liris.cnrs.fr/david.coeurjolly/misc/libqglviewer.rb
 
 ## Temporary HDF5 build issue
 export BTYPE="$BTYPE -DWITH_HDF5=false" && echo "Disabling HDF5 on MacOS";


### PR DESCRIPTION
# PR Description

There seems to be some issues in Travis while downloading the libqglviewer package for MacOS.
The error is
```
Error: Failure while executing; `/usr/bin/curl -q --show-error --user-agent Homebrew/1.7.3\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.13.3\)\ curl/7.54.0 --fail --progress-bar --silent --location --remote-time --continue-at - --output /Users/travis/Library/Caches/Homebrew/Formula/libqglviewer.rb http://liris.cnrs.fr/david.coeurjolly/misc/libqglviewer.rb` exited with 7. Here's the output:
curl: (7) Failed to connect to liris.cnrs.fr port 80: Operation timed out
```

Reproducing the same `curl` command in a terminal, I get another error about the SSL certificate verification, even using `https`:
```bash
$ /usr/bin/curl -q --show-error --user-agent Homebrew/1.7.3\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.13.3\)\ curl/7.54.0 --fail --progress-bar --silent --location --remote-time --continue-at - https://liris.cnrs.fr/david.coeurjolly/misc/libqglviewer.rb
curl:(60) server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```
By using the final target url (after the redirections), `https://perso.liris.cnrs.fr/david.coeurjolly/misc/libqglviewer.rb` ,  it seems to work but I don't know why :octocat:

# Checklist

- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] All continuous integration tests pass (Travis & appveyor)
