### PR TITLE
Change from private to public access of types Input and Output in SCellToPoint

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,9 @@
   - Fix Small bug in Integral Invariant Volume Estimator in 2D
     (Thomas Caissard, [#1316](https://github.com/DGtal-team/DGtal/pull/1316))
 
+  - Change from private to public access of types Input and Output in SCellToPoint
+    (Daniel Antunes, [#1346](https://github.com/DGtal-team/DGtal/pull/1346))
+
 - *Base*
   - Fixing wrong members in PredicateCombiner (David Coeurjolly,
     [#1321](https://github.com/DGtal-team/DGtal/pull/1321))

--- a/src/DGtal/topology/SCellsFunctors.h
+++ b/src/DGtal/topology/SCellsFunctors.h
@@ -73,7 +73,7 @@ namespace DGtal {
   template <typename KSpace>
   class SCellToPoint
   {
-
+  public:
     typedef typename KSpace::Point Output;
     typedef typename KSpace::SCell Input;
 


### PR DESCRIPTION
# PR Description

Fix issue #1343 

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
