### PR TITLE
Fix bug in ImageLinearCellEmbedder

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -51,6 +51,10 @@
   - Adding missing headers in some files of DEC.
     (Roland Denis, [#1349](https://github.com/DGtal-team/DGtal/pull/1349))
 
+- *Image*
+  - Fix bug in ImageLinearCellEmbedder.
+    (Jacques-Olivier Lachaud, [#1356](https://github.com/DGtal-team/DGtal/pull/1356))
+
 # DGtal 0.9.4.1
 
 ## Bug Fixes

--- a/examples/shapes/viewMarchingCubes.cpp
+++ b/examples/shapes/viewMarchingCubes.cpp
@@ -42,11 +42,13 @@ using namespace Z3i;
 
 void usage( int, char** argv )
 {
-  std::cerr << "Usage: " << argv[ 0 ] << " <fileName.vol> <minT> <maxT> <Adj>" << std::endl;
+  std::cerr << "Usage: " << argv[ 0 ] << " <fileName.vol> <minT> [<maxT>=255] [<Adj>=0]" << std::endl;
   std::cerr << "\t - displays the boundary of the shape stored in vol file <fileName.vol>" << std::endl;
   std::cerr << "\t   as a Marching-Cube triangulated surface (more precisely a dual" << std::endl;
   std::cerr << "\t   surface to the digital boundary)." << std::endl;
-  std::cerr << "\t - voxel v belongs to the shape iff its value I(v) follows minT <= I(v) <= maxT." << std::endl;
+  std::cerr << "\t - voxel v belongs to the shape iff its value I(v) follows minT < I(v) <= maxT." << std::endl;
+  std::cerr << "\t - minT is the iso-surface level." << std::endl;
+  std::cerr << "\t - maxT should be equal to the maximum possible value in the image." << std::endl;
   std::cerr << "\t - 0: interior adjacency, 1: exterior adjacency (rules used to connect surface elements unambiguously)." << std::endl;
 }
 
@@ -59,8 +61,8 @@ int main( int argc, char** argv )
     }
   std::string inputFilename = argv[ 1 ];
   unsigned int minThreshold = atoi( argv[ 2 ] );
-  unsigned int maxThreshold = atoi( argv[ 3 ] );
-  bool intAdjacency = atoi( argv[ 4 ] ) == 0;
+  unsigned int maxThreshold = argc > 3 ? atoi( argv[ 3 ] ) : 255;
+  bool intAdjacency = argc > 4 ? (atoi( argv[ 4 ] ) == 0) : true;
 
   typedef ImageSelector < Domain, int>::Type Image;
       

--- a/src/DGtal/images/ImageLinearCellEmbedder.ih
+++ b/src/DGtal/images/ImageLinearCellEmbedder.ih
@@ -124,6 +124,7 @@ operator()( const Cell & cell ) const
   Point p1( myPtrK->uCoords( cell ) );
   RealPoint x1( embed( p1 ) );
   ImageValue y1 = (*myPtrImage)( p1 );
+  double     v1 = NumberTraits<ImageValue>::castToDouble( y1 );
   for ( typename KSpace::DirIterator qit = myPtrK->uOrthDirs( cell );
         qit != 0; ++qit )
     { // cell is closed along this dimension.
@@ -132,9 +133,8 @@ operator()( const Cell & cell ) const
       Point p2( p1 ); --p2[ k ];
       RealPoint x2( embed( p2 ) );
       ImageValue y2 = (*myPtrImage)( p2 );
-      x1[ k ] -= ( NumberTraits<ImageValue>::castToDouble( y1 ) - myIsoValue )
-        * ( x2[ k ] - x1[ k ] )
-        / NumberTraits<ImageValue>::castToDouble( y2 - y1 );
+      double     v2 = NumberTraits<ImageValue>::castToDouble( y2 );
+      x1[ k ] -= ( v1 - myIsoValue ) * ( x2[ k ] - x1[ k ] ) / ( v2 - v1 );
     }
   return x1;
 }


### PR DESCRIPTION
*Thanks a lot for contributing to DGtal, before submitting your PR, please fill up the description and make sure that all checkboxes are checked. Please remove these lines in your PR.*

# PR Description

This PR fixes a bug in class ImageLinearCellEmbedder when the image was made of unsigned values (for instance, a grayscale image made of unsigned char). In this case, the difference y2-y1 may sometimes be negative but the type forbids the value to be negative. The solution is to first cast values to double, then make the difference.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)