### PR TITLE
Fixing warning of Clang when including GraphicsMagick 1.3.31

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@
     [#1326](https://github.com/DGtal-team/DGtal/pull/1326)
   - Fixing documentation checks and updating Travis scripts
     (Roland Denis, [#1335](https://github.com/DGtal-team/DGtal/pull/1335))
+  - Fixing warning of Clang when including GraphicsMagick v1.3.31
+    (Roland Denis, [#1366](https://github.com/DGtal-team/DGtal/pull/1366))
 
 - Miscellaneous
   - Fix Small bug in Integral Invariant Volume Estimator in 2D

--- a/src/DGtal/io/readers/MagickReader.h
+++ b/src/DGtal/io/readers/MagickReader.h
@@ -45,9 +45,22 @@
 #include <cstdio>
 
 #if defined(WITH_MAGICK)
-#include <Magick++.h>
+// Specific inclusion method to fix warning with GraphicsMagic 1.3.31 and Clang.
+// The warning comes from two "diagnostic pop" with missing corresponding push.
+// "MagickLibAddendum" is defined in ImageMagick since 9 years but not in GraphicsMagic.
+#  if !defined(MagickLibAddendum) && defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic push
+#    include <Magick++.h>
+#    if MagickLibVersion != 0x221900
+#      pragma clang diagnostic pop
+#      pragma clang diagnostic pop
+#    endif
+#  else
+#    include <Magick++.h>
+#  endif
 #else // defined WITH_MAGICK
-#error "DGtal has not been built with imagemagick support. Consider adding -DWITH_MAGICK=true when building the project with cmake."
+#  error "DGtal has not been built with imagemagick support. Consider adding -DWITH_MAGICK=true when building the project with cmake."
 #endif // defined WITH_MAGICK
 
 

--- a/src/DGtal/io/writers/MagickWriter.h
+++ b/src/DGtal/io/writers/MagickWriter.h
@@ -50,7 +50,22 @@
 #ifndef WITH_MAGICK
 #pragma error "You must activate imagemagick (-DWITH_MAGICK=true) to include this file"
 #endif
-#include <Magick++.h>
+
+// Specific inclusion method to fix warning with GraphicsMagic 1.3.31 and Clang.
+// The warning comes from two "diagnostic pop" with missing corresponding push.
+// "MagickLibAddendum" is defined in ImageMagick since 9 years but not in GraphicsMagic.
+#if !defined(MagickLibAddendum) && defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic push
+#  include <Magick++.h>
+#  if MagickLibVersion != 0x221900
+#    pragma clang diagnostic pop
+#    pragma clang diagnostic pop
+#  endif
+#else
+#  include <Magick++.h>
+#endif
+
 //////////////////////////////////////////////////////////////////////////////
 
 namespace DGtal


### PR DESCRIPTION
# PR Description

Fixing warning of Clang when including GraphicsMagick 1.3.31, so that Travis job on Mac doesn't fail.

# Checklist

- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
