### PR TITLE
Improve ITKReader, testITKio and testITKReader

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,8 +49,8 @@
     out of range. (Kacper Pluta, [#1359](https://github.com/DGtal-team/DGtal/pull/1359))
 
 - *IO*
-  - Improve ITKReader handled types and fix testITKio and testITKReader (Boris Mansencal,
-    [#1378](https://github.com/DGtal-team/DGtal/pull/1378))
+  - Improve ITKReader, testITKio and testITKReader (Boris Mansencal,
+    [#1379](https://github.com/DGtal-team/DGtal/pull/1379))
   - Fix wrong typedef for double case in ITKReader (Adrien Krähenbühl,
     [#1259](https://github.com/DGtal-team/DGtal/pull/1322))
   - Fix safeguard when using ImageMagick without cmake activation (David Coeurjolly,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,8 @@
     out of range. (Kacper Pluta, [#1359](https://github.com/DGtal-team/DGtal/pull/1359))
 
 - *IO*
+  - Improve ITKReader handled types and fix testITKio and testITKReader (Boris Mansencal,
+    [#1378](https://github.com/DGtal-team/DGtal/pull/1378))
   - Fix wrong typedef for double case in ITKReader (Adrien Krähenbühl,
     [#1259](https://github.com/DGtal-team/DGtal/pull/1322))
   - Fix safeguard when using ImageMagick without cmake activation (David Coeurjolly,

--- a/src/DGtal/images/ImageContainerByITKImage.h
+++ b/src/DGtal/images/ImageContainerByITKImage.h
@@ -51,6 +51,7 @@
 #if defined(__GNUG__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #if defined(__clang__)
 #pragma clang diagnostic push

--- a/src/DGtal/io/readers/DicomReader.ih
+++ b/src/DGtal/io/readers/DicomReader.ih
@@ -43,6 +43,7 @@
 #if defined(__GNUG__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #if defined(__clang__)
 #pragma clang diagnostic push

--- a/src/DGtal/io/readers/ITKReader.h
+++ b/src/DGtal/io/readers/ITKReader.h
@@ -47,7 +47,14 @@
 #include "DGtal/images/CImage.h"
 #include "DGtal/base/BasicFunctors.h"
 #include "DGtal/io/ITKIOTrait.h"
+#if defined(__GNUG__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <itkImageFileReader.h>
+#if defined(__GNUG__)
+#endif
+#pragma GCC diagnostic pop
 
 namespace DGtal
 {

--- a/src/DGtal/io/readers/ITKReader.h
+++ b/src/DGtal/io/readers/ITKReader.h
@@ -51,7 +51,14 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+#endif
 #include <itkImageFileReader.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 #if defined(__GNUG__)
 #endif
 #pragma GCC diagnostic pop

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -72,85 +72,61 @@ namespace DGtal {
     case itk::ImageIOBase::UCHAR:
     {
       typedef ImageContainerByITKImage<Domain, unsigned char> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::CHAR:
     {
       typedef ImageContainerByITKImage<Domain, char> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::USHORT:
     {
       typedef ImageContainerByITKImage<Domain, unsigned short> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::SHORT:
     {
       typedef ImageContainerByITKImage<Domain, short> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::UINT:
     {
       typedef ImageContainerByITKImage<Domain, unsigned int> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::INT:
     {
       typedef ImageContainerByITKImage<Domain, int> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::ULONG:
     {
       typedef ImageContainerByITKImage<Domain, unsigned long> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::LONG:
     {
       typedef ImageContainerByITKImage<Domain, long> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::ULONGLONG:
     {
       typedef ImageContainerByITKImage<Domain, unsigned long long> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::LONGLONG:
     {
       typedef ImageContainerByITKImage<Domain, long long> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::FLOAT:
     {
       typedef ImageContainerByITKImage<Domain, float> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     case itk::ImageIOBase::DOUBLE:
     {
       typedef ImageContainerByITKImage<Domain, double> DGtalITKImage;
-      Domain d;
-      DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
     }

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -166,7 +166,7 @@ namespace DGtal {
     typedef typename TypeDGtalImage::ITKImagePointer ITKImagePointer;
     typedef typename Image::Domain Domain;
 
-    ITKImagePointer itk_image = TypeDGtalImage::ITKImage::New();
+    ITKImagePointer itk_image = nullptr;
 
     try
     {

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -66,7 +66,8 @@ namespace DGtal {
 
     default:
     case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
-      std::cerr << "Unknown and unsupported component type!" << std::endl;
+      trace.warning() << "[ITKReader] Unknown and unsupported component type! File will be loaded with UCHAR component type" << std::endl;
+      //fallthrough
     case itk::ImageIOBase::UCHAR:
     {
       typedef ImageContainerByITKImage<Domain, unsigned char> DGtalITKImage;

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -141,7 +141,8 @@ namespace DGtal {
     {
       itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
       filename.c_str(), itk::ImageIOFactory::ReadMode );
-      if (imageIO) {
+      if (imageIO)
+      {
 	imageIO->SetFileName( filename.c_str() );
 	imageIO->ReadImageInformation();
 	componentType = imageIO->GetComponentType();

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -97,6 +97,20 @@ namespace DGtal {
       DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
+    case itk::ImageIOBase::UINT:
+    {
+      typedef ImageContainerByITKImage<Domain, unsigned int> DGtalITKImage;
+      Domain d;
+      DGtalITKImage im( d );
+      return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
+    }
+    case itk::ImageIOBase::INT:
+    {
+      typedef ImageContainerByITKImage<Domain, int> DGtalITKImage;
+      Domain d;
+      DGtalITKImage im( d );
+      return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
+    }
     case itk::ImageIOBase::ULONG:
     {
       typedef ImageContainerByITKImage<Domain, unsigned long> DGtalITKImage;

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -142,9 +142,11 @@ namespace DGtal {
     {
       itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
       filename.c_str(), itk::ImageIOFactory::ReadMode );
-      imageIO->SetFileName( filename.c_str() );
-      imageIO->ReadImageInformation();
-      componentType = imageIO->GetComponentType();
+      if (imageIO) {
+	imageIO->SetFileName( filename.c_str() );
+	imageIO->ReadImageInformation();
+	componentType = imageIO->GetComponentType();
+      }
     }
     catch ( itk::ExceptionObject & e )
     {

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -125,6 +125,20 @@ namespace DGtal {
       DGtalITKImage im( d );
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
+    case itk::ImageIOBase::ULONGLONG:
+    {
+      typedef ImageContainerByITKImage<Domain, unsigned long long> DGtalITKImage;
+      Domain d;
+      DGtalITKImage im( d );
+      return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
+    }
+    case itk::ImageIOBase::LONGLONG:
+    {
+      typedef ImageContainerByITKImage<Domain, long long> DGtalITKImage;
+      Domain d;
+      DGtalITKImage im( d );
+      return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
+    }
     case itk::ImageIOBase::FLOAT:
     {
       typedef ImageContainerByITKImage<Domain, float> DGtalITKImage;

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -58,11 +58,9 @@ namespace DGtal {
   const TFunctor & aFunctor )
   {
     typedef typename Image::Domain Domain;
-    typedef typename Domain::Point Point;
     typedef itk::ImageIOBase::IOComponentType IOComponentType;
     BOOST_CONCEPT_ASSERT( (concepts::CUnaryFunctor<TFunctor, ValueOut, Value>));
     const IOComponentType componentType = getITKComponentType( filename );
-    typedef unsigned char ElementType;
     switch ( componentType )
     {
 

--- a/src/DGtal/io/writers/ITKWriter.ih
+++ b/src/DGtal/io/writers/ITKWriter.ih
@@ -31,6 +31,7 @@
 #if defined(__GNUG__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #if defined(__clang__)
 #pragma clang diagnostic push

--- a/tests/io/readers/testITKReader.cpp
+++ b/tests/io/readers/testITKReader.cpp
@@ -68,16 +68,17 @@ TEST_CASE( "Testing ITKReader" )
     testPath + "samples/lobsterCroped16b.mhd", resc );
     REQUIRE( ( im( Z3i::Point( 35, 29, 3 ) ) == resc( 60400 ) ) );
   }
-
   SECTION(
   "Testing behavior of ITKReader on non existent image file" )
   {
     bool caughtException = false;
     const std::string filename = testPath + "samples/null.mhd"; //non existent file
-    try {
+    try
+    {
       Image3DUC im = ITKReader<Image3DUC>::importITK(filename);
     }
-    catch(exception &) {
+    catch(exception &)
+    {
       caughtException = true;
       trace.info() <<"Exception was correctly caught" << std::endl;
     }

--- a/tests/io/readers/testITKReader.cpp
+++ b/tests/io/readers/testITKReader.cpp
@@ -68,6 +68,23 @@ TEST_CASE( "Testing ITKReader" )
     testPath + "samples/lobsterCroped16b.mhd", resc );
     REQUIRE( ( im( Z3i::Point( 35, 29, 3 ) ) == resc( 60400 ) ) );
   }
+
+  SECTION(
+  "Testing behavior of ITKReader on non existent image file" )
+  {
+    bool caughtException = false;
+    const std::string filename = testPath + "samples/null.mhd"; //non existent file
+    try {
+      Image3DUC im = ITKReader<Image3DUC>::importITK(filename);
+    }
+    catch(exception &) {
+      caughtException = true;
+      trace.info() <<"Exception was correctly caught" << std::endl;
+    }
+    REQUIRE( caughtException == true);
+  }
+
+
 }
 
 /** @ingroup Tests **/

--- a/tests/io/testITKio.cpp
+++ b/tests/io/testITKio.cpp
@@ -65,6 +65,7 @@ test_image(const string& filename)
 
     typedef typename std::vector<typename Image::Value> Values;
     Values values;
+    values.reserve(domain.size());
     for (typename Domain::Size kk=0; kk<domain.size(); kk++)
         values.push_back(rand());
 

--- a/tests/io/testITKio.cpp
+++ b/tests/io/testITKio.cpp
@@ -103,22 +103,26 @@ bool testITKio()
   unsigned int nbok = 0;
   unsigned int nb = 0;
 
-  nb += 6;
+  nb += 8;
   trace.beginBlock ( "Testing 2D ITK image value types ..." );
   nbok += test_image<ImageSelector<Z2i::Domain, int>::Type>("image_2d_int.mha");
   nbok += test_image<ImageSelector<Z2i::Domain, bool>::Type>("image_2d_bool.mha");
   nbok += test_image<ImageSelector<Z2i::Domain, unsigned int>::Type>("image_2d_unsigned_int.mha");
   nbok += test_image<ImageSelector<Z2i::Domain, unsigned char>::Type>("image_2d_unsigned_char.mha");
+  nbok += test_image<ImageSelector<Z2i::Domain, unsigned long>::Type>("image_2d_unsigned_long.mha");
+  nbok += test_image<ImageSelector<Z2i::Domain, long>::Type>("image_2d_long.mha");
   nbok += test_image<ImageSelector<Z2i::Domain, float>::Type>("image_2d_float.mha");
   nbok += test_image<ImageSelector<Z2i::Domain, double>::Type>("image_2d_double.mha");
   trace.endBlock();
 
-  nb += 6;
+  nb += 8;
   trace.beginBlock ( "Testing 3D ITK image value types ..." );
   nbok += test_image<ImageSelector<Z3i::Domain, int>::Type>("image_3d_int.mha");
   nbok += test_image<ImageSelector<Z3i::Domain, bool>::Type>("image_3d_bool.mha");
   nbok += test_image<ImageSelector<Z3i::Domain, unsigned int>::Type>("image_3d_unsigned_int.mha");
   nbok += test_image<ImageSelector<Z3i::Domain, unsigned char>::Type>("image_3d_unsigned_char.mha");
+  nbok += test_image<ImageSelector<Z3i::Domain, unsigned long>::Type>("image_3d_unsigned_long.mha");
+  nbok += test_image<ImageSelector<Z3i::Domain, long>::Type>("image_3d_long.mha");
   nbok += test_image<ImageSelector<Z3i::Domain, float>::Type>("image_3d_float.mha");
   nbok += test_image<ImageSelector<Z3i::Domain, double>::Type>("image_3d_double.mha");
   trace.endBlock();

--- a/tests/io/testITKio.cpp
+++ b/tests/io/testITKio.cpp
@@ -103,31 +103,31 @@ bool testITKio()
   unsigned int nbok = 0;
   unsigned int nb = 0;
 
-  nbok += 6;
+  nb += 6;
   trace.beginBlock ( "Testing 2D ITK image value types ..." );
-  nb += test_image<ImageSelector<Z2i::Domain, int>::Type>("image_2d_int.mha");
-  nb += test_image<ImageSelector<Z2i::Domain, bool>::Type>("image_2d_bool.mha");
-  nb += test_image<ImageSelector<Z2i::Domain, unsigned int>::Type>("image_2d_unsigned_int.mha");
-  nb += test_image<ImageSelector<Z2i::Domain, unsigned char>::Type>("image_2d_unsigned_char.mha");
-  nb += test_image<ImageSelector<Z2i::Domain, float>::Type>("image_2d_float.mha");
-  nb += test_image<ImageSelector<Z2i::Domain, double>::Type>("image_2d_double.mha");
+  nbok += test_image<ImageSelector<Z2i::Domain, int>::Type>("image_2d_int.mha");
+  nbok += test_image<ImageSelector<Z2i::Domain, bool>::Type>("image_2d_bool.mha");
+  nbok += test_image<ImageSelector<Z2i::Domain, unsigned int>::Type>("image_2d_unsigned_int.mha");
+  nbok += test_image<ImageSelector<Z2i::Domain, unsigned char>::Type>("image_2d_unsigned_char.mha");
+  nbok += test_image<ImageSelector<Z2i::Domain, float>::Type>("image_2d_float.mha");
+  nbok += test_image<ImageSelector<Z2i::Domain, double>::Type>("image_2d_double.mha");
   trace.endBlock();
 
-  nbok += 6;
+  nb += 6;
   trace.beginBlock ( "Testing 3D ITK image value types ..." );
-  nb += test_image<ImageSelector<Z3i::Domain, int>::Type>("image_3d_int.mha");
-  nb += test_image<ImageSelector<Z3i::Domain, bool>::Type>("image_3d_bool.mha");
-  nb += test_image<ImageSelector<Z3i::Domain, unsigned int>::Type>("image_3d_unsigned_int.mha");
-  nb += test_image<ImageSelector<Z3i::Domain, unsigned char>::Type>("image_3d_unsigned_char.mha");
-  nb += test_image<ImageSelector<Z3i::Domain, float>::Type>("image_3d_float.mha");
-  nb += test_image<ImageSelector<Z3i::Domain, double>::Type>("image_3d_double.mha");
+  nbok += test_image<ImageSelector<Z3i::Domain, int>::Type>("image_3d_int.mha");
+  nbok += test_image<ImageSelector<Z3i::Domain, bool>::Type>("image_3d_bool.mha");
+  nbok += test_image<ImageSelector<Z3i::Domain, unsigned int>::Type>("image_3d_unsigned_int.mha");
+  nbok += test_image<ImageSelector<Z3i::Domain, unsigned char>::Type>("image_3d_unsigned_char.mha");
+  nbok += test_image<ImageSelector<Z3i::Domain, float>::Type>("image_3d_float.mha");
+  nbok += test_image<ImageSelector<Z3i::Domain, double>::Type>("image_3d_double.mha");
   trace.endBlock();
 
-  nbok += 3;
+  nb += 3;
   trace.beginBlock ( "Testing 2D ITK image formats ..." );
-  nb += test_image<ImageSelector<Z2i::Domain, unsigned char>::Type>("image_unsigned_char.jpg"); nbok--; // jpg is lossy
-  nb += test_image<ImageSelector<Z2i::Domain, unsigned char>::Type>("image_unsigned_char.png");
-  nb += test_image<ImageSelector<Z2i::Domain, unsigned char>::Type>("image_unsigned_char.bmp");
+  nbok += test_image<ImageSelector<Z2i::Domain, unsigned char>::Type>("image_unsigned_char.jpg"); nb--; // jpg is lossy
+  nbok += test_image<ImageSelector<Z2i::Domain, unsigned char>::Type>("image_unsigned_char.png");
+  nbok += test_image<ImageSelector<Z2i::Domain, unsigned char>::Type>("image_unsigned_char.bmp");
   trace.endBlock();
 
   trace.info() << "(" << nbok << "/" << nb << ") " << endl;


### PR DESCRIPTION
# PR Description

Currently, when DGtal is configured with ITK, testITKio is failing.

This PR:
- add UINT and INT types handling to ITKReader to make testITKio pass
- add ULONG and LONG type handling to ITKReader and corresponding tests (in testITKio)
- fix ITKReader crash on non existing files and add corresponding test (in testITKReader)
- clean code (in particular remove some dead code) in ITKReader, testITKio and testITKReader

It compiles with gcc (8.2.1) and clang (7.0) and pass tests.

In Debug mode, gcc 8.2.1 produces some warnings. Some are specific to ITK. Another is due to the "implicit fallthrough" in the switch case line 71 of ITKReader.ih. I don't know if it was the expected behavior. If it is, a comment with "Falls through" (for example) should be added to silence gcc7 implicit-fallthrough warning (see https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-fallthrough ).

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
