### PR TITLE
Update CowPtr and Clone to fix testClone2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,7 +34,7 @@
 - *Base*
   - Fixing wrong members in PredicateCombiner (David Coeurjolly,
     [#1321](https://github.com/DGtal-team/DGtal/pull/1321))
-  - Fix testClone2.cpp and efficiency issue in Clone/CountedPtr mecanism (Jacques-Olivier Lachaud,
+  - Fix testClone2.cpp and efficiency issue in Clone/CountedPtr mechanism (Jacques-Olivier Lachaud,
     [#1382](https://github.com/DGtal-team/DGtal/pull/1382)). Fix issue
     [#1203](https://github.com/DGtal-team/DGtal/issues/1203))
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,6 +34,8 @@
 - *Base*
   - Fixing wrong members in PredicateCombiner (David Coeurjolly,
     [#1321](https://github.com/DGtal-team/DGtal/pull/1321))
+  - Fix testClone2.cpp and efficiency issue in Clone/CountedPtr mecanism (Jacques-Olivier Lachaud,
+    [#1382](https://github.com/DGtal-team/DGtal/pull/1382))
 
 - *Shapes*
   - Add two new star shapes: Astroid and Lemniscate

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,7 +35,8 @@
   - Fixing wrong members in PredicateCombiner (David Coeurjolly,
     [#1321](https://github.com/DGtal-team/DGtal/pull/1321))
   - Fix testClone2.cpp and efficiency issue in Clone/CountedPtr mecanism (Jacques-Olivier Lachaud,
-    [#1382](https://github.com/DGtal-team/DGtal/pull/1382))
+    [#1382](https://github.com/DGtal-team/DGtal/pull/1382)). Fix issue
+    [#1203](https://github.com/DGtal-team/DGtal/issues/1203))
 
 - *Shapes*
   - Add two new star shapes: Astroid and Lemniscate

--- a/src/DGtal/base/Clone.h
+++ b/src/DGtal/base/Clone.h
@@ -273,13 +273,12 @@ namespace DGtal
 		     COW_PTR, COUNTED_PTR, RIGHT_VALUE_REF, COUNTED_PTR_OR_PTR,
 		     COUNTED_CONST_PTR_OR_CONST_PTR };
     /**
-       Debug method for displaying what's happening when using Clone mecanism
+       Debug method for displaying what's happening when using Clone mechanism
        @param method the name of the conversion method
        @param p the type of parameter
     */
     void display( const std::string& method, Parameter p ) const
     {
-      std::cout << "[Clone<T>::" << method << " param=";
       std::string sp;
       switch (p) {
       case CONST_LEFT_VALUE_REF: sp = "CONST_LEFT_VALUE_REF"; break;
@@ -293,7 +292,8 @@ namespace DGtal
       case COUNTED_CONST_PTR_OR_CONST_PTR: sp = "COUNTED_CONST_PTR_OR_CONST_PTR"; break;
       default:                   sp = "UNKNOWN"; break;
       }
-      std::cout << sp << "]" << std::endl;
+      trace.info() << "[Clone<T>::" << method << " param="
+                   << sp << "]" << std::endl;
         
     }
     /// Internal class that is used for a late deletion of an acquired pointer.

--- a/src/DGtal/base/CowPtr.h
+++ b/src/DGtal/base/CowPtr.h
@@ -75,11 +75,33 @@ public:
     // no need for ~CowPtr - the CountedPtr takes care of everything.
     CowPtr(const CowPtr& r) noexcept             : myPtr(r.myPtr) {}
     /**
-     * Builds a copy-on-write pointer from a counted pointer. Requires
-     * an extra dummy parameter in order to solve ambiguities when
-     * casting from Clone<T> to CowPtr<T>.
-     *
-     * @param r any counted pointer
+       Builds a copy-on-write pointer from a counted pointer. Requires
+       an extra dummy parameter in order to solve ambiguities when
+       casting from Clone<T> to CowPtr<T>.
+       
+       @param r any counted pointer
+       
+       @note Since 1.0, there is no more the direct constructor
+       CowPtr<T>::CowPtr( CountedPtr<T> ). Indeed, it was creating an
+       ambiguity when using conversion operator in class
+       Clone<T>. More precisely it was impossible to have two
+       conversion operators: Clone<T>::operator CountedPtr<T> and
+       Clone<T>::operator CowPtr<T> since this was creating a
+       compilation ambiguity. This is why there is now a dummy bool
+       parameter in this constructor. And there are the conversion
+       operator Clone<T>::operator CountedPtr<T> and
+       Clone<T>::operator CowPtr<T>.
+       
+       @code
+       struct B {};
+       struct A {
+         CowPtr<B> _bcow;
+         CountedPtr<B> _bcounted;
+         // both constructions below are valid and do lazy copy if possible.
+         A( Clone<B> b1, Clone<B> b2 ) : _bcow( b1 ), _bcounted( b2 ) {}
+       };
+       @endcode
+
      */
     CowPtr(const CountedPtr<T> & r, bool /* unused */ )    : myPtr( r ) {}
     CowPtr& operator=(const CowPtr& r)

--- a/src/DGtal/base/CowPtr.h
+++ b/src/DGtal/base/CowPtr.h
@@ -88,9 +88,9 @@ public:
        conversion operators: Clone<T>::operator CountedPtr<T> and
        Clone<T>::operator CowPtr<T> since this was creating a
        compilation ambiguity. This is why there is now a dummy bool
-       parameter in this constructor. And there are the conversion
-       operator Clone<T>::operator CountedPtr<T> and
-       Clone<T>::operator CowPtr<T>.
+       parameter in this constructor while both conversion operator
+       Clone<T>::operator CountedPtr<T> and Clone<T>::operator
+       CowPtr<T> are present.
        
        @code
        struct B {};

--- a/src/DGtal/base/CowPtr.h
+++ b/src/DGtal/base/CowPtr.h
@@ -75,9 +75,13 @@ public:
     // no need for ~CowPtr - the CountedPtr takes care of everything.
     CowPtr(const CowPtr& r) noexcept             : myPtr(r.myPtr) {}
     /**
-     * @todo JOL: check this.
+     * Builds a copy-on-write pointer from a counted pointer. Requires
+     * an extra dummy parameter in order to solve ambiguities when
+     * casting from Clone<T> to CowPtr<T>.
+     *
+     * @param r any counted pointer
      */
-    CowPtr(const CountedPtr<T> & r)    : myPtr( r ) {}
+    CowPtr(const CountedPtr<T> & r, bool /* unused */ )    : myPtr( r ) {}
     CowPtr& operator=(const CowPtr& r)
     {
         if (this != &r)

--- a/src/DGtal/base/CowPtr.h
+++ b/src/DGtal/base/CowPtr.h
@@ -88,7 +88,7 @@ public:
        conversion operators: Clone<T>::operator CountedPtr<T> and
        Clone<T>::operator CowPtr<T> since this was creating a
        compilation ambiguity. This is why there is now a dummy bool
-       parameter in this constructor while both conversion operator
+       parameter in this constructor while both conversion operators
        Clone<T>::operator CountedPtr<T> and Clone<T>::operator
        CowPtr<T> are present.
        

--- a/tests/base/testClone2.cpp
+++ b/tests/base/testClone2.cpp
@@ -948,7 +948,7 @@ int main()
 {
   bool ok = true
     && testCloneCases() 
-    //    && testCloneTimings()
+    && testCloneTimings()
     && testAliasCases()
     && testConstAliasCases();
 

--- a/tests/base/testClone2.cpp
+++ b/tests/base/testClone2.cpp
@@ -241,7 +241,7 @@ struct CloneToValueMember {
 
 struct CloneToCountedMember { // requires explicit duplication
   inline CloneToCountedMember( Clone<DummyTbl> a1 ) // : myDummyTbl( a1 ) {} does not compile
-    : myDummyTbl( new DummyTbl( a1 ) ) {}
+    : myDummyTbl( a1 ) {} // : myDummyTbl( new DummyTbl( a1 ) ) {}
   inline int value() const { return myDummyTbl->value(); }
   CountedPtr<DummyTbl> myDummyTbl;
 };
@@ -948,7 +948,7 @@ int main()
 {
   bool ok = true
     && testCloneCases() 
-    && testCloneTimings()
+    //    && testCloneTimings()
     && testAliasCases()
     && testConstAliasCases();
 


### PR DESCRIPTION
# PR Description

This PR fixes an issue in testClone2.cpp (and more generally in the Clone / CowPtr and CountedPtr mecanism) so that it compiles correctly both with gcc and clang (and hopefully Visual Studio).
GCC was unable to solve a construction of a CountedPtr<T> member from a Clone<T> parameter in an efficient way.

Related to #1381. Fix #1203.

# Checklist

- [x] Unit-test of your feature with testClone2.cpp
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
