### PR TITLE
Fix Travis (documentation deploy & DGtalTools)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,30 +54,26 @@ addons:
 ############
 # Main rules
 ############
-script:
-  - source .travis/before_global.sh
-  - source .travis/build_all.sh
-  - cd "$TRAVIS_BUILD_DIR/build/" ; echo "Checking, dir=$PWD"
-  - source ../.travis/check_tests.sh
+script: |
+  source .travis/before_global.sh &&
+  .travis/build_all.sh &&
+  .travis/check_tests.sh
 
 jobs:
  include:
    - stage: "DGtalTools"
      name: "Testing DGtalTools + DGtal with examples"
-     script:
-       - source .travis/before_global.sh
-       - source .travis/build_dgtal.sh
-       - cd "$TRAVIS_BUILD_DIR" ; echo "Checking, dir=$PWD"
-       # source .travis/getAndCheckDGtalTools.sh
+     script: |
+       source .travis/before_global.sh &&
+       .travis/build_dgtal.sh &&
+       .travis/getAndCheckDGtalTools.sh
    - stage: "Documentation"
      name: "Building and deploying the documentation"
-     script:  #need doxygen first
-       - source .travis/before_global.sh
-       - source .travis/install_doxygen.sh
-       - cd "$TRAVIS_BUILD_DIR/build"
-       - source ../.travis/build_dgtal_doc.sh
-       - cd "$TRAVIS_BUILD_DIR/build"
-       - source ../.travis/checkDoxygenDocumentation.sh
+     script: |
+       source .travis/before_global.sh &&
+       .travis/install_doxygen.sh &&
+       .travis/build_dgtal_doc.sh &&
+       .travis/checkDoxygenDocumentation.sh
      deploy:
        provider: pages
        skip-cleanup: true

--- a/.travis/before_global.sh
+++ b/.travis/before_global.sh
@@ -3,6 +3,7 @@
 # Useful paths
 export SRC_DIR="$TRAVIS_BUILD_DIR"
 export BUILD_DIR="$SRC_DIR/build"
+export DEPS_DIR="$SRC_DIR/deps"
 
 # Options send to the set command.
 # e to exit immediately if a command fails
@@ -19,13 +20,13 @@ echo $SCRIPT_END
 
 $SCRIPT_BEGIN
 
-# Build default options
-export BTYPE=
-export BJOBS=2 # See https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
-
 # Compiler configuration
 export CCOMPILER=$CC
 export CXXCOMPILER=$CXX
+
+# Build default options
+export BTYPE="-DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER"
+export BJOBS=2 # See https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
 
 if [ $TRAVIS_OS_NAME == linux ]
 then
@@ -35,13 +36,21 @@ then
     export CXXCOMPILER=g++-5
  fi
 fi
-# Build directory
-mkdir -p build
+
+# Preparing folders
+# mkdir -p fails on OSX jobs, cd command also...
+echo Preparing folders $BUILD_DIR and $DEPS_DIR
+mkdir "$BUILD_DIR"
+mkdir "$DEPS_DIR"
 
 export MAGICK_CONFIG_PATH=".travis/delegate.mgk"
 $MAGICK_CODER_MODULE_PATH
 $MAGICK_FILTER_MODULE_PATH
 
-# Preparing folders
-mkdir -p "$SRC_DIR/deps/local"
+# General environment variables
+export PATH="${DEPS_DIR}/bin:${PATH}"
+export CPATH="${DEPS_DIR}/include:${CPATH}"
+export CMAKE_PREFIX_PATH="${DEPS_DIR}:$CMAKE_PREFIX_PATH"
+export LD_LIBRARY_PATH="${DEPS_DIR}/lib:${LD_LIBRARY_PATH}"
+
 $SCRIPT_END

--- a/.travis/build_all.sh
+++ b/.travis/build_all.sh
@@ -1,44 +1,42 @@
 #!/bin/bash
 $SCRIPT_BEGIN
 
-
-export CONFIG="Debug,Magick,GMP,ITK,FFTW3,Debug,Cairo,QGLviewer,HDF5,EIGEN"
-
 # OS dependent deps
-source "$SRC_DIR/.travis/install_eigen.sh"
-echo $EIGEN_ROOT
+"$SRC_DIR/.travis/install_eigen.sh"
 
-export BTYPE="$BTYPE -DBUILD_EXAMPLES=false -DBUILD_TESTING=true"
-export BTYPE="$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
-                     -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug \
-                     -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DWITH_EIGEN=true\
-                     -DWARNING_AS_ERROR=OFF -DEIGEN3_INCLUDE_DIR='$EIGEN_ROOT/include/eigen3'"
+# Build options
+BTYPE="$BTYPE -DBUILD_EXAMPLES=false -DBUILD_TESTING=true"
+BTYPE="$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
+              -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug \
+              -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DWITH_EIGEN=true\
+              -DWARNING_AS_ERROR=OFF -DCMAKE_INSTALL_PREFIX='$DEPS_DIR'"
 
-if [ $TRAVIS_OS_NAME == osx ]; then source "$SRC_DIR/.travis/install_deps_macos.sh"; fi
+# OSX dependencies and build customization (hence the source)
+if [ $TRAVIS_OS_NAME == osx ]
+then
+  source "$SRC_DIR/.travis/install_deps_macos.sh"
+fi
 
 #############################
 #     cmake
 #############################
 #Build directory
-cd build
-# Common build options
-export BTYPE="$BTYPE -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER"
+cd "$BUILD_DIR"
 
 # Cmake
 echo "Using C++ = $CXXCOMPILER"
 echo "CMake options = $BTYPE"
-echo "Pwd = $PWD"
-echo "SRC_dir=$SRC_DIR"
 cmake "$SRC_DIR" $BTYPE -G Ninja
 
 #############################
 #     make all
 #############################
-echo "Preparing the build..."
+echo "Building..."
 
 #Sequential DEC examples, this would also build library
 #make examplePropagation
 ninja testDiscreteExteriorCalculusExtended
 #make exampleDiscreteExteriorCalculusChladni
 ninja
+
 $SCRIPT_END

--- a/.travis/build_dgtal.sh
+++ b/.travis/build_dgtal.sh
@@ -1,31 +1,27 @@
 #!/bin/bash
 $SCRIPT_BEGIN
 
-#cd "$BUILD_DIR"
-
-export CONFIG="Debug,Magick,GMP,ITK,FFTW3,Debug,Cairo,QGLviewer,HDF5,EIGEN"
-
 # OS dependent deps
-source "$SRC_DIR/.travis/install_eigen.sh"
-echo $EIGEN_ROOT
+"$SRC_DIR/.travis/install_eigen.sh"
 
-export BTYPE="$BTYPE -DBUILD_EXAMPLES=true -DBUILD_TESTING=false"
-export BTYPE="$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
-                     -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug \
-                     -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DWITH_EIGEN=true\
-                     -DWARNING_AS_ERROR=OFF -DEIGEN3_INCLUDE_DIR='$EIGEN_ROOT/include/eigen3'"
+# Build options
+BTYPE="$BTYPE -DBUILD_EXAMPLES=true -DBUILD_TESTING=false"
+BTYPE="$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
+              -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug \
+              -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DWITH_EIGEN=true\
+              -DWARNING_AS_ERROR=OFF -DCMAKE_INSTALL_PREFIX='$DEPS_DIR'"
 
-if [ $TRAVIS_OS_NAME == osx ]; then source "$SRC_DIR/.travis/install_deps_macos.sh"; fi
+# OSX dependencies and build customization (hence the source)
+if [ $TRAVIS_OS_NAME == osx ]
+then
+  source "$SRC_DIR/.travis/install_deps_macos.sh"
+fi
 
 #############################
 #     cmake
 #############################
 #Build directory
-cd build
-echo "Build folder= $BUILD_DIR"
-
-# Common build options
-export BTYPE="$BTYPE -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER"
+cd "$BUILD_DIR"
 
 # Cmake
 echo "Using C++ = $CXXCOMPILER"
@@ -35,8 +31,8 @@ cmake "$SRC_DIR" $BTYPE -G Ninja
 #############################
 #     make all
 #############################
-echo "Preparing the build..."
-#cd "$BUILD_DIR"
-#Sequential DEC examples, this would also build library
+echo "Building..."
 ninja
+ninja install
+
 $SCRIPT_END

--- a/.travis/build_dgtal_doc.sh
+++ b/.travis/build_dgtal_doc.sh
@@ -1,41 +1,21 @@
 #!/bin/bash
 $SCRIPT_BEGIN
 
-#cd "$BUILD_DIR"
-
-export CONFIG="Debug,Magick,GMP,ITK,FFTW3,Debug,Cairo,QGLviewer,HDF5,EIGEN"
-
 # OS dependent deps
 source "$SRC_DIR/.travis/install_eigen.sh"
-echo $EIGEN_ROOT
-cd build
-echo "SRCDIR=$SRC_DIR"
-echo "PWDDDDD = $PWD"
-echo " -DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.14/bin/doxygen"
 
-export BTYPE="$BTYPE -DBUILD_EXAMPLES=true -DBUILD_TESTING=false"
-export BTYPE="$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
+BTYPE="$BTYPE -DBUILD_EXAMPLES=true -DBUILD_TESTING=false"
+BTYPE="$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
                      -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug \
                      -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DWITH_EIGEN=true\
-                     -DWARNING_AS_ERROR=OFF -DEIGEN3_INCLUDE_DIR='$EIGEN_ROOT/include/eigen3'\
-                     -DDOXYGEN_EXECUTABLE=$TRAVIS_BUILD_DIR/doxygen/bin/doxygen"
-
-
-echo "export BTYPE=$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
-                     -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug \
-                     -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DWITH_EIGEN=true\
-                     -DWARNING_AS_ERROR=OFF -DEIGEN3_INCLUDE_DIR='$EIGEN_ROOT/include/eigen3'\
-                     -DDOXYGEN_EXECUTABLE=$TRAVIS_BUILD_DIR/doxygen/bin/doxygen"
+                     -DWARNING_AS_ERROR=OFF"
 
 #############################
 #     cmake
 #############################
 #Build directory
-cd build
+cd "$BUILD_DIR"
 echo "Build folder= $BUILD_DIR"
-
-# Common build options
-export BTYPE="$BTYPE -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER"
 
 # Cmake
 echo "Using C++ = $CXXCOMPILER"

--- a/.travis/checkDoxygenDocumentation.sh
+++ b/.travis/checkDoxygenDocumentation.sh
@@ -3,7 +3,7 @@ $SCRIPT_BEGIN
 
 return_code=0
 
-DOXYGENLOG=doxygen.log
+DOXYGENLOG="$BUILD_DIR/doxygen.log"
 
 ## We first check that the doxygen.log is empty
 if [[ -f "$DOXYGENLOG" ]]
@@ -49,7 +49,7 @@ else
 fi
 
 
-## We check src code consitency
+## We check src code consistency
 cd "$SRC_DIR/src"
 "$SRC_DIR/.travis/check_src_file_tag.sh"
 if [[ $? == 0 ]]

--- a/.travis/check_tests.sh
+++ b/.travis/check_tests.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 $SCRIPT_BEGIN
 
-echo "Running the unit tests."
 ### DGtal Tests
-echo "PWD = $PWD"
-ls
+echo "Running the unit tests."
+cd "$BUILD_DIR"
 ctest -j $BJOBS --output-on-failure
+
 $SCRIPT_END
 
 

--- a/.travis/getAndCheckDGtalTools.sh
+++ b/.travis/getAndCheckDGtalTools.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 $SCRIPT_BEGIN
 
-
 ## Get and test if DGtalTools compiles
-DGTALPATH="$SRC_DIR"
-echo "DGtal path = $DGTALPATH"
-echo "Build = $BUILD"
-echo "TRAVIS_BUILD_DIR= $TRAVIS_BUILD_DIR"
+
+cd "$SRC_DIR/.."
 git clone --depth 1 git://github.com/DGtal-team/DGtalTools.git
 cd DGtalTools
 mkdir build ; cd build
-cmake .. -DDGtal_DIR=$TRAVIS_BUILD_DIR/build  -G Ninja
+cmake .. $BTYPE -G Ninja
   #inplace
 ninja
+
 $SCRIPT_END

--- a/.travis/install_deps_macos.sh
+++ b/.travis/install_deps_macos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-$SCRIPT_BEGIN
 
+set_options=$- # Backup of set options
 set +e # The brew install has errors
 
 #
@@ -13,7 +13,9 @@ brew install qt5 graphicsmagick fftw eigen ninja
 brew install http://liris.cnrs.fr/david.coeurjolly/misc/libqglviewer.rb
 
 ## Temporary HDF5 build issue
-export BTYPE="$BTYPE -DWITH_HDF5=false" && echo "Disabling HDF5 on MacOS";
-export BTYPE="$BTYPE -DWITH_QT5=true -DCMAKE_PREFIX_PATH=$(brew --prefix qt5)" && echo "Forcing Qt5 on MacOS";
+BTYPE="$BTYPE -DWITH_HDF5=false" && echo "Disabling HDF5 on MacOS";
+BTYPE="$BTYPE -DWITH_QT5=true -DCMAKE_PREFIX_PATH=$(brew --prefix qt5)" && echo "Forcing Qt5 on MacOS";
 
-$SCRIPT_END
+# Restoring set options
+set -$set_options
+

--- a/.travis/install_doxygen.sh
+++ b/.travis/install_doxygen.sh
@@ -7,7 +7,7 @@ $SCRIPT_BEGIN
 mkdir ~/doxygen && cd ~/doxygen
 wget http://doxygen.nl/files/doxygen-1.8.14.src.tar.gz && tar xzf doxygen-1.8.14.src.tar.gz
 cd doxygen-1.8.14 ; mkdir build ; cd build
-cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$SRC_DIR/doxygen/
+cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"
 ninja install
 
 $SCRIPT_END

--- a/.travis/install_eigen.sh
+++ b/.travis/install_eigen.sh
@@ -4,22 +4,20 @@ $SCRIPT_BEGIN
 #
 # Local install of Eigen on linux system
 #
-export EIGEN_ROOT="/usr/local/"
-
 if [ "$TRAVIS_OS_NAME" == linux ];
 then
-    cd "$SRC_DIR/deps"
-    wget http://bitbucket.org/eigen/eigen/get/3.2.10.tar.bz2
+    cd "$HOME"
 
+    wget http://bitbucket.org/eigen/eigen/get/3.2.10.tar.bz2
     bunzip2 3.2.10.tar.bz2
-    tar xf 3.2.10.tar 
+    tar xf 3.2.10.tar
 
     cd eigen-eigen-b9cd8366d4e8
     mkdir build ; cd build
 
-    cmake .. -DCMAKE_INSTALL_PREFIX="${SRC_DIR}/deps/local"
-    make -j 2 && make install && cd "${SRC_DIR}" && export EIGEN_ROOT="$SRC_DIR/deps/local"
-
+    cmake .. -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"
+    make -j $BJOBS
+    make install
 fi
 
 $SCRIPT_END

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@
     (Roland Denis, [#1335](https://github.com/DGtal-team/DGtal/pull/1335))
   - Fixing warning of Clang when including GraphicsMagick v1.3.31
     (Roland Denis, [#1366](https://github.com/DGtal-team/DGtal/pull/1366))
+  - Fixing & updating Travis: documentation deployement and DGtalTools job
+    (Roland Denis, [#1383](https://github.com/DGtal-team/DGtal/pull/1383))
 
 - Miscellaneous
   - Fix Small bug in Integral Invariant Volume Estimator in 2D


### PR DESCRIPTION
# PR Description
Update and fix of Travis script:
- using classical environment variables (`PATH`, `CPATH` and `CMAKE_PREFIX_PATH`) instead of keeping path of each dependency.
- calling script instead or sourcing it when possible.
- chaining script lines so that it terminates if one step fails (but we loose the separate timings).
- re-enabling DGtalTools compilation.
- fixing documentation deploy.

# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
- [x] https://github.com/DGtal-team/DGtalTools/pull/345 is merged in DGtalTools
- [x] Removing temporary fix that ignore DGtalTools compilation failure
