### PR TITLE
LpMetric in R^d

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 # DGtal 1.0
 
 ## New Features / Critical Changes
+
 - *Base package*
   - Adding FunctorHolder to transform any callable object (e.g. function,
     functor, lambda function,...) into a valid DGtal functor.
@@ -37,6 +38,10 @@
   - Remove the internal object from VoxelComplex, improving performance
     (Pablo Hernandez, [#1369](https://github.com/DGtal-team/DGtal/pull/1369))
 
+- *Geometry*
+  - New LpMetric class (model of CMetricSpace) for distance computations in R^n.
+    (David Coeurjolly,  [#1388](https://github.com/DGtal-team/DGtal/pull/1388))
+ 
 ## Bug Fixes
 - *Configuration/General*
   - Continuous integration AppVeyor fix

--- a/examples/geometry/surfaces/exampleEstimatorFromSurfelFunctors.cpp
+++ b/examples/geometry/surfaces/exampleEstimatorFromSurfelFunctors.cpp
@@ -141,7 +141,7 @@ int main(  )
   ReporterNormalLeast reporterL;
 #endif
 
-  LpMetric<Z3i::Space> l2;
+  LpMetric<Z3i::Space> l2(2.0);
   FunctorNormalElem estimatorNormalElem(embedder,1.0);
   ///sigma = 2.0 for the gaussian smoothing
   DGtal::functors::GaussianKernel gaussian(2.0);

--- a/examples/geometry/surfaces/exampleEstimatorFromSurfelFunctors.cpp
+++ b/examples/geometry/surfaces/exampleEstimatorFromSurfelFunctors.cpp
@@ -44,6 +44,7 @@
 #include "DGtal/shapes/Shapes.h"
 
 #include "DGtal/geometry/surfaces/estimation/LocalEstimatorFromSurfelFunctorAdapter.h"
+#include "DGtal/geometry/volumes/distance/LpMetric.h"
 #ifdef WITH_CGAL
 #include "DGtal/geometry/surfaces/estimation/estimationFunctors/MongeJetFittingGaussianCurvatureEstimator.h"
 #include "DGtal/geometry/surfaces/estimation/estimationFunctors/MongeJetFittingMeanCurvatureEstimator.h"
@@ -109,16 +110,16 @@ int main(  )
   //constant convolution functor
   typedef functors::ConstValue<double> ConstFunctor;
 
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric, FunctorGaussian, ConstFunctor> ReporterK;
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric, FunctorMean, ConstFunctor> ReporterH;
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric, FunctorNormal, ConstFunctor> ReporterNormal;
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric, FunctorNormalLeast, ConstFunctor> ReporterNormalLeast;
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>, FunctorGaussian, ConstFunctor> ReporterK;
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>, FunctorMean, ConstFunctor> ReporterH;
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>, FunctorNormal, ConstFunctor> ReporterNormal;
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>, FunctorNormalLeast, ConstFunctor> ReporterNormalLeast;
 #endif
 
   ///For Elmentary convolution, we specify a Gaussian convolution
   ///kernel from the BasicFunctors.h file
   typedef functors::ElementaryConvolutionNormalVectorEstimator<Surfel, CanonicSCellEmbedder<KSpace> > FunctorNormalElem;
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric,
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>,
                                                  FunctorNormalElem, DGtal::functors::GaussianKernel> ReporterNormalElem;
   //! [SurfelFunctorsType]
 
@@ -140,10 +141,11 @@ int main(  )
   ReporterNormalLeast reporterL;
 #endif
 
+  LpMetric<Z3i::Space> l2;
   FunctorNormalElem estimatorNormalElem(embedder,1.0);
   ///sigma = 2.0 for the gaussian smoothing
   DGtal::functors::GaussianKernel gaussian(2.0);
-  ReporterNormalElem reporterElem(surface, l2Metric,
+  ReporterNormalElem reporterElem(surface, l2,
                                   estimatorNormalElem, gaussian);
   //! [SurfelFunctorsInstances]
 
@@ -159,10 +161,10 @@ int main(  )
   reporterN.init(1, surface.begin(), surface.end());
   reporterL.init(1, surface.begin(), surface.end());
 
-  reporterK.setParams(l2Metric, estimatorK, constFunctor, 5.0);
-  reporterH.setParams(l2Metric, estimatorH, constFunctor, 5.0);
-  reporterN.setParams(l2Metric, estimatorN, constFunctor, 5.0);
-  reporterL.setParams(l2Metric, estimatorL, constFunctor, 5.0);
+  reporterK.setParams(l2, estimatorK, constFunctor, 5.0);
+  reporterH.setParams(l2, estimatorH, constFunctor, 5.0);
+  reporterN.setParams(l2, estimatorN, constFunctor, 5.0);
+  reporterL.setParams(l2, estimatorL, constFunctor, 5.0);
 
   FunctorGaussian::Quantity valK = reporterK.eval( surface.begin());
   FunctorMean::Quantity valH = reporterH.eval( surface.begin());
@@ -171,7 +173,7 @@ int main(  )
 #endif
   
   reporterElem.attach(surface);
-  reporterElem.setParams(l2Metric,
+  reporterElem.setParams(l2,
                          estimatorNormalElem, gaussian, 5.0);
   reporterElem.init(1.0, surface.begin(), surface.end());
   FunctorNormalElem::Quantity valElem = reporterElem.eval( surface.begin());

--- a/src/DGtal/geometry/doc/moduleMetrics.dox
+++ b/src/DGtal/geometry/doc/moduleMetrics.dox
@@ -69,7 +69,7 @@ example,
 on C++ "double").
 - @f$ l_p@f$ metrics (ExactPredicateLpSeparableMetric or
   InexactPredicateLpSeparableMetric) are models of CMetricSpace on @f$(\mathbb{Z}^n, \mathbb{Z}, d)@f$ for
-  @f$p>1@f$ with specific separabilty methods.
+  @f$p>1@f$ with specific separability methods.
 - Chamfer norms with axis symmetric unit ball (see experimental::ChamferNorm2D in dimension 2).
 - DigitalMetricAdapter which adapts any metric (model of CMetricSpace)
   to digital space using the ceil function. This induces a digital

--- a/src/DGtal/geometry/doc/moduleMetrics.dox
+++ b/src/DGtal/geometry/doc/moduleMetrics.dox
@@ -62,12 +62,14 @@ In the following, we restrict our attention to metric spaces even if some of the
 In DGtal, the concept of CMetricSpace is associated with metric space
 definition. A first refinement of this concept is the concept of
 CDigitalMetricSpace whose models implement distance functions on
-integer numbers (i.e. @f$(\mathbb{Z}^n, \mathbb{Z}, d)@f$)). For
+integer numbers (i.e. @f$(\mathbb{Z}^n, \mathbb{Z}, d)@f$). For
 example,
 
+- LpMetric are models of CMetricSpace on @f$(\mathbb{R}^n, \mathbb{R}, d)@f$ spaces (i.e. all computations are performed
+on c++ "double").
 - @f$ l_p@f$ metrics (ExactPredicateLpSeparableMetric or
-  InexactPredicateLpSeparableMetric) are models of CMetricSpace for
-  @f$p>1@f$.
+  InexactPredicateLpSeparableMetric) are models of CMetricSpace on @f$(\mathbb{Z}^n, \mathbb{Z}, d)@f$ for
+  @f$p>1@f$ with specific separabilty methods.
 - Chamfer norms with axis symmetric unit ball (see experimental::ChamferNorm2D in dimension 2).
 - DigitalMetricAdapter which adapts any metric (model of CMetricSpace)
   to digital space using the ceil function. This induces a digital

--- a/src/DGtal/geometry/doc/moduleMetrics.dox
+++ b/src/DGtal/geometry/doc/moduleMetrics.dox
@@ -66,7 +66,7 @@ integer numbers (i.e. @f$(\mathbb{Z}^n, \mathbb{Z}, d)@f$). For
 example,
 
 - LpMetric are models of CMetricSpace on @f$(\mathbb{R}^n, \mathbb{R}, d)@f$ spaces (i.e. all computations are performed
-on c++ "double").
+on C++ "double").
 - @f$ l_p@f$ metrics (ExactPredicateLpSeparableMetric or
   InexactPredicateLpSeparableMetric) are models of CMetricSpace on @f$(\mathbb{Z}^n, \mathbb{Z}, d)@f$ for
   @f$p>1@f$ with specific separabilty methods.

--- a/src/DGtal/geometry/surfaces/estimation/LocalEstimatorFromSurfelFunctorAdapter.h
+++ b/src/DGtal/geometry/surfaces/estimation/LocalEstimatorFromSurfelFunctorAdapter.h
@@ -93,7 +93,7 @@ namespace DGtal
    * canonical embedding of surfel elements (cf CanonicSCellEmbedder).
    *
    *  @tparam TDigitalSurfaceContainer any model of digital surface container concept (CDigitalSurfaceContainer)
-   *  @tparam TMetric any model of CMetricSpace to be used in the neighborhood construction.
+   *  @tparam TMetric any model of CMetricSpace to be used in the neighborhood construction (e.g. LpMetric)
    *  @tparam TFunctorOnSurfel an estimator on surfel set (model of CLocalEstimatorFromSurfelFunctor)
    *  @tparam TConvolutionFunctor type of  functor on double
    *  [0,1]->[0,1] to implement the response of a symmetric convolution kernel.

--- a/src/DGtal/geometry/surfaces/estimation/VoronoiCovarianceMeasureOnDigitalSurface.h
+++ b/src/DGtal/geometry/surfaces/estimation/VoronoiCovarianceMeasureOnDigitalSurface.h
@@ -153,7 +153,7 @@ namespace DGtal
      * used for finding the correct orientation inside/outside for the
      * VCM.
      *
-     * @param aMetric an instance of the metric.
+     * @param aMetric an instance of the metric (used for the Voronoi map construction).
      *
      * @param verbose if 'true' displays information on ongoing computation.
      */

--- a/src/DGtal/geometry/surfaces/estimation/VoronoiCovarianceMeasureOnDigitalSurface.ih
+++ b/src/DGtal/geometry/surfaces/estimation/VoronoiCovarianceMeasureOnDigitalSurface.ih
@@ -33,6 +33,7 @@
 #include "DGtal/math/ScalarFunctors.h"
 #include "DGtal/geometry/surfaces/estimation/LocalEstimatorFromSurfelFunctorAdapter.h"
 #include "DGtal/geometry/surfaces/estimation/estimationFunctors/ElementaryConvolutionNormalVectorEstimator.h"
+#include "DGtal/geometry/volumes/distance/LpMetric.h"
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -99,16 +100,17 @@ VoronoiCovarianceMeasureOnDigitalSurface( ConstAlias< Surface > _surface,
   if ( verbose ) trace.beginBlock ( "Computing average orientation for each surfel." );
   typedef functors::HatFunction<Scalar> Functor;
   Functor fct( 1.0, myRadiusTrivial );
+  LpMetric<Space> l2(2.0); //L2 metric in R^3 for surface propagation.
   typedef functors::ElementaryConvolutionNormalVectorEstimator< Surfel, CanonicSCellEmbedder<KSpace> > 
     SurfelFunctor;
-  typedef LocalEstimatorFromSurfelFunctorAdapter< DigitalSurfaceContainer, Metric, SurfelFunctor, Functor>
+  typedef LocalEstimatorFromSurfelFunctorAdapter< DigitalSurfaceContainer, LpMetric<Space>, SurfelFunctor, Functor>
     NormalEstimator;
 
   CanonicSCellEmbedder<KSpace> canonic_embedder( ks );
   SurfelFunctor surfelFct( canonic_embedder, 1.0 );
   NormalEstimator estimator;
   estimator.attach( *mySurface);
-  estimator.setParams( aMetric, surfelFct, fct , myRadiusTrivial);
+  estimator.setParams( l2, surfelFct, fct , myRadiusTrivial);
   estimator.init( 1.0,  mySurface->begin(), mySurface->end());
   i = 0; 
   std::vector<Point> pts; 

--- a/src/DGtal/geometry/volumes/distance/CMetricSpace.h
+++ b/src/DGtal/geometry/volumes/distance/CMetricSpace.h
@@ -114,7 +114,7 @@ squares of Point::Coordiante values.
 
 ### Models
 
-ExactPredicateLpSeparableMetric, InexactPredicateLpSeparableMetric.
+LpMetric, ExactPredicateLpSeparableMetric, InexactPredicateLpSeparableMetric.
 
 ### Notes
 

--- a/src/DGtal/geometry/volumes/distance/LpMetric.h
+++ b/src/DGtal/geometry/volumes/distance/LpMetric.h
@@ -183,7 +183,7 @@ namespace DGtal
       if (dfirst < dsecond)
         return ClosestFIRST;
       else
-        if (dfirst>dsecond)
+        if (dfirst > dsecond)
           return ClosestSECOND;
       
       return ClosestBOTH;

--- a/src/DGtal/geometry/volumes/distance/LpMetric.h
+++ b/src/DGtal/geometry/volumes/distance/LpMetric.h
@@ -23,7 +23,6 @@
  *
  * @date 2019/27/01
  *
- * Header file for module LpMetric.cpp
  *
  * This file is part of the DGtal library.
  */

--- a/src/DGtal/geometry/volumes/distance/LpMetric.h
+++ b/src/DGtal/geometry/volumes/distance/LpMetric.h
@@ -97,7 +97,7 @@ namespace DGtal
       /**
      * Constructor.
      *
-     * @param anExponent the exponent (p) of the lp metric.
+     * @param anExponent the exponent (@a p) of the lp metric.
      */
     LpMetric( const double anExponent): myExponent(anExponent)
     {}

--- a/src/DGtal/geometry/volumes/distance/LpMetric.h
+++ b/src/DGtal/geometry/volumes/distance/LpMetric.h
@@ -216,7 +216,11 @@ namespace DGtal
    */
   template <typename T>
   std::ostream&
-  operator<< ( std::ostream & out, const LpMetric<T> & object );
+  operator<< ( std::ostream & out, const LpMetric<T> & object )
+  {
+    object.selfDisplay( out );
+    return out;
+  }
 
 } // namespace DGtal
 

--- a/src/DGtal/geometry/volumes/distance/LpMetric.h
+++ b/src/DGtal/geometry/volumes/distance/LpMetric.h
@@ -88,13 +88,6 @@ namespace DGtal
     typedef double RawValue;
     
     /**
-     * Default Constructor (p=2.0)
-     *
-     */
-    LpMetric(): myExponent(2.0) {}
-    
-
-      /**
      * Constructor.
      *
      * @param anExponent the exponent (@a p) of the lp metric.
@@ -158,8 +151,8 @@ namespace DGtal
     {
       RawValue tmp=0.0;
       for(auto i = 0; i < aP.size(); ++i)
-        tmp += std::pow(NumberTraits<typename Point::Coordinate>::castToDouble(std::abs(aP[i] - aQ[i])),
-                        myExponent);
+        tmp += static_cast<RawValue>(std::pow(NumberTraits<typename Point::Coordinate>::castToDouble(std::abs(aP[i] - aQ[i])),
+                                              myExponent));
       return tmp;
     }
 

--- a/src/DGtal/geometry/volumes/distance/LpMetric.h
+++ b/src/DGtal/geometry/volumes/distance/LpMetric.h
@@ -55,7 +55,7 @@ namespace DGtal
  * Description of template class 'LpMetric' <p>
  * \brief Aim: implements  l_p metrics.
  *
- * Given a parameter p, the class implement classical l_p
+ * Given a parameter p, the class implements classical l_p
  * metric as a model of CMetricSpace. Hence, given two points
  * @f$ x=(x_0...x_{n-1})@f$, @f$ y=(y_0...y_{n-1})@f$, we define a metric as:
  *
@@ -156,7 +156,7 @@ namespace DGtal
      */
     RawValue rawDistance(const Point & aP, const Point &aQ) const
     {
-      double tmp=0.0;
+      RawValue tmp=0.0;
       for(auto i = 0; i < aP.size(); ++i)
         tmp += std::pow(NumberTraits<typename Point::Coordinate>::castToDouble(std::abs(aP[i] - aQ[i])),
                         myExponent);

--- a/src/DGtal/geometry/volumes/distance/LpMetric.h
+++ b/src/DGtal/geometry/volumes/distance/LpMetric.h
@@ -150,7 +150,7 @@ namespace DGtal
     RawValue rawDistance(const Point & aP, const Point &aQ) const
     {
       RawValue tmp=0.0;
-      for(auto i = 0; i < aP.size(); ++i)
+      for(typename Point::Dimension i = 0; i < aP.size(); ++i)
         tmp += static_cast<RawValue>(std::pow(NumberTraits<typename Point::Coordinate>::castToDouble(std::abs(aP[i] - aQ[i])),
                                               myExponent));
       return tmp;

--- a/src/DGtal/geometry/volumes/distance/LpMetric.h
+++ b/src/DGtal/geometry/volumes/distance/LpMetric.h
@@ -1,0 +1,237 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+#pragma once
+
+/**
+ * @file LpMetric.h
+ * @author David Coeurjolly (\c david.coeurjolly@liris.cnrs.fr )
+ * Laboratoire d'InfoRmatique en Image et Systèmes d'information - LIRIS (CNRS, UMR 5205), CNRS, France
+ *
+ * @date 2019/27/01
+ *
+ * Header file for module LpMetric.cpp
+ *
+ * This file is part of the DGtal library.
+ */
+
+#if defined(LpMetric_RECURSES)
+#error Recursive header files inclusion detected in LpMetric.h
+#else // defined(LpMetric_RECURSES)
+/** Prevents recursive inclusion of headers. */
+#define LpMetric_RECURSES
+
+#if !defined LpMetric_h
+/** Prevents repeated inclusion of headers. */
+#define LpMetric_h
+
+//////////////////////////////////////////////////////////////////////////////
+// Inclusions
+#include <iostream>
+#include <cmath>
+#include "DGtal/base/Common.h"
+#include "DGtal/kernel/CSpace.h"
+#include "DGtal/kernel/CEuclideanRing.h"
+//////////////////////////////////////////////////////////////////////////////
+
+namespace DGtal
+{
+
+/////////////////////////////////////////////////////////////////////////////
+// template class LpMetric
+/**
+ * Description of template class 'LpMetric' <p>
+ * \brief Aim: implements  l_p metrics.
+ *
+ * Given a parameter p, the class implement classical l_p
+ * metric as a model of CMetricSpace. Hence, given two points
+ * @f$ x=(x_0...x_{n-1})@f$, @f$ y=(y_0...y_{n-1})@f$, we define a metric as:
+ *
+ * @f$ distance(x,y)= \left(
+ * \sum_{i=0}^{n-1} |x_i-y_i|^p\right)^{1/p}@f$
+ *
+ * This class performs all computations on C++ double converting the digital
+ * points to Space::RealPoint
+ *
+ * The exponent @a p is specifed at the constructor.
+ *
+ * @tparam TSpace the model of CSpace on which the metric is
+ * defined.
+ */
+  template <typename TSpace>
+  class LpMetric
+  {
+    // ----------------------- Standard services ------------------------------
+  public:
+
+    ///Copy the space type
+    typedef TSpace Space;
+    BOOST_CONCEPT_ASSERT(( concepts::CSpace<TSpace> ));
+    
+    ///Type for points (RealPoint for this class)
+    typedef typename Space::RealPoint Point;
+    ///Type for distance values
+    typedef double Value;
+    ///Type for raw distance values
+    typedef double RawValue;
+    
+    /**
+     * Default Constructor (p=2.0)
+     *
+     */
+    LpMetric(): myExponent(2.0) {}
+    
+
+      /**
+     * Constructor.
+     *
+     * @param anExponent the exponent (p) of the lp metric.
+     */
+    LpMetric( const double anExponent): myExponent(anExponent)
+    {}
+
+
+    /**
+     * Destructor.
+     */
+    ~LpMetric()
+    {}
+
+    /**
+     * Copy constructor.
+     * @param other the object to clone.
+     */
+    LpMetric ( const LpMetric & other )
+    {
+      myExponent = other.myExponent;
+    }
+
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     */
+    LpMetric & operator= ( const LpMetric & other )
+    {
+      myExponent = other.myExponent;
+      return *this;
+    }
+
+    // ----------------------- Interface --------------------------------------
+  public:
+
+    // ----------------------- CMetric --------------------------------------
+    /**
+     * Compute the distance between @a aP and @a aQ.
+     *
+     * @param aP a first point.
+     * @param aQ a second point.
+     *
+     * @return the distance between aP and aQ.
+     */
+    Value operator()(const Point & aP, const Point &aQ) const
+    {
+      return std::pow( rawDistance(aP,aQ), 1.0/myExponent);
+    }
+
+    /**
+     * Compute the raw distance between @a aP and @a aQ.
+     *
+     * @param aP a first point.
+     * @param aQ a second point.
+     *
+     * @return the distance between aP and aQ.
+     */
+    RawValue rawDistance(const Point & aP, const Point &aQ) const
+    {
+      double tmp=0.0;
+      for(auto i = 0; i < aP.size(); ++i)
+        tmp += std::pow(NumberTraits<typename Point::Coordinate>::castToDouble(std::abs(aP[i] - aQ[i])),
+                        myExponent);
+      return tmp;
+    }
+
+    /**
+     * Given an origin and two points, this method decides which one
+     * is closest to the origin. This method should be faster than
+     * comparing distance values.
+     *
+     * @param origin the origin
+     * @param first  the first point
+     * @param second the second point
+     *
+     * @return a Closest enum: FIRST, SECOND or BOTH.
+     */
+    Closest closest(const Point &origin,
+                    const Point &first,
+                    const Point &second) const
+    {
+      auto dfirst = rawDistance(origin,first);
+      auto dsecond = rawDistance(origin,second);
+      if (dfirst < dsecond)
+        return ClosestFIRST;
+      else
+        if (dfirst>dsecond)
+          return ClosestSECOND;
+      
+      return ClosestBOTH;
+    }
+
+    /**
+     * Writes/Displays the object on an output stream.
+     * @param out the output stream where the object is written.
+     */
+    void selfDisplay ( std::ostream & out ) const
+    {
+      out << "[LpMetric] Lp Metric exponent=" << myExponent ;
+    }
+
+    /**
+     * Checks the validity/consistency of the object.
+     * @return 'true' if the object is valid, 'false' otherwise.
+     */
+    bool isValid() const
+    {
+      return true;
+    }
+ 
+    // ------------------------- Private Datas --------------------------------
+  private:
+
+    ///Exponent value
+    Value myExponent;
+
+  }; // end of class LpMetric
+
+  /**
+   * Overloads 'operator<<' for displaying objects of class 'LpMetric'.
+   * @param out the output stream where the object is written.
+   * @param object the object of class 'LpMetric' to write.
+   * @return the output stream after the writing.
+   */
+  template <typename T>
+  std::ostream&
+  operator<< ( std::ostream & out, const LpMetric<T> & object );
+
+} // namespace DGtal
+
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#endif // !defined LpMetric_h
+
+#undef LpMetric_RECURSES
+#endif // else defined(LpMetric_RECURSES)

--- a/tests/geometry/surfaces/testLocalEstimatorFromFunctorAdapter.cpp
+++ b/tests/geometry/surfaces/testLocalEstimatorFromFunctorAdapter.cpp
@@ -138,7 +138,7 @@ bool testLocalEstimatorFromFunctorAdapter()
   typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>,
                                                  Functor, DGtal::functors::GaussianKernel> ReporterGaussian;
 
-  LpMetric<Z3i::Space> l2;
+  LpMetric<Z3i::Space> l2(2.0);
   CanonicSCellEmbedder<KSpace> embedder(surface.container().space());
   Functor estimator(embedder, 1);
 

--- a/tests/geometry/surfaces/testLocalEstimatorFromFunctorAdapter.cpp
+++ b/tests/geometry/surfaces/testLocalEstimatorFromFunctorAdapter.cpp
@@ -41,7 +41,7 @@
 #include "DGtal/kernel/CanonicEmbedder.h"
 #include "DGtal/topology/CanonicSCellEmbedder.h"
 #include "DGtal/graph/DistanceBreadthFirstVisitor.h"
-#include "DGtal/geometry/volumes/distance/ExactPredicateLpSeparableMetric.h"
+#include "DGtal/geometry/volumes/distance/LpMetric.h"
 #include "DGtal/geometry/surfaces/estimation/LocalEstimatorFromSurfelFunctorAdapter.h"
 #include "DGtal/geometry/surfaces/estimation/estimationFunctors/BasicEstimatorFromSurfelsFunctors.h"
 #include "DGtal/geometry/surfaces/estimation/estimationFunctors/CLocalEstimatorFromSurfelFunctor.h"
@@ -132,25 +132,26 @@ bool testLocalEstimatorFromFunctorAdapter()
   trace.beginBlock("Creating  adapter");
   typedef DGtal::functors::DummyEstimatorFromSurfels<Surfel, CanonicSCellEmbedder<KSpace> > Functor;
   typedef DGtal::functors::ConstValue< double > ConvFunctor;
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric, 
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>,
                                                  Functor, ConvFunctor> Reporter;
 
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric, 
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>,
                                                  Functor, DGtal::functors::GaussianKernel> ReporterGaussian;
 
+  LpMetric<Z3i::Space> l2;
   CanonicSCellEmbedder<KSpace> embedder(surface.container().space());
   Functor estimator(embedder, 1);
 
   ConvFunctor convFunc(1.0);
-  Reporter reporter;//(surface,l2Metric,estimator,convFunc);
+  Reporter reporter;
   reporter.attach(surface);
-  reporter.setParams(l2Metric,estimator,convFunc, 5);
+  reporter.setParams(l2,estimator,convFunc, 5);
 
   //We just test the init for Gaussian
   DGtal::functors::GaussianKernel gaussKernelFunc(1.0);
   ReporterGaussian reporterGaussian;
   reporterGaussian.attach(surface);
-  reporterGaussian.setParams(l2Metric,estimator,gaussKernelFunc, 5.0);
+  reporterGaussian.setParams(l2,estimator,gaussKernelFunc, 5.0);
   reporterGaussian.init(1, surface.begin(), surface.end());
 
   reporter.init(1.0, surface.begin(), surface.end());
@@ -159,7 +160,7 @@ bool testLocalEstimatorFromFunctorAdapter()
   nbok += ((fabs((double)val - 124.0)) < 40) ? 1 : 0;
   nb++;
 
-  reporter.setParams(l2Metric,estimator,convFunc, 20.0);
+  reporter.setParams(l2,estimator,convFunc, 20.0);
   reporter.init(1, surface.begin(), surface.end());
   Functor::Quantity val2 = reporter.eval( surface.begin() );
   trace.info() <<  "Value with radius 20= "<<val2 << std::endl;

--- a/tests/geometry/surfaces/testSphericalHoughNormalVectorEstimator.cpp
+++ b/tests/geometry/surfaces/testSphericalHoughNormalVectorEstimator.cpp
@@ -40,7 +40,7 @@
 #include "DGtal/topology/DigitalSurface.h"
 #include "DGtal/topology/CanonicSCellEmbedder.h"
 #include "DGtal/base/BasicFunctors.h"
-
+#include "DGtal/geometry/volumes/distance/LpMetric.h"
 #include "DGtal/geometry/surfaces/estimation/LocalEstimatorFromSurfelFunctorAdapter.h"
 #include "DGtal/geometry/surfaces/estimation/estimationFunctors/SphericalHoughNormalVectorEstimator.h"
 
@@ -89,15 +89,16 @@ TEST_CASE( "Testing SphericalHoughNormalVectorEstimator" )
   
   typedef functors::SphericalHoughNormalVectorEstimator<Surfel, CanonicSCellEmbedder<KSpace> > SphericalHough;
   typedef functors::ConstValue<double> ConstFunctor;
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric, SphericalHough, ConstFunctor> Reporter;
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>, SphericalHough, ConstFunctor> Reporter;
   
   CanonicSCellEmbedder<KSpace> embedder(surface.container().space());
   SphericalHough estimator(embedder,1.0 , 0.001, 1000 , 10, 1);
   
+  LpMetric<Z3i::Space> l2;
   ConstFunctor constFunc(1.0);
-  Reporter reporter(surface, l2Metric, estimator , constFunc);
+  Reporter reporter(surface, l2, estimator , constFunc);
   reporter.attach(surface);
-  reporter.setParams(l2Metric, estimator , constFunc, 10.0);
+  reporter.setParams(l2, estimator , constFunc, 10.0);
   reporter.init(1, surface.begin(),surface.end());
 
   REQUIRE( reporter.isValid() );

--- a/tests/geometry/surfaces/testSphericalHoughNormalVectorEstimator.cpp
+++ b/tests/geometry/surfaces/testSphericalHoughNormalVectorEstimator.cpp
@@ -94,7 +94,7 @@ TEST_CASE( "Testing SphericalHoughNormalVectorEstimator" )
   CanonicSCellEmbedder<KSpace> embedder(surface.container().space());
   SphericalHough estimator(embedder,1.0 , 0.001, 1000 , 10, 1);
   
-  LpMetric<Z3i::Space> l2;
+  LpMetric<Z3i::Space> l2(2.0);
   ConstFunctor constFunc(1.0);
   Reporter reporter(surface, l2, estimator , constFunc);
   reporter.attach(surface);

--- a/tests/geometry/surfaces/testTensorVoting.cpp
+++ b/tests/geometry/surfaces/testTensorVoting.cpp
@@ -39,7 +39,7 @@
 #include "DGtal/shapes/Shapes.h"
 #include "DGtal/topology/CanonicSCellEmbedder.h"
 #include "DGtal/graph/DistanceBreadthFirstVisitor.h"
-#include "DGtal/geometry/volumes/distance/ExactPredicateLpSeparableMetric.h"
+#include "DGtal/geometry/volumes/distance/LpMetric.h"
 #include "DGtal/geometry/surfaces/estimation/LocalEstimatorFromSurfelFunctorAdapter.h"
 #include "DGtal/geometry/surfaces/estimation/estimationFunctors/BasicEstimatorFromSurfelsFunctors.h"
 #include "DGtal/topology/LightImplicitDigitalSurface.h"
@@ -103,7 +103,7 @@ bool testLocalEstimatorFromFunctorAdapter()
   typedef functors::TensorVotingFeatureExtraction<Surfel, CanonicSCellEmbedder<KSpace> > FunctorVoting;
 
   typedef functors::GaussianKernel ConvFunctor;
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric, FunctorVoting, ConvFunctor> Reporter;
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>, FunctorVoting, ConvFunctor> Reporter;
 
   CanonicSCellEmbedder<KSpace> embedder(surface.container().space());
   FunctorVoting estimator(embedder,1);
@@ -111,7 +111,8 @@ bool testLocalEstimatorFromFunctorAdapter()
   ConvFunctor convFunc(1.0);
   Reporter reporter;
   reporter.attach(surface);
-  reporter.setParams(l2Metric, estimator , convFunc, 2.0);
+  LpMetric<Z3i::Space> l2double;
+  reporter.setParams(l2double, estimator , convFunc, 2.0);
 
   reporter.init(1, surface.begin(), surface.end());
 

--- a/tests/geometry/surfaces/testTensorVoting.cpp
+++ b/tests/geometry/surfaces/testTensorVoting.cpp
@@ -111,7 +111,7 @@ bool testLocalEstimatorFromFunctorAdapter()
   ConvFunctor convFunc(1.0);
   Reporter reporter;
   reporter.attach(surface);
-  LpMetric<Z3i::Space> l2double;
+  LpMetric<Z3i::Space> l2double(2.0);
   reporter.setParams(l2double, estimator , convFunc, 2.0);
 
   reporter.init(1, surface.begin(), surface.end());

--- a/tests/geometry/surfaces/testTensorVoting.cpp
+++ b/tests/geometry/surfaces/testTensorVoting.cpp
@@ -175,15 +175,17 @@ bool testCube()
   typedef functors::TensorVotingFeatureExtraction<Surfel, CanonicSCellEmbedder<KSpace> > FunctorVoting;
 
   typedef functors::GaussianKernel ConvFunctor;
-  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, Z3i::L2Metric, FunctorVoting, ConvFunctor> Reporter;
+  typedef LocalEstimatorFromSurfelFunctorAdapter<SurfaceContainer, LpMetric<Z3i::Space>, FunctorVoting, ConvFunctor> Reporter;
 
   CanonicSCellEmbedder<KSpace> embedder(surface.container().space());
   FunctorVoting estimator(embedder,1);
-
+  
+  LpMetric<Z3i::Space> l2(2.0);
+  
   ConvFunctor convFunc(1.0);
-  Reporter reporter(surface, l2Metric, estimator , convFunc);
+  Reporter reporter(surface, l2, estimator , convFunc);
   reporter.attach(surface);
-  reporter.setParams(l2Metric, estimator , convFunc, 2.0);
+  reporter.setParams(l2, estimator , convFunc, 2.0);
   reporter.init(1, surface.begin(),surface.end());
   trace.endBlock();
 

--- a/tests/geometry/volumes/distance/CMakeLists.txt
+++ b/tests/geometry/volumes/distance/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(DGTAL_TESTS_SRC
   testChamferDT
   testChamferVoro
   testDigitalMetricAdapter
+  testLpMetric
   )
 
 
@@ -21,7 +22,7 @@ FOREACH(FILE ${DGTAL_TESTS_SRC})
   target_link_libraries (${FILE} DGtal)
   add_test(${FILE} ${FILE})
 ENDFOREACH(FILE)
- 
+
 SET(DGTAL_BENCH_SRC
   testMetrics-benchmark
   )
@@ -35,4 +36,3 @@ IF(BUILD_BENCHMARKS)
     ADD_DEPENDENCIES(benchmark ${FILE}-benchmark)
   ENDFOREACH(FILE)
 ENDIF(BUILD_BENCHMARKS)
-

--- a/tests/geometry/volumes/distance/testLpMetric.cpp
+++ b/tests/geometry/volumes/distance/testLpMetric.cpp
@@ -53,10 +53,10 @@ TEST_CASE( "Testing LpMetric" )
   LpMetric<Z2i::Space> l55_2D(5.5);
   Z2i::Space::RealPoint a(0,0), b(1.0,1.0), c(0.5,0.5);
   Z3i::Space::RealPoint aa(0,0,0), bb(1.0,1.0,1.0);
-  trace.info() << l55_2D << std::endl;
   
   SECTION("Testing LpMetric distance values")
     {
+      CAPTURE( l55_2D) ;
       REQUIRE( l2_2D.rawDistance(a,b) == Approx(2.0) );
       REQUIRE( l2_3D.rawDistance(aa,bb) == Approx(3.0) );
       REQUIRE( l2_2D(a,b) == Approx(std::sqrt(2.0)) );

--- a/tests/geometry/volumes/distance/testLpMetric.cpp
+++ b/tests/geometry/volumes/distance/testLpMetric.cpp
@@ -53,6 +53,7 @@ TEST_CASE( "Testing LpMetric" )
   LpMetric<Z2i::Space> l55_2D(5.5);
   Z2i::Space::RealPoint a(0,0), b(1.0,1.0), c(0.5,0.5);
   Z3i::Space::RealPoint aa(0,0,0), bb(1.0,1.0,1.0);
+  trace.info() << l55_2D << std::endl;
   
   SECTION("Testing LpMetric distance values")
     {

--- a/tests/geometry/volumes/distance/testLpMetric.cpp
+++ b/tests/geometry/volumes/distance/testLpMetric.cpp
@@ -1,0 +1,67 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file
+ * @ingroup Tests
+ * @author David Coeurjolly (\c david.coeurjolly@liris.cnrs.fr )
+ * Laboratoire d'InfoRmatique en Image et Systemes d'information - LIRIS (CNRS, UMR 5205), CNRS, France
+ *
+ * @date 2019/01/27
+ *
+ * Functions for testing class LpMetric.
+ *
+ * This file is part of the DGtal library.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+#include <iostream>
+#include "DGtal/base/Common.h"
+#include "ConfigTest.h"
+#include "DGtalCatch.h"
+#include "DGtal/helpers/StdDefs.h"
+#include "DGtal/geometry/volumes/distance/LpMetric.h"
+#include "DGtal/geometry/volumes/distance/CMetricSpace.h"
+///////////////////////////////////////////////////////////////////////////////
+
+using namespace std;
+using namespace DGtal;
+
+///////////////////////////////////////////////////////////////////////////////
+// Functions for testing class LpMetric.
+///////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE( "Testing LpMetric" )
+{
+  
+  BOOST_CONCEPT_ASSERT(( concepts::CMetricSpace<LpMetric<Z2i::Space>> ));
+
+  LpMetric<Z2i::Space> l2_2D(2.0);
+  LpMetric<Z3i::Space> l2_3D(2.0);
+  LpMetric<Z2i::Space> l55_2D(5.5);
+  Z2i::Space::RealPoint a(0,0), b(1.0,1.0);
+  Z3i::Space::RealPoint aa(0,0,0), bb(1.0,1.0,1.0);
+  
+  SECTION("Testing LpMetric distance values")
+    {
+      REQUIRE( l2_2D.rawDistance(a,b) == Approx(2.0) );
+      REQUIRE( l2_3D.rawDistance(aa,bb) == Approx(3.0) );
+      REQUIRE( l2_2D(a,b) == Approx(std::sqrt(2.0)) );
+      REQUIRE( l55_2D(a,b) == Approx(1.1343125));
+    }
+}
+
+/** @ingroup Tests **/

--- a/tests/geometry/volumes/distance/testLpMetric.cpp
+++ b/tests/geometry/volumes/distance/testLpMetric.cpp
@@ -43,7 +43,6 @@ using namespace DGtal;
 ///////////////////////////////////////////////////////////////////////////////
 // Functions for testing class LpMetric.
 ///////////////////////////////////////////////////////////////////////////////
-
 TEST_CASE( "Testing LpMetric" )
 {
   
@@ -52,7 +51,7 @@ TEST_CASE( "Testing LpMetric" )
   LpMetric<Z2i::Space> l2_2D(2.0);
   LpMetric<Z3i::Space> l2_3D(2.0);
   LpMetric<Z2i::Space> l55_2D(5.5);
-  Z2i::Space::RealPoint a(0,0), b(1.0,1.0);
+  Z2i::Space::RealPoint a(0,0), b(1.0,1.0), c(0.5,0.5);
   Z3i::Space::RealPoint aa(0,0,0), bb(1.0,1.0,1.0);
   
   SECTION("Testing LpMetric distance values")
@@ -60,7 +59,9 @@ TEST_CASE( "Testing LpMetric" )
       REQUIRE( l2_2D.rawDistance(a,b) == Approx(2.0) );
       REQUIRE( l2_3D.rawDistance(aa,bb) == Approx(3.0) );
       REQUIRE( l2_2D(a,b) == Approx(std::sqrt(2.0)) );
-      REQUIRE( l55_2D(a,b) == Approx(1.1343125));
+      REQUIRE( l55_2D(a,b) == Approx(1.1343125) );
+      REQUIRE( l2_2D.closest(a,c,b) == DGtal::ClosestFIRST );
+      REQUIRE( l2_2D.closest(c,a,b) == DGtal::ClosestBOTH );
     }
 }
 


### PR DESCRIPTION
# PR Description

This PR introduces a generic LpMetric class on double (to fix Point<->RealPoint implicit casts when considering the distance between two (integer) Points).

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)