### PR TITLE
Remove VoxelComplex operators from namespace functions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -134,6 +134,9 @@
     testParDirCollapse. (Jacques-Olivier Lachaud,
     [#1390](https://github.com/DGtal-team/DGtal/pull/1390))
 
+  - Move operators outside of functions namespace in VoxelComplexFunctions.
+    (Pablo Hernandez, [#1392](https://github.com/DGtal-team/DGtal/pull/1392))
+
 - *Miscellaneous*
   - Fix Small bug in Integral Invariant Volume Estimator in 2D
     (Thomas Caissard, [#1316](https://github.com/DGtal-team/DGtal/pull/1316))

--- a/src/DGtal/topology/VoxelComplex.h
+++ b/src/DGtal/topology/VoxelComplex.h
@@ -50,7 +50,7 @@ namespace DGtal {
 // Forward definitions.
 template <typename TKSpace, typename TCellContainer>
 class VoxelComplex;
-namespace functions {
+
 template <typename TKSpace, typename TCellContainer>
 VoxelComplex<TKSpace, TCellContainer> &
 operator-=(VoxelComplex<TKSpace, TCellContainer> &,
@@ -60,7 +60,6 @@ VoxelComplex<TKSpace, TCellContainer>
 operator-(const VoxelComplex<TKSpace, TCellContainer> &,
           const VoxelComplex<TKSpace, TCellContainer> &);
 
-} // namespace functions
   /////////////////////////////////////////////////////////////////////////////
   // template class VoxelComplex
   /**
@@ -94,8 +93,8 @@ class VoxelComplex : public CubicalComplex<TKSpace, TCellContainer> {
     /** Type of this instance of VoxelComplex. */
     using Self = VoxelComplex<TKSpace, TCellContainer>;
 
-    friend Self &DGtal::functions::operator-=<>(Self &, const Self &);
-    friend Self DGtal::functions::operator-<>(const Self &, const Self &);
+    friend Self &DGtal::operator-=<>(Self &, const Self &);
+    friend Self DGtal::operator-<>(const Self &, const Self &);
     // ----------------------- associated types ------------------------------
     /** Type of the parent class CubicalComplex. */
     using Parent = CubicalComplex<TKSpace, TCellContainer>;

--- a/src/DGtal/topology/VoxelComplexFunctions.h
+++ b/src/DGtal/topology/VoxelComplexFunctions.h
@@ -365,55 +365,55 @@ namespace DGtal
     template <typename TObject >
     std::vector< TObject >
     connectedComponents(const TObject & input_obj, bool verbose);
-
+  } // namespace functions
 
 //////////////////////////////////////////////////////////////////////////////
-//Operators between VoxelComplexes//
+  //Operators between VoxelComplexes//
 
-    /**
-     * Voxel Complex difference operation. Updates the voxel complex S1 as S1 - S2.
-     * @tparam TKSpace the digital space in which lives the voxel complex.
-     * @tparam TCellContainer the associative container used to store cells within the voxel complex.
-     *
-     * @param[in,out] S1 an input voxel complex, \a S1 - \a S2 as output.
-     * @param[in] S2 another input voxel complex.
-     *
-     * @return a reference to the modified voxel complex S1.
-     */
-    template <typename TKSpace, typename TCellContainer>
+  /**
+   * Voxel Complex difference operation. Updates the voxel complex S1 as S1 - S2.
+   * @tparam TKSpace the digital space in which lives the voxel complex.
+   * @tparam TCellContainer the associative container used to store cells within
+   * the voxel complex.
+   *
+   * @param[in,out] S1 an input voxel complex, \a S1 - \a S2 as output.
+   * @param[in] S2 another input voxel complex.
+   *
+   * @return a reference to the modified voxel complex S1.
+   */
+  template <typename TKSpace, typename TCellContainer>
     inline VoxelComplex< TKSpace, TCellContainer >&
     operator-=( VoxelComplex< TKSpace, TCellContainer >& S1,
-                const VoxelComplex< TKSpace, TCellContainer >& S2 )
+        const VoxelComplex< TKSpace, TCellContainer >& S2 )
     {
       typedef VoxelComplex< TKSpace, TCellContainer > VC;
       for ( Dimension i = 0; i <= VC::dimension; ++i )
-        setops::operator-=( S1.myCells[ i ],S2.myCells[ i ] );
+        functions::setops::operator-=( S1.myCells[ i ],S2.myCells[ i ] );
       return S1;
     }
 
-    /**
-     * Voxel Complex difference operation. Returns the difference of \a S1 - \a S2.
-     * @tparam TKSpace the digital space in which lives the voxel complex.
-     * @tparam TCellContainer the associative container used to store cells within the voxel complex.
-     *
-     * @param[in] S1 an input voxel complex
-     * @param[in] S2 another input voxel complex.
-     *
-     * @return the voxel complex \a S1 - \a S2.
-     */
-    template <typename TKSpace, typename TCellContainer>
+  /**
+   * Voxel Complex difference operation. Returns the difference of \a S1 - \a S2.
+   * @tparam TKSpace the digital space in which lives the voxel complex.
+   * @tparam TCellContainer the associative container used to store cells within
+   * the voxel complex.
+   *
+   * @param[in] S1 an input voxel complex
+   * @param[in] S2 another input voxel complex.
+   *
+   * @return the voxel complex \a S1 - \a S2.
+   */
+  template <typename TKSpace, typename TCellContainer>
     inline VoxelComplex< TKSpace, TCellContainer >
     operator-( const VoxelComplex< TKSpace, TCellContainer >& S1,
-               const VoxelComplex< TKSpace, TCellContainer >& S2 )
+        const VoxelComplex< TKSpace, TCellContainer >& S2 )
     {
       typedef VoxelComplex< TKSpace, TCellContainer > VC;
       VC S(S1);
       for ( Dimension i = 0; i <= VC::dimension; ++i )
-        setops::operator-=( S.myCells[ i ],S2.myCells[ i ] );
+        functions::setops::operator-=( S.myCells[ i ],S2.myCells[ i ] );
       return S;
     }
-
-  } // namespace functions
 } // namespace DGtal
 
 

--- a/tests/topology/testVoxelComplex.cpp
+++ b/tests/topology/testVoxelComplex.cpp
@@ -545,7 +545,6 @@ TEST_CASE_METHOD(Fixture_complex_fig4, "zeroSurface and oneSurface",
                  "[isSurface][function]") {
     auto &vc = complex_fixture;
     using namespace DGtal::functions;
-    using Point = FixtureComplex::Point;
     vc.clear();
     Point c(0, 0, 0);
     {


### PR DESCRIPTION
Follows #1390

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)