### PR TITLE
Allow to use ITK < 4.13

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -78,6 +78,7 @@
 - *IO*
   - Improve ITKReader, testITKio and testITKReader (Boris Mansencal,
     [#1379](https://github.com/DGtal-team/DGtal/pull/1379))
+    [#1394](https://github.com/DGtal-team/DGtal/pull/1394))
   - Fix wrong typedef for double case in ITKReader (Adrien Krähenbühl,
     [#1259](https://github.com/DGtal-team/DGtal/pull/1322))
   - Fix safeguard when using ImageMagick without cmake activation (David Coeurjolly,

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -108,6 +108,7 @@ namespace DGtal {
       typedef ImageContainerByITKImage<Domain, long> DGtalITKImage;
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
+#if (ITK_VERSION_MAJOR > 4) || (ITK_VERSION_MAJOR == 4 && ITK_VERSION_MINOR >= 13)
     case itk::ImageIOBase::ULONGLONG:
     {
       typedef ImageContainerByITKImage<Domain, unsigned long long> DGtalITKImage;
@@ -118,6 +119,7 @@ namespace DGtal {
       typedef ImageContainerByITKImage<Domain, long long> DGtalITKImage;
       return readDGtalImageFromITKtypes<DGtalITKImage>( filename, aFunctor );
     }
+#endif
     case itk::ImageIOBase::FLOAT:
     {
       typedef ImageContainerByITKImage<Domain, float> DGtalITKImage;


### PR DESCRIPTION
# PR Description

This small change allows to still compile with ITK version < 4.13.
Changes by my previous PR #1379 forced to used ITK 4.13 or 5.x.

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
