### PR TITLE
Fix double conversion

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,14 @@
+# DGtal 1.0.1
+
+## Bug Fixes
+
+- *Helpers*
+
+  - Fixing double conversion bug in class Parameters, related to
+    english/french decimal point inconsistency between atof and
+    boost::program_options (Jacques-Olivier Lachaud,
+    [#1411](https://github.com/DGtal-team/DGtal/pull/1411))
+
 
 # DGtal 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 - *Helpers*
 
   - Fixing double conversion bug in class Parameters, related to
-    english/french decimal point inconsistency between atof and
+    English/French decimal point inconsistency between `atof` and
     boost::program_options (Jacques-Olivier Lachaud,
     [#1411](https://github.com/DGtal-team/DGtal/pull/1411))
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
 
   - Fixing double conversion bug in class Parameters, related to
     English/French decimal point inconsistency between `atof` and
-    boost::program_options (Jacques-Olivier Lachaud,
+    `boost::program_options` (Jacques-Olivier Lachaud,
     [#1411](https://github.com/DGtal-team/DGtal/pull/1411))
 
 

--- a/src/DGtal/helpers/Parameters.h
+++ b/src/DGtal/helpers/Parameters.h
@@ -66,21 +66,39 @@ namespace DGtal
     template <>
       struct ValueConverter< std::string, double >{
       static double cast( const std::string& value )
-      { return atof( value.c_str() ); }
+      {
+        // note (JOL): cannot use atof (C) since it uses a different locale as program_options (C++).
+        double val;
+        std::istringstream iss( value );
+        iss >> val;
+        return val;
+      }
     };
     
     /// Specialized definitions of a class for converting type X toward type Y.
     template <>
       struct ValueConverter< std::string, float >{
       static float cast( const std::string& value )
-      { return (float) atof( value.c_str() ); }
+      {
+        // note (JOL): cannot use atof (C) since it uses a different locale as program_options (C++).
+        float val;
+        std::istringstream iss( value );
+        iss >> val;
+        return val;
+      }
     };
 
     /// Specialized definitions of a class for converting type X toward type Y.
     template <>
       struct ValueConverter< std::string, int >{
       static int cast( const std::string& value )
-      { return atoi( value.c_str() ); }
+      {
+        // note (JOL): cannot use atoi (C) since it uses a different locale as program_options (C++).
+        int val;
+        std::istringstream iss( value );
+        iss >> val;
+        return val;
+      }
     };
     /// Specialized definitions of a class for converting type X toward type Y.
     template < typename X >

--- a/tests/helpers/CMakeLists.txt
+++ b/tests/helpers/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(DGTAL_TESTS_SRC_HELPERS
   testParametricShape
   testImplicitShape
+  testParameters
   )
 
 FOREACH(FILE ${DGTAL_TESTS_SRC_HELPERS})

--- a/tests/helpers/testParameters.cpp
+++ b/tests/helpers/testParameters.cpp
@@ -1,0 +1,74 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file testParameters.cpp
+ * @ingroup Tests
+ * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr )
+ * Laboratory of Mathematics (CNRS, UMR 5127), University of Savoie, France
+ *
+ * @date 2019/05/14
+ *
+ * Functions for testing class CubicalComplex.
+ *
+ * This file is part of the DGtal library.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+#include <iostream>
+#include <string>
+#include "DGtal/base/Common.h"
+#include "DGtal/helpers/Parameters.h"
+
+#include "DGtalCatch.h"
+///////////////////////////////////////////////////////////////////////////////
+
+using namespace std;
+using namespace DGtal;
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Functions for testing class Parameters
+///////////////////////////////////////////////////////////////////////////////
+
+SCENARIO( "Parameters decimal conversion tests", "[parameters]" )
+{
+  GIVEN( "A Parameters object" ) {
+    Parameters params;
+    WHEN( "initialized with strings" ) {
+      params( "foo", "bar" )( "Laurel", "Hardy" );
+      THEN( "it does store strings" ) {
+        REQUIRE( params[ "foo"    ].as<string>() == "bar" );
+        REQUIRE( params[ "Laurel" ].as<string>() == "Hardy" );
+      }      
+    }
+    WHEN( "initialized with integers" ) {
+      params( "prime", 7 )( "negative-int", -2 );
+      THEN( "it does store ints" ) {
+        REQUIRE( params[ "prime"        ].as<int>() == 7 );
+        REQUIRE( params[ "negative-int" ].as<int>() == -2 );
+      }      
+    }
+    WHEN( "initialized with doubles" ) {
+      params( "pi", 3.14159 )( "planck", 6.62607004e-34 )( "g", 9.80665 );
+      THEN( "it does store ints" ) {
+        REQUIRE( params[ "pi"     ].as<double>() == Approx( 3.14159 ) );
+        REQUIRE( params[ "planck" ].as<double>() == Approx( 6.62607004e-34 ) );
+        REQUIRE( params[ "g"      ].as<double>() == Approx( 9.80665 ) );
+      }      
+    }
+  }
+}


### PR DESCRIPTION
# PR Description

atof (C) and boost::program_option (C++) use a different "locale" information to determine if the decimal point is a point '.' or a comma ','. Since we use boost::program_option for managing parameters, it is necessary to use C++ stringstream to perform string -> double conversions in class Parameters. This is fixed in this PR.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
