### PR TITLE
Removing std namespace in header

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,10 @@
     `boost::program_options` (Jacques-Olivier Lachaud,
     [#1411](https://github.com/DGtal-team/DGtal/pull/1411))
 
+- *IO*
+  - Removing a `using namespace std;` in the Viewer3D hearder file. (David
+    Coeurjolly [#XXXX](https://github.com/DGtal-team/DGtal/pull/1411))
+
 
 # DGtal 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,7 @@
 
 - *IO*
   - Removing a `using namespace std;` in the Viewer3D hearder file. (David
-    Coeurjolly [#XXXX](https://github.com/DGtal-team/DGtal/pull/1411))
+    Coeurjolly [#1413](https://github.com/DGtal-team/DGtal/pull/1413))
 
 
 # DGtal 1.0

--- a/examples/geometry/surfaces/exampleIntegralInvariantCurvature3D.cpp
+++ b/examples/geometry/surfaces/exampleIntegralInvariantCurvature3D.cpp
@@ -139,8 +139,8 @@ int main( int argc, char** argv )
     //! [IntegralInvariantUsage]
 
     /// Drawing results
-    Value min = numeric_limits < Value >::max();
-    Value max = numeric_limits < Value >::min();
+    Value min = std::numeric_limits < Value >::max();
+    Value max = std::numeric_limits < Value >::min();
     for ( unsigned int i = 0; i < results.size(); ++i )
     {
         if ( results[ i ] < min )

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -38,11 +38,6 @@
 #include "DGtal/io/viewers/windows/GL/glext.h"
 #endif
 
-//On macos, disabling GL deprecated
-#ifndef __linux__
-#define GL_SILENCE_DEPRECATION
-#endif
-
 #include "DGtal/io/viewers/Viewer3D.h"
 
 #include <algorithm> 

--- a/src/DGtal/io/viewers/Viewer3D.ih
+++ b/src/DGtal/io/viewers/Viewer3D.ih
@@ -38,6 +38,11 @@
 #include "DGtal/io/viewers/windows/GL/glext.h"
 #endif
 
+//On macos, disabling GL deprecated
+#ifndef __linux__
+#define GL_SILENCE_DEPRECATION
+#endif
+
 #include "DGtal/io/viewers/Viewer3D.h"
 
 #include <algorithm> 
@@ -56,7 +61,6 @@
 #include "QGLViewer/manipulatedCameraFrame.h"
 //////////////////////////////////////////////////////////////////////////////
 
-using namespace std;
 using namespace qglviewer;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -657,7 +661,7 @@ inline void DGtal::Viewer3D<TSpace, TKSpace>::draw()
   glLightfv(GL_LIGHT0, GL_POSITION, myLightPosition);  
   
   unsigned int i = 0;
-  typename vector<
+  typename std::vector<
   typename Viewer3D<TSpace, TKSpace>::ClippingPlaneD3D>::const_iterator it =
   Viewer3D<TSpace, TKSpace>::myClippingPlaneList.begin();
 
@@ -715,7 +719,7 @@ inline void DGtal::Viewer3D<TSpace, TKSpace>::draw()
       if ( Viewer3D<TSpace, TKSpace>::myLineSetList.at( j ).size() != 0 )
       {
         glLineWidth(
-        max( myGLLineMinWidth,
+        std::max( myGLLineMinWidth,
              Viewer3D<TSpace, TKSpace>::myLineSetList.at( j ).at( 0 ).width ) );
         }
       glCallList(myLineSetListId+j);
@@ -732,7 +736,7 @@ inline void DGtal::Viewer3D<TSpace, TKSpace>::draw()
     {
       if ( Viewer3D<TSpace, TKSpace>::myBallSetList.at( j ).size() != 0 )
       {
-        glPointSize( max(
+        glPointSize( std::max(
         myGLPointMinWidth,
         ( Viewer3D<TSpace, TKSpace>::myBallSetList.at( j ).at( 0 ).radius ) ) );
       }
@@ -749,7 +753,7 @@ inline void DGtal::Viewer3D<TSpace, TKSpace>::draw()
   if(myViewWire)
     {
       glLineWidth(
-      max( myGLLineMinWidth,
+      std::max( myGLLineMinWidth,
            Viewer3D<TSpace, TKSpace>::myMeshDefaultLineWidth / distCam ) );
       glCallList(myQuadsMapWiredId);
     }
@@ -759,7 +763,7 @@ inline void DGtal::Viewer3D<TSpace, TKSpace>::draw()
   if(myViewWire)
     {
       glLineWidth(
-      max( myGLLineMinWidth,
+      std::max( myGLLineMinWidth,
            Viewer3D<TSpace, TKSpace>::myMeshDefaultLineWidth / distCam ) );
       glCallList(myTriangleSetListWiredId);
     }
@@ -769,7 +773,7 @@ inline void DGtal::Viewer3D<TSpace, TKSpace>::draw()
   if(myViewWire)
     {
       glLineWidth(
-      max( myGLLineMinWidth,
+      std::max( myGLLineMinWidth,
            Viewer3D<TSpace, TKSpace>::myMeshDefaultLineWidth / distCam ) );
       glCallList(myPolygonSetListWiredId);
     }
@@ -834,9 +838,9 @@ void DGtal::Viewer3D<TSpace, TKSpace>::init()
   setForegroundColor ( QColor ( 217, 22, 25, 255  ) );
 
   Viewer3D<TSpace, TKSpace>::createNewCubeList();
-  vector<typename Viewer3D<TSpace, TKSpace>::LineD3D> listeLine;
+  std::vector<typename Viewer3D<TSpace, TKSpace>::LineD3D> listeLine;
   Viewer3D<TSpace, TKSpace>::myLineSetList.push_back( listeLine );
-  vector<typename Viewer3D<TSpace, TKSpace>::BallD3D> listeBall;
+  std::vector<typename Viewer3D<TSpace, TKSpace>::BallD3D> listeBall;
   Viewer3D<TSpace, TKSpace>::myBallSetList.push_back( listeBall );
   Viewer3D<TSpace, TKSpace>::myCurrentFillColor = Color( 220, 220, 220 );
   Viewer3D<TSpace, TKSpace>::myCurrentLineColor = Color( 22, 22, 222, 50 );
@@ -974,7 +978,7 @@ void DGtal::Viewer3D<TSpace, TKSpace>::postSelection( const QPoint & point )
   mySelectedPoint = camera()->pointUnderPixel ( point, found );
   if ( found )
     {
-      DGtal::trace.info() << "Element of liste= " << selectedName() << "selected" << endl;
+      DGtal::trace.info() << "Element of liste= " << selectedName() << "selected" << std::endl;
       // JOL: 2014/10/15
       mySelectedElementId = selectedName();
       void* aData = 0;
@@ -1284,7 +1288,7 @@ void DGtal::Viewer3D<TSpace, TKSpace>::keyPressEvent( QKeyEvent * e )
       myLightTheta = asin( myLightPosition[ 2 ] / myLightR );
       myLightPhi   = atan2( myLightPosition[ 1 ], myLightPosition[ 0 ] );
 
-      stringstream ss;
+      std::stringstream ss;
       if ( e->modifiers() == Qt::ShiftModifier )
       {
         myLightR += 5.0;
@@ -1999,7 +2003,7 @@ template <typename TSpace, typename TKSpace>
 void DGtal::Viewer3D<TSpace, TKSpace>::updateRenderingCoefficients(
 const RenderingMode aRenderMode, bool displayState )
 {
-  stringstream ss; 
+  std::stringstream ss;
   ss << "Rendering mode ";
     
   GLfloat newCoefDiff, newCoefSpec = 1.0f;


### PR DESCRIPTION
# PR Description

Remove a `using namespace std;` in header file.

# Checklist

- ~[ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).~
- ~[ ] Doxygen documentation of the code completed (classes, methods, types, members...)~
- ~[ ] Documentation module page added or updated.~
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
