### PR TITLE
Update documented boost minimal version to match cmake script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cmake ..
 make install
 ```
 
-Minimum system requirements: C++11 enabled compiler, [cmake](http://cmake.org), [boost](http://boost.org) (>= 1.46).
+Minimum system requirements: C++11 enabled compiler, [cmake](http://cmake.org), [boost](http://boost.org) (>= 1.50).
 
 DGtal can be compiled on Microsoft Windows system using Visual Studio 2014 (or newer): Generate the Visual Studio project using windows [cmake](http://cmake.org) tool and compile the DGtal solution (you may also need to set the cmake variable ```BUILD_SHARED_LIBS``` to false).
 

--- a/src/DGtal/doc/moduleBuildDGtal.dox
+++ b/src/DGtal/doc/moduleBuildDGtal.dox
@@ -35,7 +35,7 @@ dependencies:
 
 - \e c++ compiler (g++, clang++, ...) with C++11 features (gcc>4.6 for instance)
 - \e [cmake](http://cmake.org) (>3.1, optionally cmake-gui),
-- \e |boost](http://www.boost.org) boost >= 1.46.0  (no need to have the libraries installed)
+- \e |boost](http://www.boost.org) boost >= 1.50.0  (no need to have the libraries installed)
 - \e zlib (already available in most OS)
 
 To build DGtal in is full configuration, you may need these dependencies too:


### PR DESCRIPTION
# PR Description

CMake script required boost >= 1.50 but README and build documentation talk about boost >= 1.46

# Checklist

- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
