### PR TITLE
Build corrections

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,10 @@
 
 ## Bug Fixes
 
+- *Configuration/General*
+  - Fix compilation error/warnings with gcc 9.1.1 and clang 9.0
+  (Boris Mansencal, [#1431](https://github.com/DGtal-team/DGtal/pull/1431))
+
 - *Mathematics*
   - Put SimpleMatrix * scalar operation in DGtal namespace (Jacques-Olivier Lachaud,
     [#1412](https://github.com/DGtal-team/DGtal/pull/1412))

--- a/src/Board/Point.h
+++ b/src/Board/Point.h
@@ -42,6 +42,13 @@ struct Point {
    */
   Point( const Point & other ):x(other.x),y(other.y) { } 
 
+  /**
+   * Default assignment operator.
+   *
+   * @param other point to copy.
+   */
+  Point &operator=( const Point & ) = default;
+
   /** 
    * Point constructor.
    * 

--- a/src/Board/Point.h
+++ b/src/Board/Point.h
@@ -47,7 +47,7 @@ struct Point {
    *
    * @param other point to copy.
    */
-  Point &operator=( const Point & ) = default;
+  Point &operator=( const Point & other ) = default;
 
   /** 
    * Point constructor.

--- a/src/DGtal/base/Alias.h
+++ b/src/DGtal/base/Alias.h
@@ -194,6 +194,12 @@ user forward an Alias<T> parameter.
   public:
 
     /**
+     * Default copy constructor.
+     * @param other the object to copy.
+     */
+    Alias( const Alias & other ) = default;
+
+    /**
        Destructor. Does nothing.
      */
     inline ~Alias() {}

--- a/src/DGtal/base/ConstAlias.h
+++ b/src/DGtal/base/ConstAlias.h
@@ -198,6 +198,12 @@ namespace DGtal
   public:
 
     /**
+       Default copy constructor.
+       @param other object to copy.
+     */
+    ConstAlias( const ConstAlias & other ) = default;
+
+    /**
        Destructor. Does nothing.
      */
     inline ~ConstAlias() {}

--- a/src/DGtal/geometry/curves/FrechetShortcut.h
+++ b/src/DGtal/geometry/curves/FrechetShortcut.h
@@ -298,13 +298,13 @@ namespace DGtal
      @param y1 y1
     */
     Cone(double x, double y, double x0, double y0, double x1, double y1);
-    
-    /**
-       Test if the cone is empty
-       @return true if empty, false otherwise
-    */
-    bool isEmpty();
 
+    /**
+       Default copy constructor.
+       @param c other cone to copy.
+    */
+    Cone(const Cone& c) = default;
+    
     /**
        Assignement
        @param c another cone
@@ -312,6 +312,12 @@ namespace DGtal
      */
     Cone& operator=(const Cone& c);
     
+    /**
+       Test if the cone is empty
+       @return true if empty, false otherwise
+    */
+    bool isEmpty();
+
     /**
        Intersect two cones: modifies 'this'
        @param c a cone to intersect with 'this'

--- a/src/DGtal/geometry/curves/FrechetShortcut.h
+++ b/src/DGtal/geometry/curves/FrechetShortcut.h
@@ -316,7 +316,7 @@ namespace DGtal
        Test if the cone is empty
        @return true if empty, false otherwise
     */
-    bool isEmpty();
+    bool isEmpty() const;
 
     /**
        Intersect two cones: modifies 'this'

--- a/src/DGtal/geometry/curves/FrechetShortcut.ih
+++ b/src/DGtal/geometry/curves/FrechetShortcut.ih
@@ -436,7 +436,7 @@ DGtal::FrechetShortcut<TIterator,TInteger>::Cone::Cone(double x, double y, doubl
 
 template <typename TIterator, typename TInteger>
 inline
-bool DGtal::FrechetShortcut<TIterator,TInteger>::Cone::isEmpty()
+bool DGtal::FrechetShortcut<TIterator,TInteger>::Cone::isEmpty() const
 {
   if(myInf)
     return false;

--- a/src/DGtal/geometry/curves/OneBalancedWordComputer.h
+++ b/src/DGtal/geometry/curves/OneBalancedWordComputer.h
@@ -296,9 +296,15 @@ namespace DGtal
               return i - other.i;
             }
 
+          /**
+           * Default copy constructor.
+	   * @param other the object to copy.
+           */
+          ConstPointIterator( const ConstPointIterator & other) = default;
 
           /**
-           * Copy operator
+           * Assignment operator.
+	   * @param other the object to copy.
            */
           ConstPointIterator& operator=( const ConstPointIterator & other)
             {

--- a/src/DGtal/geometry/tools/MelkmanConvexHull.h
+++ b/src/DGtal/geometry/tools/MelkmanConvexHull.h
@@ -128,6 +128,13 @@ namespace DGtal
     MelkmanConvexHull( Alias<Functor> aFunctor); 
     MelkmanConvexHull(); 
     
+    /**
+     * Default copy constructor.
+     *
+     * @param mch the object to copy.
+     */
+    MelkmanConvexHull( const MelkmanConvexHull & mch ) = default;
+
     // ----------------------- Interface --------------------------------------
   public:
 

--- a/src/DGtal/helpers/Parameters.h
+++ b/src/DGtal/helpers/Parameters.h
@@ -41,6 +41,7 @@
 //////////////////////////////////////////////////////////////////////////////
 // Inclusions
 #include <iostream>
+#include <map>
 #include <string>
 #include <sstream>
 #include "DGtal/base/Common.h"

--- a/src/DGtal/helpers/Shortcuts.h
+++ b/src/DGtal/helpers/Shortcuts.h
@@ -1896,12 +1896,14 @@ namespace DGtal
 	      }
 	    }
 	  // Simplify materials (very useful for blender).
-          Idx j = 0;
           std::map<Color,Idx> map_colors;
-          for ( auto && c : diffuse_colors )
-            if ( ! map_colors.count( c ) )
-              map_colors[ c ] = j++;
-
+	  {
+            Idx j = 0;
+            for ( auto && c : diffuse_colors )
+              if ( ! map_colors.count( c ) )
+                map_colors[ c ] = j++;
+          }
+	  
 	  // Output materials
 	  bool has_material = ! diffuse_colors.empty();
           if ( has_material )

--- a/src/DGtal/images/ConstImageAdapter.h
+++ b/src/DGtal/images/ConstImageAdapter.h
@@ -146,6 +146,12 @@ public:
     }
 
     /**
+    * Default copy constructor.
+    * @param other the object to copy.
+    */
+    ConstImageAdapter( const ConstImageAdapter & other ) = default;
+
+    /**
     * Assignment.
     * @param other the object to copy.
     * @return a reference on 'this'.

--- a/src/DGtal/images/ImageAdapter.h
+++ b/src/DGtal/images/ImageAdapter.h
@@ -152,6 +152,12 @@ public:
     }
 
     /**
+    * Default copy constructor.
+    * @param other the object to copy.
+    */
+    ImageAdapter( const ImageAdapter & other ) = default;
+
+    /**
     * Assignment.
     * @param other the object to copy.
     * @return a reference on 'this'.

--- a/src/DGtal/io/readers/DicomReader.ih
+++ b/src/DGtal/io/readers/DicomReader.ih
@@ -44,6 +44,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wpedantic"
+#if __GNUC__ >= 9
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif
 #endif
 #if defined(__clang__)
 #pragma clang diagnostic push

--- a/src/DGtal/math/linalg/SimpleMatrix.h
+++ b/src/DGtal/math/linalg/SimpleMatrix.h
@@ -120,6 +120,13 @@ namespace DGtal
      */
     SimpleMatrix ( const Self & other );
 
+    /**
+     * Default assignment operator.
+     *
+     * @param other the object to copy.
+     */
+    SimpleMatrix &operator=( const Self & other ) = default;
+
     // ----------------------- Standard services ------------------------------
 
     /**

--- a/src/DGtal/shapes/fromPoints/Point2ShapePredicate.h
+++ b/src/DGtal/shapes/fromPoints/Point2ShapePredicate.h
@@ -112,6 +112,12 @@ namespace DGtal {
      */
     Point2ShapePredicate ( const Point2ShapePredicate & other );
 
+    /**
+     * Default assignment operator.
+     * @param other the object to copy.
+     */
+    Point2ShapePredicate &operator=( const Point2ShapePredicate & other ) = default;
+
    /**
      * @param p any point.
      * @return true iff @a p is in the interior of the shape.

--- a/src/DGtal/shapes/parametric/Lemniscate2D.ih
+++ b/src/DGtal/shapes/parametric/Lemniscate2D.ih
@@ -83,7 +83,7 @@ DGtal::Lemniscate2D<T>::parameter( const RealPoint2D & pp ) const
   RealPoint2D p( pp-myCenter );
   double angle;
 
-  if ( abs(p[0]) < abs(p[1]) )
+  if ( fabs(p[0]) < fabs(p[1]) )
     return 0.;
   if ( p[0] == 0. )
     angle = 0.;

--- a/tests/shapes/testAstroid2D.cpp
+++ b/tests/shapes/testAstroid2D.cpp
@@ -109,7 +109,7 @@ TEST_CASE("Astroid2D")
 	    const RealPoint point( centerX, unif(re) );
       REQUIRE_NOTHROW( shape.parameter(point) );
       double res = shape.parameter(point);
-      REQUIRE_THAT( res, Catch::WithinULP(M_PI_2,DBL_EPSILON) || Catch::WithinULP(3*M_PI_2,DBL_EPSILON) );
+      REQUIRE_THAT( res, Catch::WithinAbs(M_PI_2,DBL_EPSILON) || Catch::WithinAbs(3*M_PI_2,DBL_EPSILON) );
     }
 
   SECTION("parameter() with point parameter with null y -> 0. or pi")
@@ -119,6 +119,6 @@ TEST_CASE("Astroid2D")
 	    const RealPoint point( unif(re), centerY );
       REQUIRE_NOTHROW( shape.parameter(point) );
       double res = shape.parameter(point);
-      REQUIRE_THAT( res, Catch::WithinULP(0.,DBL_EPSILON) || Catch::WithinULP(M_PI,DBL_EPSILON) );
+      REQUIRE_THAT( res, Catch::WithinAbs(0.,DBL_EPSILON) || Catch::WithinAbs(M_PI,DBL_EPSILON) );
     }
 }

--- a/tests/topology/testHalfEdgeDataStructure.cpp
+++ b/tests/topology/testHalfEdgeDataStructure.cpp
@@ -47,6 +47,9 @@ typedef HalfEdgeDataStructure::PolygonalFace    PolygonalFace;
 typedef HalfEdgeDataStructure::Edge             Edge;
 typedef HalfEdgeDataStructure::Arc              ArcT; //Arc already defined in wingdi.h
 typedef HalfEdgeDataStructure::VertexIndexRange VertexIndexRange;
+typedef HalfEdgeDataStructure::Size Size;
+
+
 
 HalfEdgeDataStructure makeTwoTriangles()
 {
@@ -470,7 +473,7 @@ SCENARIO( "HalfEdgeDataStructure flips", "[halfedge][flips]" ){
     HalfEdgeDataStructure mesh = makeTwoTriangles();
     THEN( "Only one edge is flippable" ) {
       int nbflippable = 0;
-      for ( int e = 0; e < mesh.nbEdges(); e++ )
+      for ( Size e = 0; e < mesh.nbEdges(); e++ )
         {
           if ( mesh.isFlippable( mesh.halfEdgeIndexFromEdgeIndex( e ) ) )
             nbflippable++;
@@ -482,7 +485,7 @@ SCENARIO( "HalfEdgeDataStructure flips", "[halfedge][flips]" ){
     HalfEdgeDataStructure mesh = makePyramid();
     THEN( "Only four edges are flippable" ) {
       int nbflippable = 0;
-      for ( int e = 0; e < mesh.nbEdges(); e++ )
+      for ( Size e = 0; e < mesh.nbEdges(); e++ )
         {
           if ( mesh.isFlippable( mesh.halfEdgeIndexFromEdgeIndex( e ) ) )
             nbflippable++;
@@ -494,7 +497,7 @@ SCENARIO( "HalfEdgeDataStructure flips", "[halfedge][flips]" ){
     HalfEdgeDataStructure mesh = makeTetrahedron();
     THEN( "All edges are flippable" ) {
       int nbflippable = 0;
-      for ( int e = 0; e < mesh.nbEdges(); e++ )
+      for ( Size e = 0; e < mesh.nbEdges(); e++ )
         {
           if ( mesh.isFlippable( mesh.halfEdgeIndexFromEdgeIndex( e ) ) )
             nbflippable++;
@@ -584,7 +587,8 @@ SCENARIO( "HalfEdgeDataStructure splits", "[halfedge][splits]" ){
     HalfEdgeDataStructure mesh = makeTwoTriangles();
     auto he  = mesh.findHalfEdgeIndexFromArc( {1,2} );
     REQUIRE( mesh.isFlippable( he ) );
-    auto vtx = mesh.split( he );
+    //auto vtx =
+    mesh.split( he );
     THEN( "After split, mesh is valid" ) {
       REQUIRE( mesh.isValid() );
     }


### PR DESCRIPTION
*Thanks a lot for contributing to DGtal, before submitting your PR, please fill up the description and make sure that all checkboxes are checked. Please remove these lines in your PR.*

# PR Description

This PR do some small build corrections.
In particular, code was not building with gcc 9.1.1 on Fedora 30 : due to missing include of <map> in src/DGtal/helpers/Parameters.h.
It also correct warning -Wshadow on src/DGtal/helpers/Shortcuts.h

However, there are still some warnings when building in Debug mode:
- On Fedora 30, with gcc 9.1.1 : lots of warnings due to -Wdeprecated-copy 
- On Ubuntu 19.04, with clang 8.0.0, 4 warnings due to -Wliteral-conversion on tests/shapes/testAstroid2D.cpp:
```
/home/mansenca/DGtal/tests/shapes/testAstroid2D.cpp:112:50: warning: implicit conversion from 'double' to 'int' changes
      value from 2.220446049250313E-16 to 0 [-Wliteral-conversion]
      REQUIRE_THAT( res, Catch::WithinULP(M_PI_2,DBL_EPSILON) || Catch::WithinULP(3*M_PI_2,DBL_EPSILON) );
                         ~~~~~                   ^~~~~~~~~~~
/usr/include/clang/8.0.0/include/float.h:133:21: note: expanded from macro 'DBL_EPSILON'
#define DBL_EPSILON __DBL_EPSILON__
                    ^~~~~~~~~~~~~~~
<built-in>:161:25: note: expanded from here
#define __DBL_EPSILON__ 2.2204460492503131e-16
                        ^~~~~~~~~~~~~~~~~~~~~~
/home/mansenca/DGtal/tests/catch.hpp:16592:75: note: expanded from macro 'REQUIRE_THAT'
#define REQUIRE_THAT( arg, matcher ) INTERNAL_CHECK_THAT( "REQUIRE_THAT", matcher, Catch::ResultDisposition::Normal, arg )
                                                                          ^~~~~~~
/home/mansenca/DGtal/tests/catch.hpp:3671:74: note: expanded from macro 'INTERNAL_CHECK_THAT'
            catchAssertionHandler.handleExpr( Catch::makeMatchExpr( arg, matcher, #matcher##_catch_sr ) ); \
                                                                         ^~~~~~~
``` 


# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
