### PR TITLE
Fixing doxygen source url by downloading it from SourceForge

### DIFF
--- a/.travis/install_doxygen.sh
+++ b/.travis/install_doxygen.sh
@@ -5,7 +5,8 @@ $SCRIPT_BEGIN
 ##Download and install 1.8.1
 #
 mkdir ~/doxygen && cd ~/doxygen
-wget http://doxygen.nl/files/doxygen-1.8.14.src.tar.gz && tar xzf doxygen-1.8.14.src.tar.gz
+wget https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.src.tar.gz/download -O doxygen-1.8.14.src.tar.gz \
+  && tar xzf doxygen-1.8.14.src.tar.gz
 cd doxygen-1.8.14 ; mkdir build ; cd build
 cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"
 ninja install

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -63,6 +63,8 @@
     Coeurjolly [#1417](https://github.com/DGtal-team/DGtal/pull/1417))
   - Fixing the `doxyfiles` to have the table of contents of module pages (David
     Coeurjolly [#1424](https://github.com/DGtal-team/DGtal/pull/1424))
+  - Using SourceForge to download doxygen sources during Travis CI jobs.
+    (Roland Denis [#1424](https://github.com/DGtal-team/DGtal/pull/1434))
 
 
 # DGtal 1.0


### PR DESCRIPTION
# PR Description

During continuous integration job, downloading doxygen source from http://doxygen.nl/files/doxygen-1.8.14.src.tar.gz results in a 404 error.

Instead on upgrading to 1.8.16 that will probably lead to new warnings/errors and the same download error in few months, this PR rely on SourceForge.

# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
