### PR TITLE
Disable warnings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,6 +42,8 @@
 - *Configuration/General*
   - Fix compilation error/warnings with gcc 9.1.1 and clang 9.0
   (Boris Mansencal, [#1431](https://github.com/DGtal-team/DGtal/pull/1431))
+  - Disable some warnings in Qt5 raised by Apple clang compiler (David
+  Coeurjolly, [#1436](https://github.com/DGtal-team/DGtal/pull/1436))
 
 - *Mathematics*
   - Put SimpleMatrix * scalar operation in DGtal namespace (Jacques-Olivier Lachaud,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,7 +42,7 @@
 - *Configuration/General*
   - Fix compilation error/warnings with gcc 9.1.1 and clang 9.0
   (Boris Mansencal, [#1431](https://github.com/DGtal-team/DGtal/pull/1431))
-  - Disable some warnings in Qt5 raised by Apple clang compiler (David
+  - Disable some gcc/clang warnings in Qt5 raised by Apple clang compiler (David
   Coeurjolly, [#1436](https://github.com/DGtal-team/DGtal/pull/1436))
 
 - *Mathematics*

--- a/src/DGtal/base/Common.h
+++ b/src/DGtal/base/Common.h
@@ -43,9 +43,15 @@
 // Inclusions
 
 #ifdef WITH_VISU3D_QGLVIEWER
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <QGLViewer/qglviewer.h>
 #include <QGLWidget>
 #include <QKeyEvent>
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 
 #include <iostream>


### PR DESCRIPTION
# PR Description

Disable some warnings inside Qt. 

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
