### PR TITLE
Minor edit to allow DGtal to be used as a submodule

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,7 +16,7 @@
 
 - *General*
   - DGtal can be compiled and used as a project (git) submodule (David
-  Coeurjolly [#xx](https://github.com/DGtal-team/DGtal/pull/xxx))
+  Coeurjolly [#1444](https://github.com/DGtal-team/DGtal/pull/1444))
   
 
 - *DEC*

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,11 @@
 
 ## Changes
 
+- *General*
+  - DGtal can be compiled and used as a project (git) submodule (David
+  Coeurjolly [#xx](https://github.com/DGtal-team/DGtal/pull/xxx))
+  
+
 - *DEC*
   - Add discrete calculus model of Ambrosio-Tortorelli functional in
     order to make piecewise-smooth approximations of scalar or vector

--- a/cmake/CheckCPP11.cmake
+++ b/cmake/CheckCPP11.cmake
@@ -3,8 +3,8 @@
 # -----------------------------------------------------------------------------
 
 try_compile( CPP11_COMPATIBLE_FLAG_SET_BY_USER
-  ${CMAKE_BINARY_DIR}/CMakeTmp
-  ${CMAKE_SOURCE_DIR}/cmake/src/cpp11/cpp11_check.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/CMakeTmp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/src/cpp11/cpp11_check.cpp
   CMAKE_FLAGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
   OUTPUT_VARIABLE OUTPUT
   )
@@ -15,8 +15,8 @@ ENDIF()
 
 IF (NOT CPP11_COMPATIBLE_FLAG_SET_BY_USER)
   try_compile( CPP11_COMPATIBLE_FLAG_SET_BY_DGTAL
-    ${CMAKE_BINARY_DIR}/CMakeTmp
-    ${CMAKE_SOURCE_DIR}/cmake/src/cpp11/cpp11_check.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/CMakeTmp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/src/cpp11/cpp11_check.cpp
     COMPILE_DEFINITIONS "-std=c++11"
     OUTPUT_VARIABLE OUTPUT
     )


### PR DESCRIPTION
# PR Description

You can use a `git submodule` to use DGtal in your own project.

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
