### PR TITLE
Unify pointel ordering in Shortcuts and MeshHelpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 dist: trusty
-sudo: false
 
 # Reducing the depth when cloning using git
 # https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth
@@ -22,8 +21,6 @@ matrix:
       compiler: gcc
 
 cache: apt
-
-secure: "Ra00iyQ+5wm7G3XfaaI40aKgfcGTigfmEd+3/TY1hYcjYnJvNOG0dekolcMDSelE8SfqLcWYnK6+vtOCmyZuUWheUhA+83Tgq/bIH6dMzSvLkJdyq2D9me4sX6zx3ct90swP7Adj8EBHmv61pH5OBeEcmNWJNIZmNQs3+1awca4="
 
 ##Deps for linux builds
 addons:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -74,9 +74,14 @@
     [#1411](https://github.com/DGtal-team/DGtal/pull/1411))
   - Fix bug in Shortcuts::saveVectorFieldOBJ
     (Jacques-Olivier Lachaud,[#1421](https://github.com/DGtal-team/DGtal/pull/1421))
-
   - Fixing OBJ export: .mtl file written with relative path (Johanna
-  Delanoy [#1420](https://github.com/DGtal-team/DGtal/pull/1420))
+    Delanoy [#1420](https://github.com/DGtal-team/DGtal/pull/1420))
+  - Unify pointel ordering in Shortcuts and MeshHelper so that
+    Shortcuts::getPointelRange, Shortcuts::saveOBJ and
+    Shortcuts::makePrimalPolygonalSurface, as well as
+    MeshHelpers::digitalSurface2PrimalPolygonalSurface, all use the
+    CCW ordering by default (in 3D).
+    (Jacques-Olivier Lachaud,[#1421](https://github.com/DGtal-team/DGtal/pull/1445))
 
 - *IO*
   - Removing a `using namespace std;` in the Viewer3D hearder file. (David

--- a/src/DGtal/helpers/Shortcuts.h
+++ b/src/DGtal/helpers/Shortcuts.h
@@ -481,7 +481,6 @@ namespace DGtal
         getKSpace( Parameters params =
                    parametersKSpace() | parametersDigitizedImplicitShape3D() )
       {
-        trace.info() << "[Shortcuts::getKSpace] " << params << std::endl;
         Scalar min_x  = params[ "minAABB"  ].as<Scalar>();
         Scalar max_x  = params[ "maxAABB"  ].as<Scalar>();
         Scalar h      = params[ "gridstep" ].as<Scalar>();
@@ -1444,6 +1443,9 @@ namespace DGtal
       /// @note The order of pointels is given by the default traversal
       /// of the surfels of the surface, where the 4 pointels of each
       /// surfel are visited in order.
+      ///
+      /// @since 1.1 The pointel ordering is now the same as the one
+      /// given by makePrimalPolygonalSurface (for 3D only of course).
       ///
       /// @note If you wish to consider the primal digital surface, and
       /// visits pointels as vertices of this graph in

--- a/src/DGtal/helpers/Shortcuts.h
+++ b/src/DGtal/helpers/Shortcuts.h
@@ -1518,7 +1518,9 @@ namespace DGtal
       getPointelRange
       ( const KSpace& K, const SCell& surfel )
       {
-        return getPrimalVertices( K, surfel, true );
+        return KSpace::dimension == 3
+	  ? getPrimalVertices( K, surfel, true )
+	  : getPrimalVertices( K, surfel );
       }
       
       /// Given any digital surface, returns a vector of surfels in
@@ -2549,7 +2551,7 @@ namespace DGtal
           Size n = 1;  // OBJ vertex numbering start at 1 
           for ( auto&& s : surfels )
             {
-              auto primal_vtcs = getPointelRange( K, s );
+              auto primal_vtcs = getPointelRange( K, s, true );
               for ( auto&& primal_vtx : primal_vtcs )
                 {
                   if ( ! vtx_numbering.count( primal_vtx ) )

--- a/src/DGtal/shapes/MeshHelpers.ih
+++ b/src/DGtal/shapes/MeshHelpers.ih
@@ -272,7 +272,7 @@ DGtal::MeshHelpers::digitalSurface2PrimalPolygonalSurface
   // Numbers all vertices and add them to the triangulated surface.
   const KSpace & K = dsurf.container().space();
   for ( auto&& s : dsurf ) {
-    auto primal_vertices = Surfaces<KSpace>::getPrimalVertices( K, s );
+    auto primal_vertices = Surfaces<KSpace>::getPrimalVertices( K, s, true );
     for ( auto&& primal_vtx : primal_vertices ) {
       if ( ! cellmap.count( primal_vtx ) ) {
 	auto p = cembedder( primal_vtx );

--- a/src/DGtal/shapes/PolygonalSurface.h
+++ b/src/DGtal/shapes/PolygonalSurface.h
@@ -44,6 +44,7 @@
 #include <set>
 #include <map>
 #include "DGtal/base/Common.h"
+#include "DGtal/base/Clone.h"
 #include "DGtal/base/OwningOrAliasingPtr.h"
 #include "DGtal/base/IntegerSequenceIterator.h"
 #include "DGtal/topology/HalfEdgeDataStructure.h"

--- a/tests/helpers/CMakeLists.txt
+++ b/tests/helpers/CMakeLists.txt
@@ -2,6 +2,7 @@ SET(DGTAL_TESTS_SRC_HELPERS
   testParametricShape
   testImplicitShape
   testParameters
+  testShortcuts
   )
 
 FOREACH(FILE ${DGTAL_TESTS_SRC_HELPERS})

--- a/tests/helpers/testShortcuts.cpp
+++ b/tests/helpers/testShortcuts.cpp
@@ -1,0 +1,86 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file testShortcuts.cpp
+ * @ingroup Tests
+ * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr )
+ * Laboratory of Mathematics (CNRS, UMR 5127), University of Savoie, France
+ *
+ * @date 2015/08/28
+ *
+ * Functions for testing class Shortcuts.
+ *
+ * This file is part of the DGtal library.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+#include <iostream>
+#include "DGtal/base/Common.h"
+#include "DGtal/helpers/Shortcuts.h"
+#include "DGtalCatch.h"
+///////////////////////////////////////////////////////////////////////////////
+
+using namespace std;
+using namespace DGtal;
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Functions for testing class Shortcuts.
+///////////////////////////////////////////////////////////////////////////////
+
+SCENARIO( "Shortcuts< K3 > pointel ordering", "[shortcuts][pointel]" )
+{
+  typedef KhalimskySpaceND<3>                       KSpace;
+  typedef Shortcuts< KSpace >                       SH3;
+
+  auto params          = SH3::defaultParameters();
+  const double h       = 0.25;
+  params( "polynomial", "goursat" )( "gridstep", h );
+  auto implicit_shape  = SH3::makeImplicitShape3D  ( params );
+  auto digitized_shape = SH3::makeDigitizedImplicitShape3D( implicit_shape, params );
+  auto binary_image    = SH3::makeBinaryImage      ( digitized_shape, params );
+  auto K               = SH3::getKSpace( params );
+  auto embedder        = SH3::getCellEmbedder( K );
+  auto surface         = SH3::makeLightDigitalSurface( binary_image, K, params );
+  
+  GIVEN( "A digital surface, its associated polygonal surface, and its pointel range" ) {
+    SH3::Cell2Index c2i;
+    auto polySurf        = SH3::makePrimalPolygonalSurface( c2i, surface );
+    auto pointels        = SH3::getPointelRange( surface );
+    THEN( "The polygonal surface and the pointel range have the same number of pointels" ) {
+      REQUIRE( pointels.size() == polySurf->nbVertices() );
+    }
+    THEN( "The vertices of the polygonal surface are in the same order as the pointel range" ) {
+      unsigned int nb_ok = 0, nb_ko = 0;
+      for ( auto i = 0; i < polySurf->nbVertices(); i++ )
+	{
+	  auto    p = pointels[ i ];
+	  auto  idx = c2i[ p ];
+	  if ( i != idx )
+	    {
+	      DGtal::trace.error() << "Pointel " << p << " of primal polygonal surface has not the same index in the polygonal surface (" << idx << ") and in the pointel range (" << i << ")." << std::endl;
+	      nb_ko += 1;
+	    }
+	  else nb_ok += 1;
+	}
+      REQUIRE( nb_ko == 0 );
+    }
+  }
+}
+
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# PR Description

Unify pointel ordering in Shortcuts and MeshHelper so that Shortcuts::getPointelRange, Shortcuts::saveOBJ and Shortcuts::makePrimalPolygonalSurface, as well as MeshHelpers::digitalSurface2PrimalPolygonalSurface, all use the CCW ordering by default (in 3D).

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)