### PR TITLE
[WIP] Add SplitFunctions to split domains in hypercubes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -60,6 +60,9 @@
     [#1428](https://github.com/DGtal-team/DGtal/pull/1428))
   - Makes testVoxelComplex faster, reducing the size of the test fixture
     (Pablo Hernandez-Cerdan, [#1451](https://github.com/DGtal-team/DGtal/pull/1451))
+  - Adds functions to SplitFunctions header to divide a domain into hypercubes and the function
+    thinningWithSplits to VoxelComplexFunctions to perform a thinning in parallel.
+    (Pablo Hernandez-Cerdan,[#1448](https://github.com/DGtal-team/DGtal/pull/1448))
 
 - *Shapes package*
   - Add a moveTo(const RealPoint& point) method to implicit and star shapes

--- a/src/DGtal/topology/CubicalComplex.h
+++ b/src/DGtal/topology/CubicalComplex.h
@@ -48,6 +48,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include "DGtal/base/Common.h"
 #include "DGtal/base/ConstAlias.h"
+#include "DGtal/base/Clone.h"
 #include "DGtal/base/Alias.h"
 #include "DGtal/base/ContainerTraits.h"
 #include "DGtal/base/CSTLAssociativeContainer.h"
@@ -242,6 +243,7 @@ namespace DGtal
     static const Dimension dimension = KSpace::dimension;
     typedef typename KSpace::Integer     Integer;     ///< Type for integers in the space.
     typedef typename KSpace::Cell        Cell;        ///< Type for a cell in the space.
+    typedef typename Cell::PreCell       PreCell;     ///< Type for a precell in the space.
     typedef typename KSpace::Cells       Cells;       ///< Type for a sequence of cells in the space.
     typedef typename KSpace::Space       Space;       ///< Type of the digital space
     typedef typename KSpace::Size        Size;        ///< Type for a number of elements
@@ -543,7 +545,7 @@ namespace DGtal
     *
     * @param aK a Khalimsky space.
     */
-    CubicalComplex ( ConstAlias<KSpace> aK );
+    CubicalComplex ( Clone<KSpace> aK );
 
     /**
     * Copy constructor.
@@ -844,6 +846,7 @@ namespace DGtal
     * @return 'true' if and only if \a aCell belongs to this complex.
     */
     bool belongs( const Cell& aCell ) const;
+    bool belongs( const PreCell& aCell ) const;
 
     /**
     * @param d the dimension of cell \a aCell.
@@ -851,6 +854,7 @@ namespace DGtal
     * @return 'true' if and only if \a aCell belongs to this complex.
     */
     bool belongs( Dimension d, const Cell& aCell ) const;
+    bool belongs( Dimension d, const PreCell& aCell ) const;
 
     /**
     * Erases cell \a aCell from the complex.
@@ -1282,7 +1286,7 @@ namespace DGtal
   protected:
 
     /// The Khalimsky space in which lives the cubical complex.
-    const KSpace* myKSpace;
+    CowPtr<KSpace> myKSpace;
 
     /// An array of map Cell -> Data that stores cells dimension per
     /// dimension (i.e. cells of dimension 0 are stored in myCells[0],

--- a/src/DGtal/topology/CubicalComplex.ih
+++ b/src/DGtal/topology/CubicalComplex.ih
@@ -603,6 +603,7 @@ bool
 DGtal::CubicalComplex<TKSpace, TCellContainer>::
 belongs( Dimension d, const Cell& aCell ) const
 {
+  ASSERT( d <= dimension );
   CellMapConstIterator it = myCells[ d ].find( aCell );
   return it != myCells[ d ].end();
 }

--- a/src/DGtal/topology/CubicalComplex.ih
+++ b/src/DGtal/topology/CubicalComplex.ih
@@ -198,7 +198,7 @@ DGtal::CubicalComplex<TKSpace, TCellContainer>::
 fillData( Data data )
 {
   for ( Dimension d = 0; d <= dimension; ++d )
-    clearData( d, data );
+    fillData( d, data );
 }
 //-----------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>

--- a/src/DGtal/topology/CubicalComplex.ih
+++ b/src/DGtal/topology/CubicalComplex.ih
@@ -62,7 +62,7 @@ CubicalComplex()
 template <typename TKSpace, typename TCellContainer>
 inline
 DGtal::CubicalComplex<TKSpace, TCellContainer>::
-CubicalComplex( ConstAlias<KSpace> aK )
+CubicalComplex( Clone<KSpace> aK )
   : myKSpace( &aK ), myCells( dimension+1 )
 {
 }
@@ -603,9 +603,27 @@ bool
 DGtal::CubicalComplex<TKSpace, TCellContainer>::
 belongs( Dimension d, const Cell& aCell ) const
 {
-  ASSERT( d <= dimension );
   CellMapConstIterator it = myCells[ d ].find( aCell );
   return it != myCells[ d ].end();
+}
+//-----------------------------------------------------------------------------
+template <typename TKSpace, typename TCellContainer>
+inline
+bool
+DGtal::CubicalComplex<TKSpace, TCellContainer>::
+belongs( const PreCell& aCell ) const
+{
+  return belongs( TKSpace::PreCellularGridSpace::uDim( aCell ), aCell );
+}
+//-----------------------------------------------------------------------------
+template <typename TKSpace, typename TCellContainer>
+inline
+bool
+DGtal::CubicalComplex<TKSpace, TCellContainer>::
+belongs( Dimension d, const PreCell& aCell ) const
+{
+  if (!myKSpace->uIsValid(aCell)) return false;
+  return belongs(d, myKSpace->uCell(aCell) );
 }
 //-----------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>

--- a/src/DGtal/topology/CubicalComplexFunctions.h
+++ b/src/DGtal/topology/CubicalComplexFunctions.h
@@ -267,7 +267,8 @@ namespace DGtal
               const CubicalComplex< TKSpace, TCellContainer >& S2 )
   {
     typedef CubicalComplex< TKSpace, TCellContainer > CC;
-    ASSERT( &(S1.space()) == &(S2.space()) );
+    ASSERT( S1.space().lowerBound() == S2.space().lowerBound() &&
+        S1.space().upperBound() == S2.space().upperBound());
     for ( Dimension i = 0; i <= CC::dimension; ++i )
       if ( ! functions::isEqual( S1.myCells[ i ], S2.myCells[ i ] ) )
         return false;
@@ -294,7 +295,8 @@ namespace DGtal
               const CubicalComplex< TKSpace, TCellContainer >& S2 )
   {
     typedef CubicalComplex< TKSpace, TCellContainer > CC;
-    ASSERT( &(S1.space()) == &(S2.space()) );
+    ASSERT( S1.space().lowerBound() == S2.space().lowerBound() &&
+        S1.space().upperBound() == S2.space().upperBound());
     for ( Dimension i = 0; i <= CC::dimension; ++i )
       if ( ! functions::isEqual( S1.myCells[ i ], S2.myCells[ i ] ) )
         return true;
@@ -318,7 +320,8 @@ namespace DGtal
               const CubicalComplex< TKSpace, TCellContainer >& S2 )
   {
     typedef CubicalComplex< TKSpace, TCellContainer > CC;
-    ASSERT( &(S1.space()) == &(S2.space()) );
+    ASSERT( S1.space().lowerBound() == S2.space().lowerBound() &&
+        S1.space().upperBound() == S2.space().upperBound());
     for ( Dimension i = 0; i <= CC::dimension; ++i )
       if ( ! functions::isSubset( S1.myCells[ i ], S2.myCells[ i ] ) )
         return false;
@@ -341,7 +344,8 @@ namespace DGtal
               const CubicalComplex< TKSpace, TCellContainer >& S2 )
   {
     typedef CubicalComplex< TKSpace, TCellContainer > CC;
-    ASSERT( &(S1.space()) == &(S2.space()) );
+    ASSERT( S1.space().lowerBound() == S2.space().lowerBound() &&
+        S1.space().upperBound() == S2.space().upperBound());
     for ( Dimension i = 0; i <= CC::dimension; ++i )
       if ( ! functions::isSubset( S2.myCells[ i ], S1.myCells[ i ] ) )
         return false;

--- a/src/DGtal/topology/CubicalComplexFunctions.ih
+++ b/src/DGtal/topology/CubicalComplexFunctions.ih
@@ -305,10 +305,14 @@ objectFromSpels(
                 const CubicalComplex< TKSpace, TCellContainer > & C)
 {
 
-  auto & cs = C.space();
+  const auto & cs = C.space();
+  const typename TKSpace::Point rightlowerBound = cs.lowerBound();
+  const typename TKSpace::Point rightupperBound = cs.upperBound();
+  const typename TKSpace::Point a_lowerBound(-9990, -9991, -9992);
+  const typename TKSpace::Point a_upperBound(9990, 9991, 9992);
   // Get domain of C KSpace.
-  typename TObject::Domain domain(cs.lowerBound(), cs.upperBound());
-  typename TObject::DigitalSet dset(domain);
+  CountedPtr<typename TObject::Domain> a_domain(new typename TObject::Domain(a_lowerBound, a_upperBound));
+  typename TObject::DigitalSet dset(a_domain);
   for(auto it = C.begin(TKSpace::DIM);
       it!= C.end(TKSpace::DIM) ; ++it)
     dset.insertNew(cs.uCoords(it->first));
@@ -337,15 +341,12 @@ getSpelNeighborhoodConfigurationOccupancy
   Point p2 = Point::diagonal(  1 );
   Point c = Point::diagonal( 0 );
   Domain domain( p1, p2 );
-  const auto & not_found( input_complex.end() );
-  // const auto & not_found( input_complex.end(3) );
+  const auto & kspace = input_complex.space();
+  const auto & not_found( input_complex.end(3) );
   NeighborhoodConfiguration cfg{0};
   for ( auto it = domain.begin(); it != domain.end(); ++it ) {
-    if( *it != c  &&
-        input_complex.find(
-                           input_complex.space().uSpel(center + *it) ) != not_found )
-      // input_complex.findCell( 3,
-      //     input_complex.space().uSpel(center + *it) ) != not_found )
+    if( *it != c && kspace.uIsInside(*it) &&
+        input_complex.findCell(3, kspace.uSpel(center + *it)) != not_found )
       cfg |= mapPointToMask.at(*it) ;
   }
   return cfg;

--- a/src/DGtal/topology/CubicalComplexFunctions.ih
+++ b/src/DGtal/topology/CubicalComplexFunctions.ih
@@ -306,13 +306,8 @@ objectFromSpels(
 {
 
   const auto & cs = C.space();
-  const typename TKSpace::Point rightlowerBound = cs.lowerBound();
-  const typename TKSpace::Point rightupperBound = cs.upperBound();
-  const typename TKSpace::Point a_lowerBound(-9990, -9991, -9992);
-  const typename TKSpace::Point a_upperBound(9990, 9991, 9992);
-  // Get domain of C KSpace.
-  CountedPtr<typename TObject::Domain> a_domain(new typename TObject::Domain(a_lowerBound, a_upperBound));
-  typename TObject::DigitalSet dset(a_domain);
+  typename TObject::Domain domain(cs.lowerBound(), cs.upperBound());
+  typename TObject::DigitalSet dset(domain);
   for(auto it = C.begin(TKSpace::DIM);
       it!= C.end(TKSpace::DIM) ; ++it)
     dset.insertNew(cs.uCoords(it->first));
@@ -336,7 +331,7 @@ getSpelNeighborhoodConfigurationOccupancy
   using Point  = typename TComplex::Point;
   using Space  = typename TComplex::Space;
   using Domain = HyperRectDomain< Space >;
-  
+
   Point p1 = Point::diagonal( -1 );
   Point p2 = Point::diagonal(  1 );
   Point c = Point::diagonal( 0 );

--- a/src/DGtal/topology/SplitFunctions.h
+++ b/src/DGtal/topology/SplitFunctions.h
@@ -97,7 +97,6 @@ namespace DGtal
      * Return struct of @sa splitComplex
      *
      * Holds the splitted sub_complexes and information about the splits.
-     * Including the domains with ghost layers if this was requested in @sa splitComplex.
      *
      * @tparam TComplex Complex type
      */
@@ -111,16 +110,8 @@ namespace DGtal
       std::vector<unsigned int> splits;
       /** Two points defining the domain of the splits */
       using PointsPair = std::array<typename TComplex::Point, 2>;
-      /** Vector with the domains of the original splits.
-       * If wide_of_ghost_layer is 0, this is the domain of the complexes,
-       * otherwise, the domain is stored in splits_with_ghost_layers. */
+      /** Vector with the domains of the original splits. */
       std::vector<PointsPair> splits_domain;
-      /** Wide of the ghost layer that was added to the original split */
-      size_t wide_of_ghost_layer;
-      /** Vector with the domains of the splits with ghost layers added.
-       * If wide_of_ghost_layer is NOT 0, this is the domain of the complexes,
-       * otherwise is empty, and the domain is stored in splits. */
-      std::vector<PointsPair> splits_domain_with_ghost_layers;
     };
 
   namespace functions {
@@ -131,12 +122,6 @@ namespace DGtal
      * @tparam TComplex
      * @param[in] vc input complex
      * @param[in] requested_number_of_splits (the actual splits might be less)
-     * @param[in] wide_of_ghost_layer enlarge the splits with a number of voxels
-     * The enlarged area (ghost layers) are shared between different sub_complexes
-     * The ghost layers are useful for multi-threading purposes, where
-     * they can be marked as FIXED (no thinning on this area), then thin each sub_complex
-     * and finally create new sub_complexes containing the ghost domains, remove the FIXED
-     * tag and thin them. This way we can perform a faster thinning for big domains.
      *
      * @return SplittedComplexes with the sub_complexes and the splits domain
      *
@@ -147,8 +132,7 @@ namespace DGtal
     SplittedComplexes<TComplex>
     splitComplex(
        const TComplex & vc ,
-       const size_t requested_number_of_splits,
-       const size_t wide_of_ghost_layer = 0
+       const size_t requested_number_of_splits
        );
 
     /**
@@ -185,7 +169,7 @@ namespace DGtal
      * @param vc input complex
      * @param lowerBound the lowerBound of the hypercube defining a border (usually vc.lowerBound().
      * @param upperBound the upperBound of the hypercube defining a border (usually vc.upperBound().
-     * @param wide_point the wide of the border (3D), defaults to nullptr, which is equivalent to {0,0,0}
+     * @param wide_point the wide of the border (3D), defaults to nullptr, which is equivalent to {1,1,1}
      * it has to be greater than zero.
      * @param lowerBound_to_ignore lowerBound defining an hypercube of borders to ignore
      * @param upperBound_to_ignore upperBound defining an hypercube of borders to ignore

--- a/src/DGtal/topology/SplitFunctions.h
+++ b/src/DGtal/topology/SplitFunctions.h
@@ -90,6 +90,7 @@ namespace DGtal
           const size_t requested_number_of_splits,
           const TPoint & lowerBound,
           const TPoint & upperBound);
+  } // namespace functions
 
 
     /**
@@ -106,22 +107,26 @@ namespace DGtal
       size_t number_of_splits;
       /** Vector of sub_complexes, with the data copied from the original complex */
       std::vector<TComplex> sub_complexes;
+      /** number of splits per dimension */
+      std::vector<unsigned int> splits;
       /** Two points defining the domain of the splits */
       using PointsPair = std::array<typename TComplex::Point, 2>;
       /** Vector with the domains of the original splits.
        * If wide_of_ghost_layer is 0, this is the domain of the complexes,
        * otherwise, the domain is stored in splits_with_ghost_layers. */
-      std::vector<PointsPair> splits;
+      std::vector<PointsPair> splits_domain;
       /** Wide of the ghost layer that was added to the original split */
       size_t wide_of_ghost_layer;
       /** Vector with the domains of the splits with ghost layers added.
        * If wide_of_ghost_layer is NOT 0, this is the domain of the complexes,
        * otherwise is empty, and the domain is stored in splits. */
-      std::vector<PointsPair> splits_with_ghost_layers;
+      std::vector<PointsPair> splits_domain_with_ghost_layers;
     };
 
+  namespace functions {
+
     /**
-     * Split a CubicalComplex (or VoxelComplex) into sub_complexes
+     * Split a CubicalComplex (or VoxelComplex) into sub_complexes.
      *
      * @tparam TComplex
      * @param[in] vc input complex
@@ -130,7 +135,7 @@ namespace DGtal
      * The enlarged area (ghost layers) are shared between different sub_complexes
      * The ghost layers are useful for multi-threading purposes, where
      * they can be marked as FIXED (no thinning on this area), then thin each sub_complex
-     * and finally create new sub_complexes containing the ghost domains, removed the FIXED
+     * and finally create new sub_complexes containing the ghost domains, remove the FIXED
      * tag and thin them. This way we can perform a faster thinning for big domains.
      *
      * @return SplittedComplexes with the sub_complexes and the splits domain
@@ -146,6 +151,73 @@ namespace DGtal
        const size_t wide_of_ghost_layer = 0
        );
 
+    /**
+     * Perform an union between out and each complex in complexes.
+     * out |= complex;
+     *
+     * @tparam TComplex complex type
+     * @param[in,out] out complex where the merge is stored
+     * @param[in] complexes vector of complexes
+     */
+    template < typename TComplex >
+    void
+    mergeSubComplexes(TComplex & out,
+        const std::vector<TComplex> &complexes);
+
+    template < typename TComplex >
+      TComplex
+    extractSubComplex(
+       const TComplex & vc ,
+       const typename TComplex::Point & sub_lowerBound,
+       const typename TComplex::Point & sub_upperBound
+       );
+
+    /**
+     * Get the voxels from the border of the input vc.
+     * If lowerBound_to_ignore and upperBound_to_ignore are set, the borders
+     * defined by those bounds are ignored.
+     *
+     * lowerBound and upperBound are usually the lower and upper bound
+     * of the input complex vc, but they can also be changed to get the
+     * borders of a smaller hypercube contained in vc.
+     *
+     * @tparam TComplex
+     * @param vc input complex
+     * @param lowerBound the lowerBound of the hypercube defining a border (usually vc.lowerBound().
+     * @param upperBound the upperBound of the hypercube defining a border (usually vc.upperBound().
+     * @param wide_point the wide of the border (3D), defaults to nullptr, which is equivalent to {0,0,0}
+     * it has to be greater than zero.
+     * @param lowerBound_to_ignore lowerBound defining an hypercube of borders to ignore
+     * @param upperBound_to_ignore upperBound defining an hypercube of borders to ignore
+     *
+     * @return vector with iterators of the border
+     */
+    template < typename TComplex >
+      std::vector<typename TComplex::CellMapIterator>
+      getBorderVoxels(
+          TComplex & vc,
+          const typename TComplex::Point & lowerBound,
+          const typename TComplex::Point & upperBound,
+          const typename TComplex::Point * wide_point = nullptr,
+          const typename TComplex::Point * lowerBound_to_ignore = nullptr,
+          const typename TComplex::Point * upperBound_to_ignore = nullptr
+          );
+
+    /**
+     * Helper function to get the border voxels obtained from
+     * @sa getBorderVoxels to the desired data.
+     *
+     * @tparam TComplex Complex type
+     * @param vc input complex
+     * @param border_iterators iterators from getBorderVoxels
+     * @param data data of the cell to set in the border
+     */
+    template < typename TComplex >
+      void
+      setBorderData(
+          TComplex & vc,
+          const std::vector<typename TComplex::CellMapIterator> &border_iterators,
+          const DGtal::uint32_t &data);
   } // namespace functions
 } // namespace DGtal
 

--- a/src/DGtal/topology/SplitFunctions.h
+++ b/src/DGtal/topology/SplitFunctions.h
@@ -1,0 +1,99 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+#pragma once
+
+/**
+ * @file SplitFunctions.h
+ * @author Pablo Hernandez-Cerdan (\c pablo.hernandez.cerdan@outlook.com)
+ *
+ * @date 2018/01/08
+ *
+ * Defines functions associated to split domains for multi-threading purposes.
+ *
+ * This file is part of the DGtal library.
+ */
+
+#if defined(SplitFunctions_RECURSES)
+#error Recursive header files inclusion detected in SplitFunctions.h
+#else // defined(SplitFunctions_RECURSES)
+/** Prevents recursive inclusion of headers. */
+#define SplitFunctions_RECURSES
+
+#if !defined SplitFunctions_h
+/** Prevents repeated inclusion of headers. */
+#define SplitFunctions_h
+
+//////////////////////////////////////////////////////////////////////////////
+// Inclusions
+#include "DGtal/base/Common.h"
+//////////////////////////////////////////////////////////////////////////////
+namespace DGtal
+{
+  namespace functions {
+  /**
+   * Compute the number of splits given a region defined by lowerBound and upperBound
+   *
+   * @tparam TPoint point type for lower and upper bound
+   * @param requested_number_of_splits
+   * @param lowerBound
+   * @param upperBound
+   * @param splits[] the splits for each dimension
+   *
+   * @return number of splits, lesser or equal than requested_number_of_splits
+   */
+    template <typename TPoint>
+      size_t computeSplits(
+          const size_t requested_number_of_splits,
+          const TPoint & lowerBound,
+          const TPoint & upperBound,
+          unsigned int splits[]);
+
+    /**
+     * Get the ith split, where i has to be less than the number of splits
+     * computed by @computeSplits.
+     *
+     * Returns two points corresponding to the output_lowerBound and output_upperRegion
+     * of the ith split.
+     *
+     * @tparam TPoint point type for lower and upper bound
+     * @param splitIndex the ith split to be computed
+     * @param requested_number_of_splits
+     * @param lowerBound
+     * @param upperBound
+     *
+     * @return array containing output_lowerBound and output_upperBound
+     */
+    template <typename TPoint>
+      std::array<TPoint, 2> getSplit(
+          const size_t splitIndex,
+          const size_t requested_number_of_splits,
+          const TPoint & lowerBound,
+          const TPoint & upperBound);
+  } // namespace functions
+} // namespace DGtal
+
+///////////////////////////////////////////////////////////////////////////////
+// Includes inline functions.
+#include "DGtal/topology/SplitFunctions.ih"
+
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#endif // !defined SplitFunctions_h
+
+#undef SplitFunctions_RECURSES
+#endif // else defined(SplitFunctions_RECURSES)

--- a/src/DGtal/topology/SplitFunctions.h
+++ b/src/DGtal/topology/SplitFunctions.h
@@ -48,10 +48,17 @@ namespace DGtal
    * Compute the number of splits given a region defined by lowerBound and upperBound
    *
    * @tparam TPoint point type for lower and upper bound
-   * @param requested_number_of_splits
-   * @param lowerBound
-   * @param upperBound
-   * @param splits[] the splits for each dimension
+   * @param[in] requested_number_of_splits number of splits (the actual splits might be less)
+   * @param[in] lowerBound the lower bound point of the domain
+   * @param[in] upperBound the upper bound point of the domain
+   * @param[in,out] splits the splits for each dimension
+   * For example, initialize splits with a std::vector, and use data to get the raw array
+   * needed for this function.
+   * @code
+   * std::vector<unsigned int> splits(dimension);
+   * auto number_of_splits = computeSplits(requested_number_of_splits,
+   *                           lowerBound, upperBound, splits.data());
+   * @endcode
    *
    * @return number of splits, lesser or equal than requested_number_of_splits
    */
@@ -64,16 +71,16 @@ namespace DGtal
 
     /**
      * Get the ith split, where i has to be less than the number of splits
-     * computed by @computeSplits.
+     * computed by @sa computeSplits.
      *
      * Returns two points corresponding to the output_lowerBound and output_upperRegion
      * of the ith split.
      *
      * @tparam TPoint point type for lower and upper bound
-     * @param splitIndex the ith split to be computed
-     * @param requested_number_of_splits
-     * @param lowerBound
-     * @param upperBound
+     * @param[in] splitIndex the ith split to be computed
+     * @param[in] requested_number_of_splits number of splits (the actual splits might be less)
+     * @param[in] lowerBound the lower bound point of the domain
+     * @param[in] upperBound the upper bound point of the domain
      *
      * @return array containing output_lowerBound and output_upperBound
      */
@@ -83,6 +90,26 @@ namespace DGtal
           const size_t requested_number_of_splits,
           const TPoint & lowerBound,
           const TPoint & upperBound);
+
+    /**
+     * Split a CubicalComplex (or VoxelComplex) into sub_complexes
+     *
+     * @tparam TComplex
+     * @param[in] vc input complex
+     * @param[in] requested_number_of_splits (the actual splits might be less)
+     *
+     * @return vector with sub_complexes
+     *
+     * @sa computeSplits
+     * @sa getSplit
+     */
+    template < typename TComplex >
+    std::vector<TComplex>
+    splitComplex(
+       const TComplex & vc ,
+       const size_t requested_number_of_splits
+       );
+
   } // namespace functions
 } // namespace DGtal
 

--- a/src/DGtal/topology/SplitFunctions.h
+++ b/src/DGtal/topology/SplitFunctions.h
@@ -91,23 +91,59 @@ namespace DGtal
           const TPoint & lowerBound,
           const TPoint & upperBound);
 
+
+    /**
+     * Return struct of @sa splitComplex
+     *
+     * Holds the splitted sub_complexes and information about the splits.
+     * Including the domains with ghost layers if this was requested in @sa splitComplex.
+     *
+     * @tparam TComplex Complex type
+     */
+    template <typename TComplex>
+    struct SplittedComplexes {
+      /** Number of splits (might be less than the requested_number_of_splits) */
+      size_t number_of_splits;
+      /** Vector of sub_complexes, with the data copied from the original complex */
+      std::vector<TComplex> sub_complexes;
+      /** Two points defining the domain of the splits */
+      using PointsPair = std::array<typename TComplex::Point, 2>;
+      /** Vector with the domains of the original splits.
+       * If wide_of_ghost_layer is 0, this is the domain of the complexes,
+       * otherwise, the domain is stored in splits_with_ghost_layers. */
+      std::vector<PointsPair> splits;
+      /** Wide of the ghost layer that was added to the original split */
+      size_t wide_of_ghost_layer;
+      /** Vector with the domains of the splits with ghost layers added.
+       * If wide_of_ghost_layer is NOT 0, this is the domain of the complexes,
+       * otherwise is empty, and the domain is stored in splits. */
+      std::vector<PointsPair> splits_with_ghost_layers;
+    };
+
     /**
      * Split a CubicalComplex (or VoxelComplex) into sub_complexes
      *
      * @tparam TComplex
      * @param[in] vc input complex
      * @param[in] requested_number_of_splits (the actual splits might be less)
+     * @param[in] wide_of_ghost_layer enlarge the splits with a number of voxels
+     * The enlarged area (ghost layers) are shared between different sub_complexes
+     * The ghost layers are useful for multi-threading purposes, where
+     * they can be marked as FIXED (no thinning on this area), then thin each sub_complex
+     * and finally create new sub_complexes containing the ghost domains, removed the FIXED
+     * tag and thin them. This way we can perform a faster thinning for big domains.
      *
-     * @return vector with sub_complexes
+     * @return SplittedComplexes with the sub_complexes and the splits domain
      *
      * @sa computeSplits
      * @sa getSplit
      */
     template < typename TComplex >
-    std::vector<TComplex>
+    SplittedComplexes<TComplex>
     splitComplex(
        const TComplex & vc ,
-       const size_t requested_number_of_splits
+       const size_t requested_number_of_splits,
+       const size_t wide_of_ghost_layer = 0
        );
 
   } // namespace functions

--- a/src/DGtal/topology/SplitFunctions.ih
+++ b/src/DGtal/topology/SplitFunctions.ih
@@ -93,16 +93,19 @@ size_t DGtal::functions::computeSplits(
 
 }
 template <typename TPoint>
-std::array<TPoint, 2> DGtal::functions::getSplit(
+DGtal::SplitBounds<TPoint> DGtal::functions::getSplit(
     const size_t splitIndex,
     const size_t requested_number_of_splits,
     const TPoint & lowerBound,
     const TPoint & upperBound
     )
 {
-  std::array<TPoint, 2> output_lower_upper_bounds = {lowerBound, upperBound};
-  auto & outputLowerBound = output_lower_upper_bounds[0];
-  auto & outputUpperBound = output_lower_upper_bounds[1];
+  SplitBounds<TPoint> out;
+  out.splitIndex = splitIndex;
+  out.lowerBound = lowerBound;
+  out.upperBound = upperBound;
+  auto & outputLowerBound = out.lowerBound;
+  auto & outputUpperBound = out.upperBound;
 
   const auto dim = lowerBound.dimension;
   const auto region_size = upperBound - lowerBound;
@@ -113,7 +116,8 @@ std::array<TPoint, 2> DGtal::functions::getSplit(
   std::vector<unsigned int> splits(dim); // Note: stack allocation preferred
 
   // index into splitted regions
-  std::vector<unsigned int> splittedRegionIndex(dim); // Note: stack allocation preferred
+  out.splittedRegionIndex = std::vector<unsigned int>(dim); // Note: stack allocation preferred
+  auto & splittedRegionIndex = out.splittedRegionIndex;
 
   DGtal::functions::computeSplits(requested_number_of_splits,
       lowerBound, upperBound, &splits[0]);
@@ -156,7 +160,7 @@ std::array<TPoint, 2> DGtal::functions::getSplit(
   }
   outputUpperBound = outputLowerBound + output_region_size;
 
-  return output_lower_upper_bounds;
+  return out;
 }
 
 template < typename TComplex >
@@ -199,9 +203,9 @@ DGtal::functions::extractSubComplex(
 }
 
 template < typename TComplex >
-std::vector<typename TComplex::CellMapIterator>
+bool
 DGtal::functions::isInBorder(
-    const typename TComplex::KSpace &cell
+    const typename TComplex::KSpace::Cell &cell,
     const typename TComplex::Point & lowerBound,
     const typename TComplex::Point & upperBound,
     const typename TComplex::Point * wide_point,
@@ -211,7 +215,7 @@ DGtal::functions::isInBorder(
   const typename TComplex::Point wide =
     wide_point ? *wide_point : typename TComplex::Point(1,1,1);
 
-  const auto cell_coords = kspace.uCoords(cell);
+  const auto cell_coords = TComplex::KSpace::Cell::PreCellularGridSpace::uCoords(cell);
   // dist to lower and upper
   const auto distToLower = cell_coords - lowerBound;
   const auto distToUpper = upperBound - cell_coords;;
@@ -293,7 +297,6 @@ DGtal::functions::getBorderVoxels(
     const typename TComplex::Point * lowerBound_to_ignore,
     const typename TComplex::Point * upperBound_to_ignore)
 {
-  const auto & kspace = vc.space();
   if(wide_point) {
     const typename TComplex::Point wide = *wide_point;
     // wide_point has to be positive
@@ -333,7 +336,7 @@ DGtal::functions::getBorderVoxels(
   for(auto it = vc.begin(3); it != vc.end(3); ++it) {
     const auto & cell = it->first;
 
-    const bool isInBorder_not_to_ignore = isInBorder( cell,
+    const bool isInBorder_not_to_ignore = isInBorder<TComplex>(cell,
         lowerBound, upperBound,
         wide_point, lowerBound_to_ignore, upperBound_to_ignore);
 
@@ -395,7 +398,7 @@ DGtal::functions::getBorderVoxelsWithDistanceMap(
   for(auto it = vc.begin(3); it != vc.end(3); ++it) {
     const auto & cell = it->first;
 
-    const bool isInBorder_not_to_ignore = isInBorder( cell,
+    const bool isInBorder_not_to_ignore = isInBorder<TComplex>( cell,
         lowerBound, upperBound,
         wide_point, lowerBound_to_ignore, upperBound_to_ignore);
 
@@ -403,7 +406,7 @@ DGtal::functions::getBorderVoxelsWithDistanceMap(
       const auto cell_coords = kspace.uCoords(cell);
       const auto distToLower = cell_coords - lowerBound;
       const auto distToUpper = upperBound - cell_coords;;
-      const auto & dist_map_value = dist_map(cell);
+      const auto dist_map_value = (*dist_map)(cell_coords);
       bool closer_to_block_border_than_object_border = false;
       for(size_t dim = 0; dim < 3; ++dim) {
         if(   dist_map_value <= distToLower[dim]
@@ -469,13 +472,12 @@ DGtal::functions::splitComplex(
   // at least for thinning, so we make all the sub_kspaces closed.
   const bool kspace_isClosed = true;
   for(size_t split = 0; split < number_of_splits; ++split) {
-    const auto sub_lower_upper_bounds_original = DGtal::functions::getSplit(
+    const auto split_bounds = DGtal::functions::getSplit(
         split, requested_number_of_splits, lowerBound, upperBound);
     // Save the domain of the original splits in the output
-    out.splits_domain.push_back(sub_lower_upper_bounds_original);
-    auto sub_lower_upper_bounds = sub_lower_upper_bounds_original;
-    auto & sub_lowerBound = sub_lower_upper_bounds[0];
-    auto & sub_upperBound = sub_lower_upper_bounds[1];
+    out.splits_bounds.push_back(split_bounds);
+    const auto & sub_lowerBound = split_bounds.lowerBound;
+    const auto & sub_upperBound = split_bounds.upperBound;
     sub_kspaces[split].init(sub_lowerBound, sub_upperBound, kspace_isClosed);
   }
 
@@ -514,6 +516,58 @@ DGtal::functions::splitComplex(
     }
   }
   return out;
+}
+
+size_t
+DGtal::functions::getNumberOfBorderBlocksFromSplits(
+    const std::vector<unsigned int> & splits)
+{
+  const auto dimension = splits.size();
+  size_t number_of_block_complexes = 0;
+  for(size_t dim = 0; dim < dimension; ++dim) {
+    for(size_t split = 1; split < splits[dim]; ++split) {
+      number_of_block_complexes++;
+    }
+  }
+  return number_of_block_complexes;
+}
+
+template <typename TPoint>
+std::vector<std::array<TPoint, 2>>
+DGtal::functions::getBorderBlocksFromSplits(
+    const TPoint & lowerBound,
+    const TPoint & upperBound,
+    const std::vector<SplitBounds<TPoint>> & splits_bounds,
+    const size_t wide_of_block_sub_complex
+    )
+{
+  // The blocks spans the whole domain (large thin layers), and they only differ from lowerBound, upperBound in one dimension where the split is.
+  using PointPair = std::array<TPoint, 2>;
+  std::vector<PointPair> block_lower_upper_bounds;
+  std::vector<std::set<unsigned int>> visited_index_per_dim(lowerBound.dimension);
+  for(const auto & split_bound : splits_bounds) {
+    const auto & split_index = split_bound.splittedRegionIndex;
+    for(size_t dim = 0; dim < split_bound.lowerBound.dimension; dim++) {
+      if(split_index[dim] > 0 &&
+         visited_index_per_dim[dim].find(split_index[dim]) ==
+         visited_index_per_dim[dim].end()) {
+        visited_index_per_dim[dim].emplace(split_index[dim]);
+        auto block_lowerBound = lowerBound;
+        auto block_upperBound = upperBound;
+        block_lowerBound[dim] = split_bound.lowerBound[dim];
+        block_upperBound[dim] = split_bound.lowerBound[dim];
+        if(wide_of_block_sub_complex) {
+          block_lowerBound[dim] -= wide_of_block_sub_complex;
+          block_upperBound[dim] += wide_of_block_sub_complex - 1;
+          if(block_lowerBound[dim] < lowerBound[dim]) block_lowerBound[dim] = lowerBound[dim];
+          if(block_upperBound[dim] > upperBound[dim]) block_upperBound[dim] = upperBound[dim];
+        }
+        block_lower_upper_bounds.emplace_back(
+            PointPair({block_lowerBound, block_upperBound}));
+      }
+    }
+  }
+  return block_lower_upper_bounds;
 }
 
 template < typename TComplex >

--- a/src/DGtal/topology/SplitFunctions.ih
+++ b/src/DGtal/topology/SplitFunctions.ih
@@ -80,7 +80,7 @@ size_t DGtal::functions::computeSplits(
     // check if this would give us too many pieces or
     // if this would require the subpixel splits
     if ( numberOfPieces + additionalNumPieces > requested_number_of_splits ||
-         splits[ maxSplitDim ] == region_size[ maxSplitDim ] )
+         splits[ maxSplitDim ] == static_cast<unsigned int>(region_size[ maxSplitDim ]) )
     {
       return numberOfPieces;
     }
@@ -115,7 +115,7 @@ std::array<TPoint, 2> DGtal::functions::getSplit(
   // index into splitted regions
   std::vector<unsigned int> splittedRegionIndex(dim); // Note: stack allocation preferred
 
-  const auto numberOfPieces = DGtal::functions::computeSplits(requested_number_of_splits,
+  DGtal::functions::computeSplits(requested_number_of_splits,
       lowerBound, upperBound, &splits[0]);
 
   // determine which splitted region we are in
@@ -157,3 +157,76 @@ std::array<TPoint, 2> DGtal::functions::getSplit(
 
   return output_lower_upper_bounds;
 }
+
+template < typename TComplex >
+  std::vector<TComplex>
+DGtal::functions::splitComplex(
+    const TComplex & vc ,
+    const size_t requested_number_of_splits
+    ) {
+  const auto & kspace = vc.space();
+  const auto & lowerBound = kspace.lowerBound();
+  const auto & upperBound = kspace.upperBound();
+  std::vector<unsigned int> splits(kspace.dimension);
+  const auto number_of_splits =
+    DGtal::functions::computeSplits(requested_number_of_splits,
+        lowerBound, upperBound, splits.data());
+  std::vector<typename TComplex::KSpace> sub_kspaces(number_of_splits);
+  // Note that when dividing a k-space special care hast to be taken in the
+  // opennes or clossedness of the low dim cells (1-cell and 2-cell in 3D).
+  // To avoid sharing those pointels and linels in the frontier between subspaces,
+  // only one of the colindant sub_kspaces should include them, and the rest omit them.
+  // In case of Cubical and Voxel Complexes, those cells are not that signficant,
+  // at least for thinning, so we make all the sub_kspaces closed.
+  const bool kspace_isClosed = true;
+  for(size_t split = 0; split < number_of_splits; ++split) {
+    const auto sub_lower_upper_bounds = DGtal::functions::getSplit(
+        split, requested_number_of_splits, lowerBound, upperBound);
+    const auto & sub_lowerBound = sub_lower_upper_bounds[0];
+    const auto & sub_upperBound = sub_lower_upper_bounds[1];
+    sub_kspaces[split].init(sub_lowerBound, sub_upperBound, kspace_isClosed);
+  }
+  std::vector<TComplex> sub_complexes;
+  for(size_t split = 0; split < number_of_splits; ++split) {
+    sub_complexes.emplace_back(TComplex(sub_kspaces[split]));
+    // Copy cells and cell data from input vc to sub_complexes
+    // First, iterate over the kspace of the sub-domain
+    // Then find cell in original complex, if exists, insert it (copy) into the sub_complex
+    const auto sub_lowerCell = sub_kspaces[split].lowerCell();
+    const auto sub_upperCell = sub_kspaces[split].upperCell();
+    const auto & sub_lowerCell_coords = kspace.uKCoords(sub_lowerCell);
+    const auto & sub_upperCell_coords = kspace.uKCoords(sub_upperCell);
+    auto kcell = sub_lowerCell;
+    static_assert(TComplex::KSpace::dimension == 3,
+        "The KSpace::dimension of TComplex isn't 3");
+    for(auto k_x = sub_lowerCell_coords[0]; k_x < sub_upperCell_coords[0]; k_x++) {
+      for(auto k_y = sub_lowerCell_coords[1]; k_y < sub_upperCell_coords[1]; k_y++) {
+        for(auto k_z = sub_lowerCell_coords[2]; k_z < sub_upperCell_coords[2]; k_z++) {
+          kspace.uSetKCoord(kcell, 0, k_x);
+          kspace.uSetKCoord(kcell, 1, k_y);
+          kspace.uSetKCoord(kcell, 2, k_z);
+          const auto dim_cell = kspace.uDim(kcell);
+          const auto iter_cell_map = vc.findCell(dim_cell, kcell);
+          if(iter_cell_map != vc.end(dim_cell)) {
+            // iter_cell_map->first is equal to kcell...
+            sub_complexes[split].insertCell(dim_cell,
+                kcell, iter_cell_map->second);
+          }
+        }
+      }
+    }
+    // auto kcell = sub_lowerCell;
+    // do {
+    //   const auto dim_cell = kspace.uDim(kcell);
+    //   const auto iter_cell_map = vc.findCell(dim_cell, kcell);
+    //   if(iter_cell_map != vc.end(dim_cell)) {
+    //     // iter_cell_map->first is equal to kcell...
+    //     sub_complexes[split].insertCell(dim_cell,
+    //         kcell, iter_cell_map->second);
+    //   }
+    // }
+    // while( sub_kspaces[split].uNext(kcell, sub_lowerCell, sub_upperCell));
+  }
+  return sub_complexes;
+}
+

--- a/src/DGtal/topology/SplitFunctions.ih
+++ b/src/DGtal/topology/SplitFunctions.ih
@@ -105,7 +105,7 @@ std::array<TPoint, 2> DGtal::functions::getSplit(
   auto & outputUpperBound = output_lower_upper_bounds[1];
 
   const auto dim = lowerBound.dimension;
-  auto region_size = upperBound - lowerBound;
+  const auto region_size = upperBound - lowerBound;
   auto output_region_size = region_size;
   // Implementation taken from ITK:
   // itkImageRegionSplitterMultidimensional.cxx GetSplitInternal
@@ -144,8 +144,9 @@ std::array<TPoint, 2> DGtal::functions::getSplit(
     outputLowerBound[i] += indexOffset;
     if (splittedRegionIndex[i] < splits[i] - 1)
     {
+      // Modified from ITK, minus -1 (index,size in ITK versus lower/upperBounds here)
       output_region_size[i] =
-        std::floor((splittedRegionIndex[i] + 1) * (inputRegionSize / double(splits[i]))) - indexOffset;
+        std::floor((splittedRegionIndex[i] + 1) * (inputRegionSize / double(splits[i]))) - indexOffset - 1;
     }
     else
     {
@@ -158,10 +159,141 @@ std::array<TPoint, 2> DGtal::functions::getSplit(
   return output_lower_upper_bounds;
 }
 
+template < typename TComplex >
+TComplex
+DGtal::functions::extractSubComplex(
+    const TComplex & vc ,
+    const typename TComplex::Point & sub_lowerBound,
+    const typename TComplex::Point & sub_upperBound
+    ) {
+  const auto & kspace = vc.space();
+  const bool kspace_isClosed = true;
+  typename TComplex::KSpace sub_kspace;
+  sub_kspace.init(sub_lowerBound, sub_upperBound, kspace_isClosed);
+  TComplex sub_complex(sub_kspace);
 
+  const auto sub_lowerCell = sub_kspace.lowerCell();
+  const auto sub_upperCell = sub_kspace.upperCell();
+  const auto & sub_lowerCell_coords = kspace.uKCoords(sub_lowerCell);
+  const auto & sub_upperCell_coords = kspace.uKCoords(sub_upperCell);
+  auto kcell = sub_lowerCell;
+  static_assert(TComplex::KSpace::dimension == 3,
+      "The KSpace::dimension of TComplex isn't 3");
+  for(auto k_x = sub_lowerCell_coords[0]; k_x <= sub_upperCell_coords[0]; k_x++) {
+    for(auto k_y = sub_lowerCell_coords[1]; k_y <= sub_upperCell_coords[1]; k_y++) {
+      for(auto k_z = sub_lowerCell_coords[2]; k_z <= sub_upperCell_coords[2]; k_z++) {
+        kspace.uSetKCoord(kcell, 0, k_x);
+        kspace.uSetKCoord(kcell, 1, k_y);
+        kspace.uSetKCoord(kcell, 2, k_z);
+        const auto dim_cell = kspace.uDim(kcell);
+        const auto iter_cell_map = vc.findCell(dim_cell, kcell);
+        if(iter_cell_map != vc.end(dim_cell)) {
+          sub_complex.insertCell(dim_cell,
+              kcell, iter_cell_map->second);
+        }
+      }
+    }
+  }
+
+  return sub_complex;
+}
 
 template < typename TComplex >
-DGtal::functions::SplittedComplexes<TComplex>
+std::vector<typename TComplex::CellMapIterator>
+DGtal::functions::getBorderVoxels(
+    TComplex & vc,
+    const typename TComplex::Point & lowerBound,
+    const typename TComplex::Point & upperBound,
+    const typename TComplex::Point * wide_point,
+    const typename TComplex::Point * lowerBound_to_ignore,
+    const typename TComplex::Point * upperBound_to_ignore) {
+  const auto & kspace = vc.space();
+  const auto dimension = kspace.dimension;
+  // wide_point has to be positive
+  if(wide_point)
+    ASSERT(wide_point->min() > 0);
+  typename TComplex::Point wide = wide_point ? *wide_point : typename TComplex::Point(1,1,1);
+  // using KPreSpace = typename TComplex::KSpace::PreCellularGridSpace;
+
+  using CellIterators = std::vector<typename TComplex::CellMapIterator>;
+  CellIterators iterators;
+
+  for(auto it = vc.begin(3); it != vc.end(3); ++it) {
+    const auto & cell = it->first;
+    bool isInside = true;
+    const auto cell_coords = kspace.uCoords(cell);
+    // dist to lower and upper
+    const auto distToLower = cell_coords - lowerBound;
+    const auto distToUpper = upperBound - cell_coords;;
+    // upperBound - cell_coords
+    bool is_close_to_lower_border =
+      distToLower[0] < wide[0]
+      || distToLower[1] < wide[1]
+      || distToLower[2] < wide[2];
+    bool is_close_to_upper_border =
+      distToUpper[0] < wide[0]
+      || distToUpper[1] < wide[1]
+      || distToUpper[2] < wide[2];
+
+    if(lowerBound_to_ignore && upperBound_to_ignore) {
+      const auto distToLower_to_ignore = cell_coords - lowerBound;
+      bool is_close_to_lower_border_to_ignore =
+        distToLower_to_ignore[0] < wide[0]
+        || distToLower_to_ignore[1] < wide[1]
+        || distToLower_to_ignore[2] < wide[2];
+
+      if(is_close_to_lower_border_to_ignore) {
+        // Don't ignore it if closer to lowerBound than lowerBound_to_ignore (corners)
+        if(distToLower.min() >= distToLower_to_ignore.min()) {
+          is_close_to_lower_border_to_ignore = false;
+        }
+      }
+      is_close_to_lower_border &= !is_close_to_lower_border_to_ignore;
+
+      const auto distToUpper_to_ignore = upperBound - cell_coords;;
+      bool is_close_to_upper_border_to_ignore =
+        distToUpper_to_ignore[0] < wide[0]
+        || distToUpper_to_ignore[1] < wide[1]
+        || distToUpper_to_ignore[2] < wide[2];
+      if(is_close_to_upper_border_to_ignore) {
+        // Don't ignore it if closer to upperBound than upperBound_to_ignore (corners)
+        if(distToUpper.min() >= distToUpper_to_ignore.min()) {
+          is_close_to_upper_border_to_ignore = false;
+        }
+      }
+      is_close_to_upper_border &= !is_close_to_upper_border_to_ignore;
+    }
+
+    isInside &= !is_close_to_lower_border
+      && !is_close_to_upper_border;
+
+    if(!isInside) {
+      iterators.push_back(it);
+    }
+  }
+  return iterators;
+}
+
+template < typename TComplex >
+void
+DGtal::functions::setBorderData(
+    TComplex & vc,
+    const std::vector<typename TComplex::CellMapIterator> &border_iterators,
+    const DGtal::uint32_t &data) {
+  for(auto vit = border_iterators.begin(); vit != border_iterators.end(); ++vit){
+    (*vit)->second = data;
+    // Set the data of all faces as well
+    const auto faces = vc.cellBoundary((*vit)->first);
+    for(const auto & face : faces) {
+      auto it = vc.findCell(face);
+      it->second = data;
+    }
+
+  }
+}
+
+template < typename TComplex >
+DGtal::SplittedComplexes<TComplex>
 DGtal::functions::splitComplex(
     const TComplex & vc ,
     const size_t requested_number_of_splits,
@@ -178,6 +310,7 @@ DGtal::functions::splitComplex(
   // Initiate output struct
   SplittedComplexes<TComplex> out;
   out.number_of_splits = number_of_splits;
+  out.splits = splits;
   out.wide_of_ghost_layer = wide_of_ghost_layer;
   auto & sub_complexes = out.sub_complexes;
   // Note that when dividing a k-space special care hast to be taken in the
@@ -192,7 +325,7 @@ DGtal::functions::splitComplex(
         split, requested_number_of_splits, lowerBound, upperBound);
     // Save the domain of the original splits in the output
     // If wide_of_ghost_layer == 0, this is the final domain of the sub_complexes
-    out.splits.push_back(sub_lower_upper_bounds_original);
+    out.splits_domain.push_back(sub_lower_upper_bounds_original);
     auto sub_lower_upper_bounds = sub_lower_upper_bounds_original;
     auto & sub_lowerBound = sub_lower_upper_bounds[0];
     auto & sub_upperBound = sub_lower_upper_bounds[1];
@@ -211,13 +344,18 @@ DGtal::functions::splitComplex(
       }
       // Save the domain of the splits with the added ghost layer in the output
       // If wide_of_ghost_layer != 0, this is the final domain of the sub_complexes
-      out.splits_with_ghost_layers.push_back(sub_lower_upper_bounds);
+      out.splits_domain_with_ghost_layers.push_back(sub_lower_upper_bounds);
     }
     sub_kspaces[split].init(sub_lowerBound, sub_upperBound, kspace_isClosed);
   }
 
   for(size_t split = 0; split < number_of_splits; ++split) {
     sub_complexes.emplace_back(TComplex(sub_kspaces[split]));
+    // Note: You don't want to use simplicity table, some spels are going to be FIXED
+    // Also, isSimple from object does not give the same results than isSimpleByThinning
+    // being the latter correct and more general in the case of FIXED data.
+    // sub_complexes[split].copySimplicityTable(vc);
+
     // Copy cells and cell data from input vc to sub_complexes
     // First, iterate over the kspace of the sub-domain
     // Then find cell in original complex, if exists, insert it (copy) into the sub_complex
@@ -228,9 +366,9 @@ DGtal::functions::splitComplex(
     auto kcell = sub_lowerCell;
     static_assert(TComplex::KSpace::dimension == 3,
         "The KSpace::dimension of TComplex isn't 3");
-    for(auto k_x = sub_lowerCell_coords[0]; k_x < sub_upperCell_coords[0]; k_x++) {
-      for(auto k_y = sub_lowerCell_coords[1]; k_y < sub_upperCell_coords[1]; k_y++) {
-        for(auto k_z = sub_lowerCell_coords[2]; k_z < sub_upperCell_coords[2]; k_z++) {
+    for(auto k_x = sub_lowerCell_coords[0]; k_x <= sub_upperCell_coords[0]; k_x++) {
+      for(auto k_y = sub_lowerCell_coords[1]; k_y <= sub_upperCell_coords[1]; k_y++) {
+        for(auto k_z = sub_lowerCell_coords[2]; k_z <= sub_upperCell_coords[2]; k_z++) {
           kspace.uSetKCoord(kcell, 0, k_x);
           kspace.uSetKCoord(kcell, 1, k_y);
           kspace.uSetKCoord(kcell, 2, k_z);
@@ -239,7 +377,7 @@ DGtal::functions::splitComplex(
           if(iter_cell_map != vc.end(dim_cell)) {
             // iter_cell_map->first is equal to kcell...
             sub_complexes[split].insertCell(dim_cell,
-                kcell, iter_cell_map->second);
+                iter_cell_map->first, iter_cell_map->second);
           }
         }
       }
@@ -248,3 +386,12 @@ DGtal::functions::splitComplex(
   return out;
 }
 
+template < typename TComplex >
+void
+DGtal::functions::mergeSubComplexes(TComplex & out,
+    const std::vector<TComplex> &complexes)
+{
+  for(auto & sc : complexes) {
+    out |= sc;
+  }
+}

--- a/src/DGtal/topology/SplitFunctions.ih
+++ b/src/DGtal/topology/SplitFunctions.ih
@@ -200,13 +200,99 @@ DGtal::functions::extractSubComplex(
 
 template < typename TComplex >
 std::vector<typename TComplex::CellMapIterator>
+DGtal::functions::isInBorder(
+    const typename TComplex::KSpace &cell
+    const typename TComplex::Point & lowerBound,
+    const typename TComplex::Point & upperBound,
+    const typename TComplex::Point * wide_point,
+    const typename TComplex::Point * lowerBound_to_ignore,
+    const typename TComplex::Point * upperBound_to_ignore) {
+
+  const typename TComplex::Point wide =
+    wide_point ? *wide_point : typename TComplex::Point(1,1,1);
+
+  const auto cell_coords = kspace.uCoords(cell);
+  // dist to lower and upper
+  const auto distToLower = cell_coords - lowerBound;
+  const auto distToUpper = upperBound - cell_coords;;
+  bool is_close_to_lower_border =
+    distToLower[0] < wide[0]
+    || distToLower[1] < wide[1]
+    || distToLower[2] < wide[2];
+  bool is_close_to_upper_border =
+    distToUpper[0] < wide[0]
+    || distToUpper[1] < wide[1]
+    || distToUpper[2] < wide[2];
+
+  if(lowerBound_to_ignore && upperBound_to_ignore) {
+    if(is_close_to_lower_border) {
+      const auto distToLower_to_ignore = cell_coords - *lowerBound_to_ignore;
+      bool is_close_to_lower_border_to_ignore =
+        distToLower_to_ignore[0] < wide[0]
+        || distToLower_to_ignore[1] < wide[1]
+        || distToLower_to_ignore[2] < wide[2];
+
+      if(is_close_to_lower_border_to_ignore) {
+        // Don't ignore if it is closer to lowerBound than
+        // lowerBound_to_ignore (corners) for any dimension
+        // Compute the border plane normal that results in non-zero
+        // for the dimensions that need checking.
+        const auto lowerBound_border_plane_normal =
+          lowerBound - *lowerBound_to_ignore;
+        for(size_t dim = 0; dim < 3; dim++) {
+          if(lowerBound_border_plane_normal[dim]) {
+            if(distToLower[dim] < wide[dim]
+                && distToLower[dim] <= distToLower_to_ignore[dim]) {
+              is_close_to_lower_border_to_ignore = false;
+            }
+          }
+        }
+      }
+      is_close_to_lower_border &= !is_close_to_lower_border_to_ignore;
+    }
+
+    if(is_close_to_upper_border) {
+      const auto distToUpper_to_ignore = *upperBound_to_ignore - cell_coords;;
+      bool is_close_to_upper_border_to_ignore =
+        distToUpper_to_ignore[0] < wide[0]
+        || distToUpper_to_ignore[1] < wide[1]
+        || distToUpper_to_ignore[2] < wide[2];
+
+      if(is_close_to_upper_border_to_ignore) {
+        // Don't ignore if it is closer to upperBound than
+        // upperBound_to_ignore (corners) for any dimension
+        // Compute the border plane normal that results in non-zero
+        // for the dimensions that need checking.
+        const auto upperBound_border_plane_normal =
+          *upperBound_to_ignore - upperBound;
+        for(size_t dim = 0; dim < 3; dim++) {
+          if(upperBound_border_plane_normal[dim]) {
+            if(distToUpper[dim] < wide[dim]
+                && distToUpper[dim] <= distToUpper_to_ignore[dim]) {
+              is_close_to_upper_border_to_ignore = false;
+            }
+          }
+        }
+      }
+      is_close_to_upper_border &= !is_close_to_upper_border_to_ignore;
+    }
+  }
+
+  const bool isInBorder_not_to_ignore = is_close_to_lower_border
+    || is_close_to_upper_border;
+  return isInBorder_not_to_ignore;
+}
+
+template < typename TComplex >
+std::vector<typename TComplex::CellMapIterator>
 DGtal::functions::getBorderVoxels(
     TComplex & vc,
     const typename TComplex::Point & lowerBound,
     const typename TComplex::Point & upperBound,
     const typename TComplex::Point * wide_point,
     const typename TComplex::Point * lowerBound_to_ignore,
-    const typename TComplex::Point * upperBound_to_ignore) {
+    const typename TComplex::Point * upperBound_to_ignore)
+{
   const auto & kspace = vc.space();
   if(wide_point) {
     const typename TComplex::Point wide = *wide_point;
@@ -240,84 +326,16 @@ DGtal::functions::getBorderVoxels(
       }
     }
   }
-  const typename TComplex::Point wide = wide_point ? *wide_point : typename TComplex::Point(1,1,1);
-  // using KPreSpace = typename TComplex::KSpace::PreCellularGridSpace;
 
   using CellIterators = std::vector<typename TComplex::CellMapIterator>;
   CellIterators iterators;
 
   for(auto it = vc.begin(3); it != vc.end(3); ++it) {
     const auto & cell = it->first;
-    const auto cell_coords = kspace.uCoords(cell);
-    // dist to lower and upper
-    const auto distToLower = cell_coords - lowerBound;
-    const auto distToUpper = upperBound - cell_coords;;
-    // upperBound - cell_coords
-    bool is_close_to_lower_border =
-      distToLower[0] < wide[0]
-      || distToLower[1] < wide[1]
-      || distToLower[2] < wide[2];
-    bool is_close_to_upper_border =
-      distToUpper[0] < wide[0]
-      || distToUpper[1] < wide[1]
-      || distToUpper[2] < wide[2];
 
-    if(lowerBound_to_ignore && upperBound_to_ignore) {
-      if(is_close_to_lower_border) {
-        const auto distToLower_to_ignore = cell_coords - *lowerBound_to_ignore;
-        bool is_close_to_lower_border_to_ignore =
-          distToLower_to_ignore[0] < wide[0]
-          || distToLower_to_ignore[1] < wide[1]
-          || distToLower_to_ignore[2] < wide[2];
-
-        if(is_close_to_lower_border_to_ignore) {
-          // Don't ignore if it is closer to lowerBound than
-          // lowerBound_to_ignore (corners) for any dimension
-          // Compute the border plane normal that results in non-zero
-          // for the dimensions that need checking.
-          const auto lowerBound_border_plane_normal =
-            lowerBound - *lowerBound_to_ignore;
-          for(size_t dim = 0; dim < 3; dim++) {
-            if(lowerBound_border_plane_normal[dim]) {
-              if(distToLower[dim] < wide[dim]
-                 && distToLower[dim] <= distToLower_to_ignore[dim]) {
-                is_close_to_lower_border_to_ignore = false;
-              }
-            }
-          }
-        }
-        is_close_to_lower_border &= !is_close_to_lower_border_to_ignore;
-      }
-
-      if(is_close_to_upper_border) {
-        const auto distToUpper_to_ignore = *upperBound_to_ignore - cell_coords;;
-        bool is_close_to_upper_border_to_ignore =
-          distToUpper_to_ignore[0] < wide[0]
-          || distToUpper_to_ignore[1] < wide[1]
-          || distToUpper_to_ignore[2] < wide[2];
-
-        if(is_close_to_upper_border_to_ignore) {
-          // Don't ignore if it is closer to upperBound than
-          // upperBound_to_ignore (corners) for any dimension
-          // Compute the border plane normal that results in non-zero
-          // for the dimensions that need checking.
-          const auto upperBound_border_plane_normal =
-            *upperBound_to_ignore - upperBound;
-          for(size_t dim = 0; dim < 3; dim++) {
-            if(upperBound_border_plane_normal[dim]) {
-              if(distToUpper[dim] < wide[dim]
-                 && distToUpper[dim] <= distToUpper_to_ignore[dim]) {
-                is_close_to_upper_border_to_ignore = false;
-              }
-            }
-          }
-        }
-        is_close_to_upper_border &= !is_close_to_upper_border_to_ignore;
-      }
-    }
-
-    const bool isInBorder_not_to_ignore = is_close_to_lower_border
-      || is_close_to_upper_border;
+    const bool isInBorder_not_to_ignore = isInBorder( cell,
+        lowerBound, upperBound,
+        wide_point, lowerBound_to_ignore, upperBound_to_ignore);
 
     if(isInBorder_not_to_ignore) {
       iterators.push_back(it);
@@ -325,6 +343,86 @@ DGtal::functions::getBorderVoxels(
   }
   return iterators;
 }
+
+template < typename TComplex, typename TDistanceTransform >
+std::vector<typename TComplex::CellMapIterator>
+DGtal::functions::getBorderVoxelsWithDistanceMap(
+    TComplex & vc,
+    const typename TComplex::Point & lowerBound,
+    const typename TComplex::Point & upperBound,
+    const typename TComplex::Point * wide_point,
+    const typename TComplex::Point * lowerBound_to_ignore,
+    const typename TComplex::Point * upperBound_to_ignore,
+    const TDistanceTransform * dist_map)
+{
+  const auto & kspace = vc.space();
+  if(wide_point) {
+    const typename TComplex::Point wide = *wide_point;
+    // wide_point has to be positive
+    ASSERT(wide.min() > 0);
+    // wide point cannot be greater than the domain in any dimension
+    std::array<bool, 3> is_close_to_lower_upper_border_to_ignore =
+    {false, false, false};
+    if(lowerBound_to_ignore && upperBound_to_ignore) {
+      const auto dist_lowerToUpper_to_ignore =
+        *upperBound_to_ignore - *lowerBound_to_ignore;
+      for(size_t dim = 0; dim < 3; ++dim) {
+        if(wide[dim] <= dist_lowerToUpper_to_ignore[dim]) {
+          is_close_to_lower_upper_border_to_ignore[dim] = true;
+        }
+      }
+    }
+    const auto dist_lowerToUpper = upperBound - lowerBound;
+    for(size_t dim = 0; dim < 3; ++dim) {
+      if(wide[dim] >= dist_lowerToUpper[dim]
+         && !is_close_to_lower_upper_border_to_ignore[dim]) {
+        std::cerr <<
+          "wide_point in getBorderVoxels is equal or greater than the domain itself\n" <<
+          "wide_point: " << wide << "\n" <<
+          "dist_lowerToUpper: " << dist_lowerToUpper <<
+          std::endl;
+        if(lowerBound_to_ignore && upperBound_to_ignore) {
+          std::cerr << "dist_lowerToUpper_to_ignore: " <<
+            (*upperBound_to_ignore - *lowerBound_to_ignore) << std::endl;
+        }
+      }
+    }
+  }
+
+  using CellIterators = std::vector<typename TComplex::CellMapIterator>;
+  CellIterators iterators;
+
+  for(auto it = vc.begin(3); it != vc.end(3); ++it) {
+    const auto & cell = it->first;
+
+    const bool isInBorder_not_to_ignore = isInBorder( cell,
+        lowerBound, upperBound,
+        wide_point, lowerBound_to_ignore, upperBound_to_ignore);
+
+    if(isInBorder_not_to_ignore && dist_map) {
+      const auto cell_coords = kspace.uCoords(cell);
+      const auto distToLower = cell_coords - lowerBound;
+      const auto distToUpper = upperBound - cell_coords;;
+      const auto & dist_map_value = dist_map(cell);
+      bool closer_to_block_border_than_object_border = false;
+      for(size_t dim = 0; dim < 3; ++dim) {
+        if(   dist_map_value <= distToLower[dim]
+           || dist_map_value <= distToUpper[dim]) {
+          closer_to_block_border_than_object_border = true;
+        }
+      }
+      if(closer_to_block_border_than_object_border) {
+        iterators.push_back(it);
+      }
+    }
+    // With no dmap is exactly the same as getBorderVoxels
+    else if(isInBorder_not_to_ignore) {
+      iterators.push_back(it);
+    }
+  }
+  return iterators;
+}
+
 
 template < typename TComplex >
 void
@@ -348,8 +446,7 @@ template < typename TComplex >
 DGtal::SplittedComplexes<TComplex>
 DGtal::functions::splitComplex(
     const TComplex & vc ,
-    const size_t requested_number_of_splits,
-    const size_t wide_of_ghost_layer
+    const size_t requested_number_of_splits
     ) {
   const auto & kspace = vc.space();
   const auto & lowerBound = kspace.lowerBound();
@@ -363,7 +460,6 @@ DGtal::functions::splitComplex(
   SplittedComplexes<TComplex> out;
   out.number_of_splits = number_of_splits;
   out.splits = splits;
-  out.wide_of_ghost_layer = wide_of_ghost_layer;
   auto & sub_complexes = out.sub_complexes;
   // Note that when dividing a k-space special care hast to be taken in the
   // opennes or clossedness of the low dim cells (1-cell and 2-cell in 3D).
@@ -376,28 +472,10 @@ DGtal::functions::splitComplex(
     const auto sub_lower_upper_bounds_original = DGtal::functions::getSplit(
         split, requested_number_of_splits, lowerBound, upperBound);
     // Save the domain of the original splits in the output
-    // If wide_of_ghost_layer == 0, this is the final domain of the sub_complexes
     out.splits_domain.push_back(sub_lower_upper_bounds_original);
     auto sub_lower_upper_bounds = sub_lower_upper_bounds_original;
     auto & sub_lowerBound = sub_lower_upper_bounds[0];
     auto & sub_upperBound = sub_lower_upper_bounds[1];
-    if(wide_of_ghost_layer) {
-      // Add ghost layer only if it is not in a boundary of the original kspace
-      // Note: cast needed for PointVector operation.
-      const auto wide =
-        static_cast<typename TComplex::Point::Component>(wide_of_ghost_layer);
-      const auto limit_lowerBound = lowerBound + wide;
-      const auto limit_upperBound = upperBound - wide;
-      for(size_t dim = 0; dim < kspace.dimension; ++dim) {
-        if(sub_lowerBound[dim] > limit_lowerBound[dim] )
-          sub_lowerBound[dim] -= wide_of_ghost_layer;
-        if(sub_upperBound[dim] < limit_upperBound[dim])
-          sub_upperBound[dim] += wide_of_ghost_layer;
-      }
-      // Save the domain of the splits with the added ghost layer in the output
-      // If wide_of_ghost_layer != 0, this is the final domain of the sub_complexes
-      out.splits_domain_with_ghost_layers.push_back(sub_lower_upper_bounds);
-    }
     sub_kspaces[split].init(sub_lowerBound, sub_upperBound, kspace_isClosed);
   }
 

--- a/src/DGtal/topology/SplitFunctions.ih
+++ b/src/DGtal/topology/SplitFunctions.ih
@@ -158,11 +158,14 @@ std::array<TPoint, 2> DGtal::functions::getSplit(
   return output_lower_upper_bounds;
 }
 
+
+
 template < typename TComplex >
-  std::vector<TComplex>
+DGtal::functions::SplittedComplexes<TComplex>
 DGtal::functions::splitComplex(
     const TComplex & vc ,
-    const size_t requested_number_of_splits
+    const size_t requested_number_of_splits,
+    const size_t wide_of_ghost_layer
     ) {
   const auto & kspace = vc.space();
   const auto & lowerBound = kspace.lowerBound();
@@ -172,6 +175,11 @@ DGtal::functions::splitComplex(
     DGtal::functions::computeSplits(requested_number_of_splits,
         lowerBound, upperBound, splits.data());
   std::vector<typename TComplex::KSpace> sub_kspaces(number_of_splits);
+  // Initiate output struct
+  SplittedComplexes<TComplex> out;
+  out.number_of_splits = number_of_splits;
+  out.wide_of_ghost_layer = wide_of_ghost_layer;
+  auto & sub_complexes = out.sub_complexes;
   // Note that when dividing a k-space special care hast to be taken in the
   // opennes or clossedness of the low dim cells (1-cell and 2-cell in 3D).
   // To avoid sharing those pointels and linels in the frontier between subspaces,
@@ -180,13 +188,34 @@ DGtal::functions::splitComplex(
   // at least for thinning, so we make all the sub_kspaces closed.
   const bool kspace_isClosed = true;
   for(size_t split = 0; split < number_of_splits; ++split) {
-    const auto sub_lower_upper_bounds = DGtal::functions::getSplit(
+    const auto sub_lower_upper_bounds_original = DGtal::functions::getSplit(
         split, requested_number_of_splits, lowerBound, upperBound);
-    const auto & sub_lowerBound = sub_lower_upper_bounds[0];
-    const auto & sub_upperBound = sub_lower_upper_bounds[1];
+    // Save the domain of the original splits in the output
+    // If wide_of_ghost_layer == 0, this is the final domain of the sub_complexes
+    out.splits.push_back(sub_lower_upper_bounds_original);
+    auto sub_lower_upper_bounds = sub_lower_upper_bounds_original;
+    auto & sub_lowerBound = sub_lower_upper_bounds[0];
+    auto & sub_upperBound = sub_lower_upper_bounds[1];
+    if(wide_of_ghost_layer) {
+      // Add ghost layer only if it is not in a boundary of the original kspace
+      // Note: cast needed for PointVector operation.
+      const auto wide =
+        static_cast<typename TComplex::Point::Component>(wide_of_ghost_layer);
+      const auto limit_lowerBound = lowerBound + wide;
+      const auto limit_upperBound = upperBound - wide;
+      for(size_t dim = 0; dim < kspace.dimension; ++dim) {
+        if(sub_lowerBound[dim] > limit_lowerBound[dim] )
+          sub_lowerBound[dim] -= wide_of_ghost_layer;
+        if(sub_upperBound[dim] < limit_upperBound[dim])
+          sub_upperBound[dim] += wide_of_ghost_layer;
+      }
+      // Save the domain of the splits with the added ghost layer in the output
+      // If wide_of_ghost_layer != 0, this is the final domain of the sub_complexes
+      out.splits_with_ghost_layers.push_back(sub_lower_upper_bounds);
+    }
     sub_kspaces[split].init(sub_lowerBound, sub_upperBound, kspace_isClosed);
   }
-  std::vector<TComplex> sub_complexes;
+
   for(size_t split = 0; split < number_of_splits; ++split) {
     sub_complexes.emplace_back(TComplex(sub_kspaces[split]));
     // Copy cells and cell data from input vc to sub_complexes
@@ -215,18 +244,7 @@ DGtal::functions::splitComplex(
         }
       }
     }
-    // auto kcell = sub_lowerCell;
-    // do {
-    //   const auto dim_cell = kspace.uDim(kcell);
-    //   const auto iter_cell_map = vc.findCell(dim_cell, kcell);
-    //   if(iter_cell_map != vc.end(dim_cell)) {
-    //     // iter_cell_map->first is equal to kcell...
-    //     sub_complexes[split].insertCell(dim_cell,
-    //         kcell, iter_cell_map->second);
-    //   }
-    // }
-    // while( sub_kspaces[split].uNext(kcell, sub_lowerCell, sub_upperCell));
   }
-  return sub_complexes;
+  return out;
 }
 

--- a/src/DGtal/topology/SplitFunctions.ih
+++ b/src/DGtal/topology/SplitFunctions.ih
@@ -208,7 +208,6 @@ DGtal::functions::getBorderVoxels(
     const typename TComplex::Point * lowerBound_to_ignore,
     const typename TComplex::Point * upperBound_to_ignore) {
   const auto & kspace = vc.space();
-  const auto dimension = kspace.dimension;
   // wide_point has to be positive
   if(wide_point)
     ASSERT(wide_point->min() > 0);

--- a/src/DGtal/topology/SplitFunctions.ih
+++ b/src/DGtal/topology/SplitFunctions.ih
@@ -208,10 +208,39 @@ DGtal::functions::getBorderVoxels(
     const typename TComplex::Point * lowerBound_to_ignore,
     const typename TComplex::Point * upperBound_to_ignore) {
   const auto & kspace = vc.space();
-  // wide_point has to be positive
-  if(wide_point)
-    ASSERT(wide_point->min() > 0);
-  typename TComplex::Point wide = wide_point ? *wide_point : typename TComplex::Point(1,1,1);
+  if(wide_point) {
+    const typename TComplex::Point wide = *wide_point;
+    // wide_point has to be positive
+    ASSERT(wide.min() > 0);
+    // wide point cannot be greater than the domain in any dimension
+    std::array<bool, 3> is_close_to_lower_upper_border_to_ignore =
+    {false, false, false};
+    if(lowerBound_to_ignore && upperBound_to_ignore) {
+      const auto dist_lowerToUpper_to_ignore =
+        *upperBound_to_ignore - *lowerBound_to_ignore;
+      for(size_t dim = 0; dim < 3; ++dim) {
+        if(wide[dim] <= dist_lowerToUpper_to_ignore[dim]) {
+          is_close_to_lower_upper_border_to_ignore[dim] = true;
+        }
+      }
+    }
+    const auto dist_lowerToUpper = upperBound - lowerBound;
+    for(size_t dim = 0; dim < 3; ++dim) {
+      if(wide[dim] >= dist_lowerToUpper[dim]
+         && !is_close_to_lower_upper_border_to_ignore[dim]) {
+        std::cerr <<
+          "wide_point in getBorderVoxels is equal or greater than the domain itself\n" <<
+          "wide_point: " << wide << "\n" <<
+          "dist_lowerToUpper: " << dist_lowerToUpper <<
+          std::endl;
+        if(lowerBound_to_ignore && upperBound_to_ignore) {
+          std::cerr << "dist_lowerToUpper_to_ignore: " <<
+            (*upperBound_to_ignore - *lowerBound_to_ignore) << std::endl;
+        }
+      }
+    }
+  }
+  const typename TComplex::Point wide = wide_point ? *wide_point : typename TComplex::Point(1,1,1);
   // using KPreSpace = typename TComplex::KSpace::PreCellularGridSpace;
 
   using CellIterators = std::vector<typename TComplex::CellMapIterator>;
@@ -219,7 +248,6 @@ DGtal::functions::getBorderVoxels(
 
   for(auto it = vc.begin(3); it != vc.end(3); ++it) {
     const auto & cell = it->first;
-    bool isInside = true;
     const auto cell_coords = kspace.uCoords(cell);
     // dist to lower and upper
     const auto distToLower = cell_coords - lowerBound;
@@ -235,38 +263,63 @@ DGtal::functions::getBorderVoxels(
       || distToUpper[2] < wide[2];
 
     if(lowerBound_to_ignore && upperBound_to_ignore) {
-      const auto distToLower_to_ignore = cell_coords - lowerBound;
-      bool is_close_to_lower_border_to_ignore =
-        distToLower_to_ignore[0] < wide[0]
-        || distToLower_to_ignore[1] < wide[1]
-        || distToLower_to_ignore[2] < wide[2];
+      if(is_close_to_lower_border) {
+        const auto distToLower_to_ignore = cell_coords - *lowerBound_to_ignore;
+        bool is_close_to_lower_border_to_ignore =
+          distToLower_to_ignore[0] < wide[0]
+          || distToLower_to_ignore[1] < wide[1]
+          || distToLower_to_ignore[2] < wide[2];
 
-      if(is_close_to_lower_border_to_ignore) {
-        // Don't ignore it if closer to lowerBound than lowerBound_to_ignore (corners)
-        if(distToLower.min() >= distToLower_to_ignore.min()) {
-          is_close_to_lower_border_to_ignore = false;
+        if(is_close_to_lower_border_to_ignore) {
+          // Don't ignore if it is closer to lowerBound than
+          // lowerBound_to_ignore (corners) for any dimension
+          // Compute the border plane normal that results in non-zero
+          // for the dimensions that need checking.
+          const auto lowerBound_border_plane_normal =
+            lowerBound - *lowerBound_to_ignore;
+          for(size_t dim = 0; dim < 3; dim++) {
+            if(lowerBound_border_plane_normal[dim]) {
+              if(distToLower[dim] < wide[dim]
+                 && distToLower[dim] <= distToLower_to_ignore[dim]) {
+                is_close_to_lower_border_to_ignore = false;
+              }
+            }
+          }
         }
+        is_close_to_lower_border &= !is_close_to_lower_border_to_ignore;
       }
-      is_close_to_lower_border &= !is_close_to_lower_border_to_ignore;
 
-      const auto distToUpper_to_ignore = upperBound - cell_coords;;
-      bool is_close_to_upper_border_to_ignore =
-        distToUpper_to_ignore[0] < wide[0]
-        || distToUpper_to_ignore[1] < wide[1]
-        || distToUpper_to_ignore[2] < wide[2];
-      if(is_close_to_upper_border_to_ignore) {
-        // Don't ignore it if closer to upperBound than upperBound_to_ignore (corners)
-        if(distToUpper.min() >= distToUpper_to_ignore.min()) {
-          is_close_to_upper_border_to_ignore = false;
+      if(is_close_to_upper_border) {
+        const auto distToUpper_to_ignore = *upperBound_to_ignore - cell_coords;;
+        bool is_close_to_upper_border_to_ignore =
+          distToUpper_to_ignore[0] < wide[0]
+          || distToUpper_to_ignore[1] < wide[1]
+          || distToUpper_to_ignore[2] < wide[2];
+
+        if(is_close_to_upper_border_to_ignore) {
+          // Don't ignore if it is closer to upperBound than
+          // upperBound_to_ignore (corners) for any dimension
+          // Compute the border plane normal that results in non-zero
+          // for the dimensions that need checking.
+          const auto upperBound_border_plane_normal =
+            *upperBound_to_ignore - upperBound;
+          for(size_t dim = 0; dim < 3; dim++) {
+            if(upperBound_border_plane_normal[dim]) {
+              if(distToUpper[dim] < wide[dim]
+                 && distToUpper[dim] <= distToUpper_to_ignore[dim]) {
+                is_close_to_upper_border_to_ignore = false;
+              }
+            }
+          }
         }
+        is_close_to_upper_border &= !is_close_to_upper_border_to_ignore;
       }
-      is_close_to_upper_border &= !is_close_to_upper_border_to_ignore;
     }
 
-    isInside &= !is_close_to_lower_border
-      && !is_close_to_upper_border;
+    const bool isInBorder_not_to_ignore = is_close_to_lower_border
+      || is_close_to_upper_border;
 
-    if(!isInside) {
+    if(isInBorder_not_to_ignore) {
       iterators.push_back(it);
     }
   }

--- a/src/DGtal/topology/SplitFunctions.ih
+++ b/src/DGtal/topology/SplitFunctions.ih
@@ -1,0 +1,159 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file SplitFunctions.ih
+ * @author Pablo Hernandez-Cerdan (\c pablo.hernandez.cerdan@outlook.com)
+ *
+ * @date 2019/01/08
+ *
+ * Implementation of inline methods defined in SplitFunctions.h
+ *
+ * This file is part of the DGtal library.
+ */
+
+template <typename TPoint>
+size_t DGtal::functions::computeSplits(
+    const size_t requested_number_of_splits,
+    const TPoint & lowerBound,
+    const TPoint & upperBound,
+    unsigned int splits[]
+    )
+{
+  const auto dim = lowerBound.dimension;
+  auto region_size = upperBound - lowerBound;
+  for ( size_t i = 0; i < dim; ++i )
+  {
+    if ( region_size[ i ] < 0 )
+      throw std::runtime_error(
+      "upperBound is smaller than lowerBound, region_size is negative" );
+  }
+
+  // Implementation taken from ITK:
+  // itkImageRegionSplitterMultidimensional.cxx ComputeSplitInternal
+  // size of each splited region
+  std::vector<double> splitRegionSize(dim); // Note: stack allocation preferred
+  unsigned int        numberOfPieces = 1;
+
+  // initialize arrays
+  for (unsigned int i = 0; i < dim; ++i)
+  {
+    splits[i] = 1;
+    splitRegionSize[i] = region_size[i];
+  }
+
+  while (true)
+  {
+    // find the dimension with the largest size
+    unsigned int maxSplitDim = 0;
+    for (unsigned int i = 1; i < dim; ++i)
+    {
+      if (splitRegionSize[maxSplitDim] < splitRegionSize[i])
+      {
+        maxSplitDim = i;
+      }
+    }
+
+    // calculate the number of additional pieces this split would add
+    unsigned int additionalNumPieces = 1;
+    for (unsigned int i = 0; i < dim; ++i)
+    {
+      if (i != maxSplitDim)
+      {
+        additionalNumPieces *= splits[i];
+      }
+    }
+
+    // check if this would give us too many pieces or
+    // if this would require the subpixel splits
+    if ( numberOfPieces + additionalNumPieces > requested_number_of_splits ||
+         splits[ maxSplitDim ] == region_size[ maxSplitDim ] )
+    {
+      return numberOfPieces;
+    }
+
+    // update the variable with the new split
+    numberOfPieces += additionalNumPieces;
+    ++splits[maxSplitDim];
+    splitRegionSize[maxSplitDim] = region_size[maxSplitDim] / double(splits[maxSplitDim]);
+  }
+
+}
+template <typename TPoint>
+std::array<TPoint, 2> DGtal::functions::getSplit(
+    const size_t splitIndex,
+    const size_t requested_number_of_splits,
+    const TPoint & lowerBound,
+    const TPoint & upperBound
+    )
+{
+  std::array<TPoint, 2> output_lower_upper_bounds = {lowerBound, upperBound};
+  auto & outputLowerBound = output_lower_upper_bounds[0];
+  auto & outputUpperBound = output_lower_upper_bounds[1];
+
+  const auto dim = lowerBound.dimension;
+  auto region_size = upperBound - lowerBound;
+  auto output_region_size = region_size;
+  // Implementation taken from ITK:
+  // itkImageRegionSplitterMultidimensional.cxx GetSplitInternal
+  // number of splits in each dimension
+  std::vector<unsigned int> splits(dim); // Note: stack allocation preferred
+
+  // index into splitted regions
+  std::vector<unsigned int> splittedRegionIndex(dim); // Note: stack allocation preferred
+
+  const auto numberOfPieces = DGtal::functions::computeSplits(requested_number_of_splits,
+      lowerBound, upperBound, &splits[0]);
+
+  // determine which splitted region we are in
+  unsigned int offset = splitIndex;
+  for (unsigned i = dim - 1; i > 0; --i)
+  {
+    unsigned int dimensionOffset = 1;
+    for (unsigned int j = 0; j < i; ++j)
+    {
+      dimensionOffset *= splits[j];
+    }
+
+    splittedRegionIndex[i] = offset / dimensionOffset;
+    offset -= (splittedRegionIndex[i] * dimensionOffset);
+  }
+  splittedRegionIndex[0] = offset;
+
+
+  // Assign the output split region to the input region in-place
+  for (unsigned int i = 0; i < dim; i++)
+  {
+    const auto inputRegionSize = region_size[i];
+    const auto indexOffset =
+      std::floor((splittedRegionIndex[i]) * (inputRegionSize / double(splits[i])));
+
+    outputLowerBound[i] += indexOffset;
+    if (splittedRegionIndex[i] < splits[i] - 1)
+    {
+      output_region_size[i] =
+        std::floor((splittedRegionIndex[i] + 1) * (inputRegionSize / double(splits[i]))) - indexOffset;
+    }
+    else
+    {
+      // this dimension is falling off the edge of the image
+      output_region_size[i] = output_region_size[i] - indexOffset;
+    }
+  }
+  outputUpperBound = outputLowerBound + output_region_size;
+
+  return output_lower_upper_bounds;
+}

--- a/src/DGtal/topology/VoxelComplex.h
+++ b/src/DGtal/topology/VoxelComplex.h
@@ -60,6 +60,21 @@ VoxelComplex<TKSpace, TCellContainer>
 operator-(const VoxelComplex<TKSpace, TCellContainer> &,
           const VoxelComplex<TKSpace, TCellContainer> &);
 
+ /**
+  * Derived class from CubicalCellData needed for the
+  * persistenceAsymetricThinningScheme algorithm
+  * to keep track of the birth_date
+  *
+  * @sa CubicalCellData
+  */
+  struct CubicalCellDataWithBirthDate: public CubicalCellData {
+    using Parent = CubicalCellData;
+    inline CubicalCellDataWithBirthDate() : CubicalCellData(), birth_date(0) {}
+    CubicalCellDataWithBirthDate( uint32_t d ) : CubicalCellData(d), birth_date(0) {}
+    CubicalCellDataWithBirthDate( uint32_t d, uint32_t p ) : CubicalCellData(d), birth_date(p) {}
+    uint32_t birth_date;
+  };
+
   /////////////////////////////////////////////////////////////////////////////
   // template class VoxelComplex
   /**

--- a/src/DGtal/topology/VoxelComplex.h
+++ b/src/DGtal/topology/VoxelComplex.h
@@ -112,6 +112,8 @@ class VoxelComplex : public CubicalComplex<TKSpace, TCellContainer> {
     using Integer = typename KSpace::Integer;
     /** Type for a cell in the space. */
     using Cell = typename KSpace::Cell;
+    /** Type for a PreCell in the space. */
+    using PreCell = typename Cell::PreCell;
     /** Type for a sequence of cells in the space. */
     using Cells = typename KSpace::Cells;
     /** Type of the digital space. */
@@ -284,6 +286,32 @@ class VoxelComplex : public CubicalComplex<TKSpace, TCellContainer> {
      * This includes the khalmisky cells and also the object points.
      */
     void clear();
+
+    /**
+    * Clears all cells of dimension \a d of the voxel complex.
+    * @param d the dimension of cell \a aCell.
+    */
+    void clear( Dimension d );
+
+    /**
+     * Erase element pointed by iterator \a it.
+     * @param position any iterator on a valid cell.
+     */
+    void erase( typename Parent::Iterator position );
+
+    /**
+     * Erases cell \a aCell from the complex (STL version, see eraseCell).
+     * @param aCell any cell valid in the Khalimsky space associated to the complex.
+     * @return the number of cells effectively removed from the cubical complex.
+     */
+    Size erase( const Cell& aCell );
+
+    /**
+     * Erases range of cells [\a first, \a last ).
+     * @param first an iterator on the beginning of a range of cells within this complex.
+     * @param last an iterator on the end of a range of cells within this complex.
+     */
+    void erase( typename Parent::Iterator first, typename Parent::Iterator last );
 
     //------ Spels ------//
     /**

--- a/src/DGtal/topology/VoxelComplex.ih
+++ b/src/DGtal/topology/VoxelComplex.ih
@@ -62,9 +62,10 @@ inline DGtal::VoxelComplex<TKSpace, TCellContainer>::VoxelComplex(
 template <typename TKSpace, typename TCellContainer>
 inline DGtal::VoxelComplex<TKSpace, TCellContainer> &
 DGtal::VoxelComplex<TKSpace, TCellContainer>::
-operator=(const Self &other) {
+operator=(const Self &other)
+{
     if (this != &other) {
-        this->myKSpace = other.myKSpace;
+        this->myKSpace = Clone<TKSpace>(other.myKSpace);
         this->myCells = other.myCells;
         myTablePtr = other.myTablePtr;
         myPointToMaskPtr = other.myPointToMaskPtr;
@@ -87,7 +88,7 @@ operator=(const Self &other) {
 //     const Cell &voxel) const {
 //     ASSERT(isSpel(voxel) == true);
 //     ASSERT(this->belongs(voxel));
-//     auto &ks = this->space();
+//     const auto &ks = this->space();
 //     return *(myObject.pointSet().find(ks.uCoords(voxel)));
 // }
 
@@ -97,7 +98,8 @@ operator=(const Self &other) {
 template <typename TKSpace, typename TCellContainer>
 template <typename TDigitalSet>
 inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::construct(
-    const TDigitalSet &input_set) {
+    const TDigitalSet &input_set)
+{
     Parent::construct(input_set);
 }
 
@@ -105,14 +107,16 @@ template <typename TKSpace, typename TCellContainer>
 template <typename TDigitalSet>
 inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::construct(
     const TDigitalSet &input_set,
-    const Alias<ConfigMap> input_table) {
+    const Alias<ConfigMap> input_table)
+{
     Parent::construct(input_set);
     setSimplicityTable(input_table);
 }
 
 template <typename TKSpace, typename TCellContainer>
 void DGtal::VoxelComplex<TKSpace, TCellContainer>::setSimplicityTable(
-    const Alias<ConfigMap> input_table) {
+    const Alias<ConfigMap> input_table)
+{
     this->myTablePtr = input_table;
     this->myPointToMaskPtr =
         functions::mapZeroPointNeighborhoodToConfigurationMask<Point>();
@@ -121,7 +125,8 @@ void DGtal::VoxelComplex<TKSpace, TCellContainer>::setSimplicityTable(
 
 template <typename TKSpace, typename TCellContainer>
 void DGtal::VoxelComplex<TKSpace, TCellContainer>::copySimplicityTable(
-    const Self & other) {
+    const Self & other)
+{
     myTablePtr = other.myTablePtr;
     myPointToMaskPtr = other.myPointToMaskPtr;
     myIsTableLoaded = other.myIsTableLoaded;
@@ -130,27 +135,31 @@ void DGtal::VoxelComplex<TKSpace, TCellContainer>::copySimplicityTable(
 template <typename TKSpace, typename TCellContainer>
 const typename DGtal::VoxelComplex<TKSpace,
                                    TCellContainer>::ConfigMap &
-DGtal::VoxelComplex<TKSpace, TCellContainer>::table() const {
+DGtal::VoxelComplex<TKSpace, TCellContainer>::table() const
+{
     return *myTablePtr;
 }
 
 template <typename TKSpace, typename TCellContainer>
 const bool &
-DGtal::VoxelComplex<TKSpace, TCellContainer>::isTableLoaded() const {
+DGtal::VoxelComplex<TKSpace, TCellContainer>::isTableLoaded() const
+{
     return myIsTableLoaded;
 }
 
 template <typename TKSpace, typename TCellContainer>
 const typename DGtal::VoxelComplex<TKSpace,
                                    TCellContainer>::PointToMaskMap &
-DGtal::VoxelComplex<TKSpace, TCellContainer>::pointToMask() const {
+DGtal::VoxelComplex<TKSpace, TCellContainer>::pointToMask() const
+{
     return *myPointToMaskPtr;
 }
 //---------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>
 inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::voxelClose(
-    const Cell &kcell) {
-    auto &ks = this->space();
+    const Cell &kcell)
+{
+    const auto &ks = this->space();
     ASSERT(ks.uDim(kcell) == 3);
     Dimension l = 2;
     auto direct_faces = ks.uLowerIncident(kcell);
@@ -164,12 +173,13 @@ inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::voxelClose(
 //---------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>
 inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::cellsClose(
-    Dimension k, const Cells &cells) {
+    Dimension k, const Cells &cells)
+{
     if (k <= 0)
         return;
     if (cells.size() == 0)
         return;
-    auto &ks = this->space();
+    const auto &ks = this->space();
     Dimension l = k - 1;
     for (auto const &kcell : cells) {
         auto direct_faces = ks.uLowerIncident(kcell);
@@ -185,8 +195,9 @@ inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::cellsClose(
 template <typename TKSpace, typename TCellContainer>
 inline void
 DGtal::VoxelComplex<TKSpace, TCellContainer>::insertVoxelCell(
-    const Cell &kcell, const bool &close_it, const Data &data) {
-    auto &ks = this->space();
+    const Cell &kcell, const bool &close_it, const Data &data)
+{
+    const auto &ks = this->space();
     ASSERT(ks.uDim(kcell) == 3);
     this->insertCell(3, kcell, data);
     if (close_it)
@@ -197,8 +208,9 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::insertVoxelCell(
 template <typename TKSpace, typename TCellContainer>
 inline void
 DGtal::VoxelComplex<TKSpace, TCellContainer>::insertVoxelPoint(
-    const Point &dig_point, const bool &close_it, const Data &data) {
-    auto &ks = this->space();
+    const Point &dig_point, const bool &close_it, const Data &data)
+{
+    const auto &ks = this->space();
     insertVoxelCell(ks.uSpel(dig_point), close_it, data);
 }
 
@@ -206,25 +218,66 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::insertVoxelPoint(
 template <typename TKSpace, typename TCellContainer>
 template <typename TDigitalSet>
 inline void
-DGtal::VoxelComplex<TKSpace, TCellContainer>::dumpVoxels(TDigitalSet & in_out_set) {
-    auto &ks = this->space();
+DGtal::VoxelComplex<TKSpace, TCellContainer>::dumpVoxels(TDigitalSet & in_out_set)
+{
+    const auto &ks = this->space();
     for (auto it = this->begin(3), itE = this->end(3) ; it != itE ; ++it ){
         in_out_set.insertNew(ks.uCoords(it->first));
     }
 }
 //---------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>
-inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::clear() {
-    for (Dimension d = 0; d <= dimension; ++d)
-        this->Parent::clear(d);
+inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::clear()
+{
+    this->Parent::clear();
 }
 
 //---------------------------------------------------------------------------
+template <typename TKSpace, typename TCellContainer>
+inline
+void
+DGtal::VoxelComplex<TKSpace, TCellContainer>::
+clear( Dimension d )
+{
+  this->Parent::clear(d);
+}
+
+//---------------------------------------------------------------------------
+template <typename TKSpace, typename TCellContainer>
+inline
+void
+DGtal::VoxelComplex<TKSpace, TCellContainer>::
+erase( typename Parent::Iterator it )
+{
+  this->Parent::erase( it );
+}
+
+//-----------------------------------------------------------------------------
+template <typename TKSpace, typename TCellContainer>
+inline
+typename DGtal::VoxelComplex<TKSpace, TCellContainer>::Size
+DGtal::VoxelComplex<TKSpace, TCellContainer>::
+erase( const Cell& aCell )
+{
+    return this->Parent::erase(aCell);
+}
+
+//-----------------------------------------------------------------------------
+template <typename TKSpace, typename TCellContainer>
+inline
+void
+DGtal::VoxelComplex<TKSpace, TCellContainer>::
+erase( typename Parent::Iterator first, typename Parent::Iterator last )
+{
+    this->Parent::erase(first, last);
+}
+//-----------------------------------------------------------------------------
 
 template <typename TKSpace, typename TCellContainer>
 void DGtal::VoxelComplex<TKSpace, TCellContainer>::pointelsFromCell(
-    std::set<Cell> &pointels_out, const Cell &input_cell) const {
-    auto input_dim = this->space().uDim(input_cell);
+    std::set<Cell> &pointels_out, const Cell &input_cell) const
+{
+    const auto input_dim = this->space().uDim(input_cell);
     if (input_dim == 0) {
         pointels_out.emplace(input_cell);
         return;
@@ -238,8 +291,9 @@ void DGtal::VoxelComplex<TKSpace, TCellContainer>::pointelsFromCell(
 //---------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>
 void DGtal::VoxelComplex<TKSpace, TCellContainer>::spelsFromCell(
-    std::set<Cell> &spels_out, const Cell &input_cell) const {
-    auto input_dim = this->space().uDim(input_cell);
+    std::set<Cell> &spels_out, const Cell &input_cell) const
+{
+    const auto input_dim = this->space().uDim(input_cell);
     if (input_dim == this->dimension) {
         if (this->belongs(input_cell))
             spels_out.emplace(input_cell);
@@ -257,11 +311,11 @@ void DGtal::VoxelComplex<TKSpace, TCellContainer>::spelsFromCell(
 template <typename TKSpace, typename TCellContainer>
 typename DGtal::VoxelComplex<TKSpace, TCellContainer>::Clique
 DGtal::VoxelComplex<TKSpace, TCellContainer>::Kneighborhood(
-    const Cell &input_cell) const {
-
+    const Cell &input_cell) const
+{
     auto spels_out = neighborhoodVoxels(input_cell);
 
-    auto &ks = this->space();
+    const auto &ks = this->space();
     Clique clique(ks);
     for (const auto &v : spels_out)
         clique.insertCell(v);
@@ -272,8 +326,8 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::Kneighborhood(
 template <typename TKSpace, typename TCellContainer>
 std::set<typename TKSpace::Cell>
 DGtal::VoxelComplex<TKSpace, TCellContainer>::neighborhoodVoxels(
-    const Cell &input_spel) const {
-
+    const Cell &input_spel) const
+{
     std::set<Cell> pointels_out;
     std::set<Cell> spels_out;
     pointelsFromCell(pointels_out, input_spel);
@@ -285,7 +339,8 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::neighborhoodVoxels(
 template <typename TKSpace, typename TCellContainer>
 std::set<typename TKSpace::Cell>
 DGtal::VoxelComplex<TKSpace, TCellContainer>::properNeighborhoodVoxels(
-    const Cell &input_spel) const {
+    const Cell &input_spel) const
+{
 
     auto spels_out = neighborhoodVoxels(input_spel);
     auto search = spels_out.find(input_spel);
@@ -298,7 +353,8 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::properNeighborhoodVoxels(
 //---------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>
 bool DGtal::VoxelComplex<TKSpace, TCellContainer>::isSpel(
-    const Cell &b) const {
+    const Cell &b) const
+{
     return (this->space().uDim(b) == this->space().DIM);
 }
 
@@ -306,12 +362,12 @@ bool DGtal::VoxelComplex<TKSpace, TCellContainer>::isSpel(
 template <typename TKSpace, typename TCellContainer>
 typename DGtal::VoxelComplex<TKSpace, TCellContainer>::Cell
 DGtal::VoxelComplex<TKSpace,
-                    TCellContainer>::surfelBetweenAdjacentSpels(const Cell &A,
-                                                                const Cell &B)
-    const {
+    TCellContainer>::surfelBetweenAdjacentSpels(const Cell &A, const Cell &B)
+    const
+{
     ASSERT(isSpel(A) == true);
     ASSERT(isSpel(B) == true);
-    auto &ks = this->space();
+    const auto &ks = this->space();
     // Digital coordinates
     auto &&orientation_BA = ks.uCoords(B) - ks.uCoords(A);
     ASSERT(orientation_BA.norm1() == 1);
@@ -323,12 +379,14 @@ DGtal::VoxelComplex<TKSpace,
 // Cliques
 template <typename TKSpace, typename TCellContainer>
 std::pair<bool, typename DGtal::VoxelComplex<TKSpace,
-                                             TCellContainer>::Clique>
+    TCellContainer>::Clique>
 DGtal::VoxelComplex<TKSpace, TCellContainer>::K_2(
-    const typename KSpace::Point &A,
-    const typename KSpace::Point &B,
-    bool verbose) const {
-    auto &ks = this->space();
+        const typename KSpace::Point &A,
+        const typename KSpace::Point &B,
+        bool verbose) const
+{
+    const auto &ks = this->space();
+    using KPreSpace = typename TKSpace::PreCellularGridSpace;
     auto orientation_vector = B - A;
     ASSERT(orientation_vector.norm1() == 1);
     int direction{-1};
@@ -350,78 +408,78 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::K_2(
         up = {1, 0, 0};
     }
 
-    Cell x0 = ks.uSpel(A + right);
-    Cell x4 = ks.uSpel(A - right);
-    Cell x2 = ks.uSpel(A + up);
-    Cell x6 = ks.uSpel(A - up);
+    const PreCell x0 = KPreSpace::uSpel(A + right);
+    const PreCell x4 = KPreSpace::uSpel(A - right);
+    const PreCell x2 = KPreSpace::uSpel(A + up);
+    const PreCell x6 = KPreSpace::uSpel(A - up);
 
-    Cell x1 = ks.uSpel(A + up + right);
-    Cell x3 = ks.uSpel(A + up - right);
-    Cell x7 = ks.uSpel(A - up + right);
-    Cell x5 = ks.uSpel(A - up - right);
+    const PreCell x1 = KPreSpace::uSpel(A + up + right);
+    const PreCell x3 = KPreSpace::uSpel(A + up - right);
+    const PreCell x7 = KPreSpace::uSpel(A - up + right);
+    const PreCell x5 = KPreSpace::uSpel(A - up - right);
 
-    Cell y0 = ks.uSpel(B + right);
-    Cell y4 = ks.uSpel(B - right);
-    Cell y2 = ks.uSpel(B + up);
-    Cell y6 = ks.uSpel(B - up);
+    const PreCell y0 = KPreSpace::uSpel(B + right);
+    const PreCell y4 = KPreSpace::uSpel(B - right);
+    const PreCell y2 = KPreSpace::uSpel(B + up);
+    const PreCell y6 = KPreSpace::uSpel(B - up);
 
-    Cell y1 = ks.uSpel(B + up + right);
-    Cell y3 = ks.uSpel(B + up - right);
-    Cell y7 = ks.uSpel(B - up + right);
-    Cell y5 = ks.uSpel(B - up - right);
+    const PreCell y1 = KPreSpace::uSpel(B + up + right);
+    const PreCell y3 = KPreSpace::uSpel(B + up - right);
+    const PreCell y7 = KPreSpace::uSpel(B - up + right);
+    const PreCell y5 = KPreSpace::uSpel(B - up - right);
 
-    auto bx0 = this->belongs(KSpace::DIM, x0);
-    auto bx1 = this->belongs(KSpace::DIM, x1);
-    auto bx2 = this->belongs(KSpace::DIM, x2);
-    auto bx3 = this->belongs(KSpace::DIM, x3);
-    auto bx4 = this->belongs(KSpace::DIM, x4);
-    auto bx5 = this->belongs(KSpace::DIM, x5);
-    auto bx6 = this->belongs(KSpace::DIM, x6);
-    auto bx7 = this->belongs(KSpace::DIM, x7);
+    const auto bx0 = this->belongs(KSpace::DIM, x0);
+    const auto bx1 = this->belongs(KSpace::DIM, x1);
+    const auto bx2 = this->belongs(KSpace::DIM, x2);
+    const auto bx3 = this->belongs(KSpace::DIM, x3);
+    const auto bx4 = this->belongs(KSpace::DIM, x4);
+    const auto bx5 = this->belongs(KSpace::DIM, x5);
+    const auto bx6 = this->belongs(KSpace::DIM, x6);
+    const auto bx7 = this->belongs(KSpace::DIM, x7);
 
-    auto by0 = this->belongs(KSpace::DIM, y0);
-    auto by1 = this->belongs(KSpace::DIM, y1);
-    auto by2 = this->belongs(KSpace::DIM, y2);
-    auto by3 = this->belongs(KSpace::DIM, y3);
-    auto by4 = this->belongs(KSpace::DIM, y4);
-    auto by5 = this->belongs(KSpace::DIM, y5);
-    auto by6 = this->belongs(KSpace::DIM, y6);
-    auto by7 = this->belongs(KSpace::DIM, y7);
+    const auto by0 = this->belongs(KSpace::DIM, y0);
+    const auto by1 = this->belongs(KSpace::DIM, y1);
+    const auto by2 = this->belongs(KSpace::DIM, y2);
+    const auto by3 = this->belongs(KSpace::DIM, y3);
+    const auto by4 = this->belongs(KSpace::DIM, y4);
+    const auto by5 = this->belongs(KSpace::DIM, y5);
+    const auto by6 = this->belongs(KSpace::DIM, y6);
+    const auto by7 = this->belongs(KSpace::DIM, y7);
 
     Clique k2_crit(ks);
     if (bx0)
-        k2_crit.insertCell(x0);
+        k2_crit.insertCell(ks.uCell(x0));
     if (bx1)
-        k2_crit.insertCell(x1);
+        k2_crit.insertCell(ks.uCell(x1));
     if (bx2)
-        k2_crit.insertCell(x2);
+        k2_crit.insertCell(ks.uCell(x2));
     if (bx3)
-        k2_crit.insertCell(x3);
+        k2_crit.insertCell(ks.uCell(x3));
     if (bx4)
-        k2_crit.insertCell(x4);
+        k2_crit.insertCell(ks.uCell(x4));
     if (bx5)
-        k2_crit.insertCell(x5);
+        k2_crit.insertCell(ks.uCell(x5));
     if (bx6)
-        k2_crit.insertCell(x6);
+        k2_crit.insertCell(ks.uCell(x6));
     if (bx7)
-        k2_crit.insertCell(x7);
+        k2_crit.insertCell(ks.uCell(x7));
 
     if (by0)
-        k2_crit.insertCell(y0);
+        k2_crit.insertCell(ks.uCell(y0));
     if (by1)
-        k2_crit.insertCell(y1);
+        k2_crit.insertCell(ks.uCell(y1));
     if (by2)
-        k2_crit.insertCell(y2);
+        k2_crit.insertCell(ks.uCell(y2));
     if (by3)
-        k2_crit.insertCell(y3);
+        k2_crit.insertCell(ks.uCell(y3));
     if (by4)
-        k2_crit.insertCell(y4);
+        k2_crit.insertCell(ks.uCell(y4));
     if (by5)
-        k2_crit.insertCell(y5);
+        k2_crit.insertCell(ks.uCell(y5));
     if (by6)
-        k2_crit.insertCell(y6);
+        k2_crit.insertCell(ks.uCell(y6));
     if (by7)
-        k2_crit.insertCell(y7);
+        k2_crit.insertCell(ks.uCell(y7));
     // Note that input spels A,B are ommited.
 
     /////////////////////////////////
@@ -482,16 +540,16 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::K_2(
 
 //---------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>
-std::pair<bool, typename DGtal::VoxelComplex<TKSpace,
-                                             TCellContainer>::Clique>
+std::pair<bool, typename DGtal::VoxelComplex<TKSpace, TCellContainer>::Clique>
 DGtal::VoxelComplex<TKSpace, TCellContainer>::K_2(const Cell &A,
-                                                           const Cell &B,
-                                                           bool verbose) const {
+        const Cell &B,
+        bool verbose) const
+{
     // Precondition:
     // A and B are contiguous spels.
     ASSERT(isSpel(A) == true);
     ASSERT(isSpel(B) == true);
-    auto &ks = this->space();
+    const auto &ks = this->space();
     auto B_coord = ks.uCoords(B);
     auto A_coord = ks.uCoords(A);
     return this->K_2(A_coord, B_coord, verbose);
@@ -499,35 +557,38 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::K_2(const Cell &A,
 //---------------------------------------------------------------------------
 
 template <typename TKSpace, typename TCellContainer>
-std::pair<bool, typename DGtal::VoxelComplex<TKSpace,
-                                             TCellContainer>::Clique>
+std::pair<bool, typename DGtal::VoxelComplex<TKSpace, TCellContainer>::Clique>
 DGtal::VoxelComplex<TKSpace, TCellContainer>::K_2(const Cell &face2,
-                                                           bool verbose) const {
-    auto &ks = this->space();
+        bool verbose) const
+{
+    const auto &ks = this->space();
     ASSERT(ks.uIsSurfel(face2));
-    auto co_faces = ks.uCoFaces(face2);
-    ASSERT(co_faces.size() == 2);
-    auto &cf0 = co_faces[0];
-    auto &cf1 = co_faces[1];
+    using KPreSpace = typename TKSpace::PreCellularGridSpace;
+    const auto co_faces = KPreSpace::uCoFaces(face2);
+    const auto nco_faces = co_faces.size();
+    ASSERT(nco_faces == 2);
+    const auto &cf0 = co_faces[0];
+    const auto &cf1 = co_faces[1];
     // spels must belong to complex.
     if (this->belongs(cf0) && this->belongs(cf1))
-        return this->K_2(cf0, cf1, verbose);
+        return this->K_2(ks.uCell(cf0), ks.uCell(cf1), verbose);
     else
         return std::make_pair(false, Clique(ks));
 }
 //---------------------------------------------------------------------------
 
 template <typename TKSpace, typename TCellContainer>
-std::pair<bool, typename DGtal::VoxelComplex<TKSpace,
-                                             TCellContainer>::Clique>
+std::pair<bool, typename DGtal::VoxelComplex<TKSpace, TCellContainer>::Clique>
 DGtal::VoxelComplex<TKSpace, TCellContainer>::K_1(const Cell &face1,
-                                                           bool verbose) const {
-    auto &ks = this->space();
+        bool verbose) const
+{
+    const auto &ks = this->space();
     ASSERT(ks.uDim(face1) == 1);
+    using KPreSpace = typename TKSpace::PreCellularGridSpace;
     // Get 2 orth dirs in orient_orth
     std::vector<Point> dirs_orth;
-    for (auto q = ks.uOrthDirs(face1); q != 0; ++q) {
-        Dimension dir = *q;
+    for (auto q = KPreSpace::uOrthDirs(face1); q != 0; ++q) {
+        const Dimension dir = *q;
         Point positive_orth{0, 0, 0};
         for (Dimension i = 0; i != ks.DIM; ++i)
             if (i == dir)
@@ -537,21 +598,21 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::K_1(const Cell &face1,
     }
 
     auto &kface = face1.preCell().coordinates;
-    Point a{kface + dirs_orth[0] + dirs_orth[1]};
-    Point b{kface + dirs_orth[0] - dirs_orth[1]};
-    Point c{kface - dirs_orth[0] + dirs_orth[1]};
-    Point d{kface - dirs_orth[0] - dirs_orth[1]};
+    const Point a{kface + dirs_orth[0] + dirs_orth[1]};
+    const Point b{kface + dirs_orth[0] - dirs_orth[1]};
+    const Point c{kface - dirs_orth[0] + dirs_orth[1]};
+    const Point d{kface - dirs_orth[0] - dirs_orth[1]};
 
-    Cell A = ks.uCell(a);
-    Cell B = ks.uCell(b);
-    Cell C = ks.uCell(c);
-    Cell D = ks.uCell(d);
+    const PreCell A = KPreSpace::uCell(a);
+    const PreCell B = KPreSpace::uCell(b);
+    const PreCell C = KPreSpace::uCell(c);
+    const PreCell D = KPreSpace::uCell(d);
 
     // Now we need the other spels forming the mask
     // Get the direction (positive) linel spans.
     Point dir_parallel{0, 0, 0};
-    for (auto q = ks.uDirs(face1); q != 0; ++q) {
-        Dimension dir = *q;
+    for (auto q = KPreSpace::uDirs(face1); q != 0; ++q) {
+        const Dimension dir = *q;
         for (Dimension i = 0; i != ks.DIM; ++i)
             if (i == dir)
                 dir_parallel[i] = 1;
@@ -559,26 +620,26 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::K_1(const Cell &face1,
     // Note that C, B are interchangeable. Same in A,D. Same between X and Y
     // sets Changed notation from paper: XA=X0, XB=X1, XC=X2, XD=X3
     // X
-    Point xa{a + 2 * dir_parallel};
-    Point xb{b + 2 * dir_parallel};
-    Point xc{c + 2 * dir_parallel};
-    Point xd{d + 2 * dir_parallel};
+    const Point xa{a + 2 * dir_parallel};
+    const Point xb{b + 2 * dir_parallel};
+    const Point xc{c + 2 * dir_parallel};
+    const Point xd{d + 2 * dir_parallel};
     // Y
-    Point ya{a - 2 * dir_parallel};
-    Point yb{b - 2 * dir_parallel};
-    Point yc{c - 2 * dir_parallel};
-    Point yd{d - 2 * dir_parallel};
+    const Point ya{a - 2 * dir_parallel};
+    const Point yb{b - 2 * dir_parallel};
+    const Point yc{c - 2 * dir_parallel};
+    const Point yd{d - 2 * dir_parallel};
 
     // Cell of the mask from KCoords
-    Cell XA = ks.uCell(xa);
-    Cell XB = ks.uCell(xb);
-    Cell XC = ks.uCell(xc);
-    Cell XD = ks.uCell(xd);
+    const PreCell XA = KPreSpace::uCell(xa);
+    const PreCell XB = KPreSpace::uCell(xb);
+    const PreCell XC = KPreSpace::uCell(xc);
+    const PreCell XD = KPreSpace::uCell(xd);
 
-    Cell YA = ks.uCell(ya);
-    Cell YB = ks.uCell(yb);
-    Cell YC = ks.uCell(yc);
-    Cell YD = ks.uCell(yd);
+    const PreCell YA = KPreSpace::uCell(ya);
+    const PreCell YB = KPreSpace::uCell(yb);
+    const PreCell YC = KPreSpace::uCell(yc);
+    const PreCell YD = KPreSpace::uCell(yd);
 
     /////////////////////////////////
     // Critical Clique Conditions:
@@ -628,48 +689,49 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::K_1(const Cell &face1,
     // out clique is the intersection between mask and object
     Clique k1(ks);
     if (this->belongs(KSpace::DIM, A))
-        k1.insert(A);
+        k1.insert(ks.uCell(A));
     if (this->belongs(KSpace::DIM, B))
-        k1.insert(B);
+        k1.insert(ks.uCell(B));
     if (this->belongs(KSpace::DIM, C))
-        k1.insert(C);
+        k1.insert(ks.uCell(C));
     if (this->belongs(KSpace::DIM, D))
-        k1.insert(D);
+        k1.insert(ks.uCell(D));
     return std::make_pair(is_critical, k1);
 }
 //---------------------------------------------------------------------------
 
 template <typename TKSpace, typename TCellContainer>
-std::pair<bool, typename DGtal::VoxelComplex<TKSpace,
-                                             TCellContainer>::Clique>
+std::pair<bool, typename DGtal::VoxelComplex<TKSpace, TCellContainer>::Clique>
 DGtal::VoxelComplex<TKSpace, TCellContainer>::K_0(const Cell &face0,
-                                                           bool verbose) const {
-    auto &ks = this->space();
+        bool verbose) const
+{
+    const auto &ks = this->space();
     ASSERT(ks.uDim(face0) == 0);
+    using KPreSpace = typename TKSpace::PreCellularGridSpace;
     auto &kface = face0.preCell().coordinates;
-    Point z{0, 0, 1};
-    Point y{0, 1, 0};
-    Point x{1, 0, 0};
+    const Point z{0, 0, 1};
+    const Point y{0, 1, 0};
+    const Point x{1, 0, 0};
 
-    Point a{kface + x - y - z};
-    Point b{kface - x - y - z};
-    Point c{kface + x - y + z};
-    Point d{kface - x - y + z};
+    const Point a{kface + x - y - z};
+    const Point b{kface - x - y - z};
+    const Point c{kface + x - y + z};
+    const Point d{kface - x - y + z};
 
-    Point e{kface + x + y - z};
-    Point f{kface - x + y - z};
-    Point g{kface + x + y + z};
-    Point h{kface - x + y + z};
+    const Point e{kface + x + y - z};
+    const Point f{kface - x + y - z};
+    const Point g{kface + x + y + z};
+    const Point h{kface - x + y + z};
 
-    Cell A{ks.uCell(a)};
-    Cell B{ks.uCell(b)};
-    Cell C{ks.uCell(c)};
-    Cell D{ks.uCell(d)};
+    const PreCell A{KPreSpace::uCell(a)};
+    const PreCell B{KPreSpace::uCell(b)};
+    const PreCell C{KPreSpace::uCell(c)};
+    const PreCell D{KPreSpace::uCell(d)};
 
-    Cell E{ks.uCell(e)};
-    Cell F{ks.uCell(f)};
-    Cell G{ks.uCell(g)};
-    Cell H{ks.uCell(h)};
+    const PreCell E{KPreSpace::uCell(e)};
+    const PreCell F{KPreSpace::uCell(f)};
+    const PreCell G{KPreSpace::uCell(g)};
+    const PreCell H{KPreSpace::uCell(h)};
 
     /////////////////////////////////
     // Critical Clique Conditions:
@@ -708,33 +770,32 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::K_0(const Cell &face0,
     // out clique is the intersection between mask and object
     Clique k0_out(ks);
     if (bA)
-        k0_out.insert(A);
+        k0_out.insert(ks.uCell(A));
     if (bB)
-        k0_out.insert(B);
+        k0_out.insert(ks.uCell(B));
     if (bC)
-        k0_out.insert(C);
+        k0_out.insert(ks.uCell(C));
     if (bD)
-        k0_out.insert(D);
+        k0_out.insert(ks.uCell(D));
     if (bE)
-        k0_out.insert(E);
+        k0_out.insert(ks.uCell(E));
     if (bF)
-        k0_out.insert(F);
+        k0_out.insert(ks.uCell(F));
     if (bG)
-        k0_out.insert(G);
+        k0_out.insert(ks.uCell(G));
     if (bH)
-        k0_out.insert(H);
-    using namespace DGtal::functions;
+        k0_out.insert(ks.uCell(H));
 
     return std::make_pair(is_critical, k0_out);
 }
 //---------------------------------------------------------------------------
 
 template <typename TKSpace, typename TCellContainer>
-std::pair<bool, typename DGtal::VoxelComplex<TKSpace,
-                                             TCellContainer>::Clique>
+std::pair<bool, typename DGtal::VoxelComplex<TKSpace, TCellContainer>::Clique>
 DGtal::VoxelComplex<TKSpace, TCellContainer>::K_3(const Cell &voxel,
-                                                           bool verbose) const {
-    auto &ks = this->space();
+        bool verbose) const
+{
+    const auto &ks = this->space();
     ASSERT(ks.uDim(voxel) == 3);
     const bool is_critical = !isSimple(voxel);
 
@@ -777,12 +838,12 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::criticalCliques(
 //---------------------------------------------------------------------------
 
 template <typename TKSpace, typename TCellContainer>
-std::pair<bool, typename DGtal::VoxelComplex<TKSpace,
-                                             TCellContainer>::Clique>
+std::pair<bool, typename DGtal::VoxelComplex<TKSpace, TCellContainer>::Clique>
 DGtal::VoxelComplex<TKSpace, TCellContainer>::criticalCliquePair(
-    const Dimension d, const CellMapConstIterator &cellMapIterator) const {
-    auto &it = cellMapIterator;
-    auto &cell = it->first;
+        const Dimension d, const CellMapConstIterator &cellMapIterator) const
+{
+    const auto &it = cellMapIterator;
+    const auto &cell = it->first;
     // auto &cell_data = it->second;
     auto clique_p = std::make_pair(false, Clique(this->space()));
     if (d == 0)
@@ -803,13 +864,14 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::criticalCliquePair(
 template <typename TKSpace, typename TCellContainer>
 typename DGtal::VoxelComplex<TKSpace, TCellContainer>::CliqueContainer
 DGtal::VoxelComplex<TKSpace, TCellContainer>::criticalCliquesForD(
-    const Dimension d, const Parent &cubical, bool verbose) const {
+    const Dimension d, const Parent &cubical, bool verbose) const
+{
 #ifdef WITH_OPENMP
 
     ASSERT(dimension >= 0 && dimension <= 3);
     CliqueContainer critical;
 
-    auto nthreads = omp_get_num_procs();
+    const auto nthreads = omp_get_num_procs();
     omp_set_num_threads(nthreads);
     std::vector<CliqueContainer> p_critical;
     p_critical.resize(nthreads);
@@ -819,8 +881,8 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::criticalCliquesForD(
         {for (auto it = cubical.begin(d), itE = cubical.end(d); it != itE; ++it)
 #pragma omp task firstprivate(it)
              {auto clique_p = criticalCliquePair(d, it);
-    auto &is_critical = clique_p.first;
-    auto &clique = clique_p.second;
+    const auto &is_critical = clique_p.first;
+    const auto &clique = clique_p.second;
     // Push
     auto th = omp_get_thread_num();
     if (is_critical)
@@ -847,7 +909,7 @@ return critical;
     ASSERT(dimension >= 0 && dimension <= 3);
     CliqueContainer critical;
     for (auto it = cubical.begin(d), itE = cubical.end(d); it != itE; ++it) {
-        auto clique_p = criticalCliquePair(d, it);
+        const auto clique_p = criticalCliquePair(d, it);
         auto &is_critical = clique_p.first;
         auto &clique = clique_p.second;
         if (is_critical)
@@ -863,13 +925,14 @@ return critical;
 ///////////////////////////////////////////////////////////////////////////////
 template <typename TKSpace, typename TCellContainer>
 bool DGtal::VoxelComplex<TKSpace, TCellContainer>::isSimpleByThinning(
-    const Cell &input_spel) const {
+        const Cell &input_spel) const
+{
     // x = input_spel ; X = VoxelComplex ~ occupancy of khalimsky space
     // a) Get the neighborhood (voxels) of input_spel intersected
     // with the voxel complex. -- N^{*}(x) intersection X --
     ASSERT(this->space().uDim(input_spel) == 3);
-    auto spels_out = this->properNeighborhoodVoxels(input_spel);
-    auto &ks = this->space();
+    const auto spels_out = this->properNeighborhoodVoxels(input_spel);
+    const auto &ks = this->space();
     Clique clique(ks);
     for (const auto &v : spels_out)
         clique.insertCell(v);
@@ -885,7 +948,8 @@ bool DGtal::VoxelComplex<TKSpace, TCellContainer>::isSimpleByThinning(
 // Object wrappers :
 template <typename TKSpace, typename TCellContainer>
 bool DGtal::VoxelComplex<TKSpace, TCellContainer>::isSimple(
-    const Cell &input_cell) const {
+    const Cell &input_cell) const
+{
     ASSERT(isSpel(input_cell) == true);
 
     if (myIsTableLoaded) {
@@ -905,7 +969,8 @@ bool DGtal::VoxelComplex<TKSpace, TCellContainer>::isSimple(
  */
 template <typename TKSpace, typename TCellContainer>
 inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::selfDisplay(
-    std::ostream &out) const {
+    std::ostream &out) const
+{
     out << "[VoxelComplex dim=" << this->dim() << " chi=" << this->euler();
     out << " isTableLoaded? " << ((isTableLoaded()) ? "True" : "False");
 }
@@ -917,14 +982,16 @@ inline void DGtal::VoxelComplex<TKSpace, TCellContainer>::selfDisplay(
  */
 template <typename TKSpace, typename TCellContainer>
 inline bool
-DGtal::VoxelComplex<TKSpace, TCellContainer>::isValid() const {
+DGtal::VoxelComplex<TKSpace, TCellContainer>::isValid() const
+{
     return true;
 }
 
 //-----------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>
 inline std::string
-DGtal::VoxelComplex<TKSpace, TCellContainer>::className() const {
+DGtal::VoxelComplex<TKSpace, TCellContainer>::className() const
+{
     return "VoxelComplex";
 }
 
@@ -934,7 +1001,8 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::className() const {
 template <typename TKSpace, typename TCellContainer>
 inline std::ostream &DGtal::
 operator<<(std::ostream &out,
-           const VoxelComplex<TKSpace, TCellContainer> &object) {
+           const VoxelComplex<TKSpace, TCellContainer> &object)
+{
     object.selfDisplay(out);
     return out;
 }

--- a/src/DGtal/topology/VoxelComplex.ih
+++ b/src/DGtal/topology/VoxelComplex.ih
@@ -880,7 +880,8 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::criticalCliquesForD(
 #pragma omp single nowait
         {for (auto it = cubical.begin(d), itE = cubical.end(d); it != itE; ++it)
 #pragma omp task firstprivate(it)
-             {auto clique_p = criticalCliquePair(d, it);
+             {
+    auto clique_p = criticalCliquePair(d, it);
     const auto &is_critical = clique_p.first;
     const auto &clique = clique_p.second;
     // Push

--- a/src/DGtal/topology/VoxelComplexFunctions.h
+++ b/src/DGtal/topology/VoxelComplexFunctions.h
@@ -44,9 +44,19 @@
 #include <iostream>
 #include "DGtal/base/Common.h"
 #include "DGtal/topology/VoxelComplex.h"
+#include "DGtal/topology/SplitFunctions.h"
 //////////////////////////////////////////////////////////////////////////////
 namespace DGtal
 {
+  template <typename TComplex>
+    struct ThinningWithSplits {
+      SplittedComplexes<TComplex> splitted_complexes;
+      std::vector<TComplex> thin_complexes;
+      std::vector<TComplex> block_complexes;
+      std::vector<TComplex> thin_block_complexes;
+      TComplex merged_complex = TComplex(typename TComplex::KSpace());
+    };
+
   namespace functions {
 
     template < typename TComplex >
@@ -64,6 +74,27 @@ namespace DGtal
        > Skel,
        bool verbose = false
     );
+
+    template < typename TComplex>
+      ThinningWithSplits<TComplex>
+      asymetricThinningSchemeWithSplits(
+          TComplex & vc ,
+          std::function<
+          std::pair<typename TComplex::Cell, typename TComplex::Data>(
+            const typename TComplex::Clique &)
+          > Select ,
+          std::function<
+          bool(
+            const TComplex & ,
+            const typename TComplex::Cell & )
+          > Skel,
+          size_t requested_number_of_splits,
+          size_t wide_of_block_sub_complex,
+          size_t number_of_threads,
+          bool closeVoxels = true,
+          bool save_memory = false,
+          bool verbose = false
+          );
 
     template < typename TComplex >
     TComplex

--- a/src/DGtal/topology/VoxelComplexFunctions.h
+++ b/src/DGtal/topology/VoxelComplexFunctions.h
@@ -75,14 +75,41 @@ namespace DGtal
        bool verbose = false
     );
 
+    /**
+     * Performs a thinning dividing the input complex into subcomplexes.
+     * The borders of the subcomplexes associcated to splits
+     * (not the border of the original complex) are set to fixed, then
+     * thinned, and then border blocks are thinned.
+     *
+     * The final result is all the subcomplex + block_complexes merged.
+     *
+     * @tparam TComplex Complex type: VoxelComplex
+     * @param vc input complex to thin
+     * @param Select Select function, because the assymetry, a rule has to be in place to decide what voxel to keep. Use a distance map to keep it centered.
+     * @param Skel skel function, for example skelEnd to keep the end points.
+     * @param requested_number_of_splits requested number of splits
+     * into subdomains, the final splits might be less.
+     * @param wide_of_block_sub_complex The wide of the border blocks.
+     * This should be the max value of the distance map of the whole complex/image to ensure correctness.
+     * @param persistence if 0 uses @sa asymetricThinningScheme, if >0 uses
+     * @sa persistenceAsymetricThinningScheme with the persistence value
+     * @param number_of_threads number of threads, if 0, it uses all the
+     * threads avalilabe if WITH_OPENMP is enabled.
+     * @param closeVoxels the merged_complex has cells of all dimensions
+     * (not only spels)
+     * @param save_memory if false, deletes all the subcomplexes when not needed
+     * @param verbose extra verbosity
+     *
+     * @return ThinningWithSplits, member merged_complex has the final thin.
+     */
     template < typename TComplex>
       ThinningWithSplits<TComplex>
-      asymetricThinningSchemeWithSplits(
+      thinningSchemeWithSplits(
           TComplex & vc ,
           std::function<
           std::pair<typename TComplex::Cell, typename TComplex::Data>(
             const typename TComplex::Clique &)
-          > Select ,
+          > Select,
           std::function<
           bool(
             const TComplex & ,
@@ -90,7 +117,8 @@ namespace DGtal
           > Skel,
           size_t requested_number_of_splits,
           size_t wide_of_block_sub_complex,
-          size_t number_of_threads,
+          uint32_t persistence = 0, // use asymetricThinningScheme
+          size_t number_of_threads = 0, // 0 uses all threads (if OMP enabled)
           bool closeVoxels = true,
           bool save_memory = false,
           bool verbose = false

--- a/src/DGtal/topology/VoxelComplexFunctions.ih
+++ b/src/DGtal/topology/VoxelComplexFunctions.ih
@@ -32,6 +32,7 @@
 #include <cstdlib>
 #include <DGtal/topology/DigitalTopology.h>
 #include <random>
+#include <DGtal/topology/SplitFunctions.h>
 //////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -71,7 +72,6 @@ asymetricThinningScheme(
   std::set<std::pair<Cell, Data>, FirstComparator> selected_voxels_per_dim;
   TComplex already_selected_voxels(vc.space());
   TComplex constraint_set(vc.space());
-
   auto & Z = selected_voxels_per_dim;
   auto & Y = already_selected_voxels;
   auto & K = constraint_set;
@@ -80,6 +80,14 @@ asymetricThinningScheme(
   K.copySimplicityTable(vc);
   typename TComplex::Parent x_y(vc.space());
   typename TComplex::Parent x_k(vc.space());
+
+  // Initialize the constraint set
+  for (auto it = vc.begin(3), itE = vc.end(3) ; it != itE ; ++it ){
+    const auto &constraint_voxel = it->first ;
+    if( Skel(vc, constraint_voxel) == true || it->second.data == TComplex::FIXED){
+      K.insertVoxelCell(constraint_voxel);
+    }
+  }
 
   bool stability{false};
   uint64_t generation{0};
@@ -128,7 +136,7 @@ asymetricThinningScheme(
     x_k = X  - K;
     for (auto it = x_k.begin(3), itE = x_k.end(3) ; it != itE ; ++it ){
       auto new_voxel = it->first ;
-      if( Skel(X, new_voxel) == true){
+      if( Skel(X, new_voxel) == true || it->second.data == TComplex::FIXED){
         K.insertVoxelCell(new_voxel);
         // K.insertCell(3, new_voxel);
         // K.objectSet().insert(K.space().uCoords(new_voxel));
@@ -156,6 +164,150 @@ asymetricThinningScheme(
   return X;
 }
 
+template < typename TComplex>
+DGtal::ThinningWithSplits<TComplex>
+DGtal::functions::
+asymetricThinningSchemeWithSplits(
+    TComplex & vc ,
+    std::function<
+    std::pair<typename TComplex::Cell, typename TComplex::Data>(
+      const typename TComplex::Clique &)
+    > Select ,
+    std::function<
+    bool(
+      const TComplex & ,
+      const typename TComplex::Cell & )
+    > Skel,
+    size_t requested_number_of_splits,
+    size_t wide_of_block_sub_complex,
+    size_t number_of_threads,
+    bool closeVoxels,
+    bool saveMemory,
+    bool verbose )
+{
+  ThinningWithSplits<TComplex> out;
+  auto & splitted_complexes = out.splitted_complexes;
+  auto & thin_complexes = out.thin_complexes;
+  auto & merged_complex = out.merged_complex;
+  const auto & kspace = vc.space();
+  merged_complex = TComplex(kspace);
+  // first split the domain
+  splitted_complexes = splitComplex(vc, requested_number_of_splits);
+  const auto number_of_splits = splitted_complexes.number_of_splits;
+  const auto & lowerBound = kspace.lowerBound();
+  const auto & upperBound = kspace.upperBound();
+  // For getBorderVoxels
+  const int wide_int = static_cast<int>(wide_of_block_sub_complex);
+  const typename TComplex::Point wide_point{wide_int, wide_int, wide_int};
+  // Set borders as FIXED
+  const auto fixed_data = TComplex::FIXED;
+  for(size_t split = 0; split < number_of_splits; ++split) {
+    auto & sc = splitted_complexes.sub_complexes[split];
+    const auto & sub_lowerBound = sc.space().lowerBound();
+    const auto & sub_upperBound = sc.space().upperBound();
+    const auto border_iterators =
+      getBorderVoxels(sc, sub_lowerBound, sub_upperBound,
+          &wide_point, &lowerBound, &upperBound);
+    setBorderData(sc, border_iterators, fixed_data);
+    // perform thinning in each subcomplex
+    // TODO use threads here to do it in parallel
+    thin_complexes.emplace_back(asymetricThinningScheme(sc, Select, Skel, verbose));
+    if(saveMemory) sc.clear();
+  }
+  // thin_complexes[0] = asymetricThinningScheme(vc, Select, Skel, verbose);
+  // Thin on complexes around blocks
+  auto region_size = upperBound - lowerBound;
+  const auto & splits = splitted_complexes.splits;
+  typename TComplex::Point min_regions = {
+    static_cast<int>(region_size[0] / double(splits[0])),
+    static_cast<int>(region_size[1] / double(splits[1])),
+    static_cast<int>(region_size[2] / double(splits[2]))
+  };
+  // Blocks per dimension
+  auto & block_complexes = out.block_complexes;
+  auto & thin_block_complexes = out.thin_block_complexes;
+  const auto wide_block = wide_of_block_sub_complex + 1;
+  for(size_t dim = 0; dim < kspace.dimension; ++dim) {
+    for(size_t split = 1; split < splits[dim]; ++split) {
+      auto sub_lowerBound = lowerBound;
+      sub_lowerBound[dim] += min_regions[dim] * split;
+      auto sub_upperBound = upperBound;
+      sub_upperBound[dim] = sub_lowerBound[dim];
+      if(wide_of_block_sub_complex) {
+        sub_lowerBound[dim] -= wide_block;
+        sub_upperBound[dim] += wide_block;
+      }
+      if(sub_lowerBound[dim] < lowerBound[dim]) sub_lowerBound[dim] = lowerBound[dim];
+      if(sub_upperBound[dim] > upperBound[dim]) sub_upperBound[dim] = upperBound[dim];
+
+      // mark voxels already skeletonized as fixed (in the border)
+      block_complexes.emplace_back(extractSubComplex(vc, sub_lowerBound, sub_upperBound));
+      auto & bc = block_complexes.back();
+      const auto border_iterators =
+        getBorderVoxels(bc, sub_lowerBound, sub_upperBound,
+            nullptr, &lowerBound, &upperBound);
+      setBorderData(bc, border_iterators, fixed_data);
+      thin_block_complexes.emplace_back(asymetricThinningScheme(bc, Select, Skel, verbose));
+    if(saveMemory) bc.clear();
+    }
+  }
+  //----------------------- Merge ----------------------//
+  // We are only interested in spels, so we clear the cells in
+  // the rest of dimensions first to speed up merge.
+  for (auto & tc : thin_complexes) {
+    for(Dimension dim = 0; dim < 3; ++dim) {
+     tc.clear(dim);
+    }
+  }
+  for (auto & tbc : thin_block_complexes) {
+    for(Dimension dim = 0; dim < 3; ++dim) {
+      tbc.clear(dim);
+    }
+  }
+  // Remove fixed spels from thin_complexes
+  for (auto & tc : thin_complexes) {
+    const auto & sub_lowerBound = tc.space().lowerBound();
+    const auto & sub_upperBound = tc.space().upperBound();
+    const auto border_iterators =
+      getBorderVoxels(tc, sub_lowerBound, sub_upperBound,
+          &wide_point, &lowerBound, &upperBound);
+    for(auto border_it = border_iterators.begin();
+        border_it != border_iterators.end(); ++border_it) {
+      tc.erase((*border_it)->first);
+    }
+  }
+  for (auto & tbc : thin_block_complexes) {
+    const auto & sub_lowerBound = tbc.space().lowerBound();
+    const auto & sub_upperBound = tbc.space().upperBound();
+    const auto border_iterators =
+      getBorderVoxels(tbc, sub_lowerBound, sub_upperBound,
+          nullptr, &lowerBound, &upperBound);
+    for(auto border_it = border_iterators.begin();
+        border_it != border_iterators.end(); ++border_it) {
+      tbc.erase((*border_it)->first);
+    }
+  }
+  // Do the final merge with all thin_complexes and thin_block_complexes
+  mergeSubComplexes(merged_complex, thin_complexes);
+  mergeSubComplexes(merged_complex, thin_block_complexes);
+
+  if(saveMemory) {
+    for (auto & tc : thin_complexes) {
+      tc.clear();
+    }
+    for (auto & tbc : thin_block_complexes) {
+      tbc.clear();
+    }
+  }
+  // optionally, voxelClose to fill cells of lower dimensions
+  if(closeVoxels) {
+    for( auto it = merged_complex.begin(3); it != merged_complex.end(3); ++it) {
+      merged_complex.voxelClose(it->first);
+    }
+  }
+
+  return out;
+}
 
 template < typename TComplex >
 TComplex
@@ -325,6 +477,7 @@ DGtal::functions::selectMaxValue(
   typename TDistanceTransform::Value value{0};
   using ComplexConstIterator = typename TComplex::CellMapConstIterator;
   ComplexConstIterator selected_pair;
+  // std::vector<ComplexConstIterator> max_value_pairs;
 
   for(ComplexConstIterator it = clique.begin(3), itE = clique.end(3);
       it != itE ; ++it){
@@ -333,15 +486,18 @@ DGtal::functions::selectMaxValue(
     if(value > max_value){
       max_value = value;
       selected_pair = it;
+      // max_value_pairs.clear();
+      // max_value_pairs.push_back(it);
       continue;
     }
     if(value == max_value){
-      // max_value = value;
-      // selected_pair = it;
-      continue; // TODO choose one wisely when they have same DM value.
+      continue; // 
+      // max_value_pairs.push_back(it);
     }
   }
 
+  // Get the median of the max value
+  // selected_pair = max_value_pairs[max_value_pairs.size()/2];
   return *selected_pair;
 }
 //////////////////////////////////////////////////////////////////////////////

--- a/src/DGtal/topology/VoxelComplexFunctions.ih
+++ b/src/DGtal/topology/VoxelComplexFunctions.ih
@@ -33,7 +33,6 @@
 #include <DGtal/topology/DigitalTopology.h>
 #include <random>
 #include <DGtal/topology/SplitFunctions.h>
-#include <boost/core/ignore_unused.hpp>
 //////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -207,7 +206,9 @@ thinningSchemeWithSplits(
   //----------------- Thinning splitted_complexes ------------------//
 
   auto nthreads = number_of_threads;
-  boost::ignore_unused(nthreads);
+  boost::ignore_unused_variable_warning(nthreads);
+  if(verbose) trace.beginBlock("thinningSchemeWithSplits: thinning sub_complexes");
+  if(verbose) trace.info() << "wide_int: " << wide_int << std::endl;
 #ifdef WITH_OPENMP
   if(number_of_threads == 0) nthreads = omp_get_num_procs();
   omp_set_num_threads(nthreads);
@@ -222,16 +223,19 @@ thinningSchemeWithSplits(
     const auto border_iterators =
       getBorderVoxels(sc, sub_lowerBound, sub_upperBound,
           &wide_point, &lowerBound, &upperBound);
+    if(verbose) trace.info() << "#split: " << split << std::endl;
+    if(verbose) trace.info() << "wide_point " << wide_point << std::endl;
+    if(verbose) trace.info() << "#fixed border_iterators: " << border_iterators.size() << std::endl;
     setBorderData(sc, border_iterators, fixed_data);
     // perform thinning in each subcomplex
-    // TODO use threads here to do it in parallel
-    if(!persistence) {
+    if(persistence == 0) {
       thin_complexes[split] = asymetricThinningScheme(sc, Select, Skel, verbose);
     } else {
       thin_complexes[split] = persistenceAsymetricThinningScheme(sc, Select, Skel, persistence, verbose);
     }
     if(saveMemory) sc.clear();
   }
+  if(verbose) trace.endBlock();
   //----------------------- Border complexes ----------------------//
   // Thin on complexes around blocks
   auto region_size = upperBound - lowerBound;
@@ -279,6 +283,7 @@ thinningSchemeWithSplits(
   const auto nullptr_point = static_cast<typename TComplex::Point *>(nullptr);
 
   ASSERT(block_lower_upper_bounds.size() == number_of_block_complexes);
+  if(verbose) trace.beginBlock("thinningSchemeWithSplits: thinning border blocks");
 #ifdef WITH_OPENMP
 #pragma omp parallel for schedule(dynamic)
 #endif
@@ -292,7 +297,7 @@ thinningSchemeWithSplits(
       getBorderVoxels(bc, sub_lowerBound, sub_upperBound,
           nullptr_point, &lowerBound, &upperBound);
     setBorderData(bc, border_iterators, fixed_data);
-    if(!persistence) {
+    if(persistence == 0) {
       thin_block_complexes[block_i] = asymetricThinningScheme(bc, Select, Skel, verbose);
     } else {
       thin_block_complexes[block_i] = persistenceAsymetricThinningScheme(bc, Select, Skel, persistence, verbose);
@@ -353,6 +358,7 @@ thinningSchemeWithSplits(
       merged_complex.voxelClose(it->first);
     }
   }
+  if(verbose) trace.endBlock();
 
   return out;
 }

--- a/src/DGtal/topology/VoxelComplexFunctions.ih
+++ b/src/DGtal/topology/VoxelComplexFunctions.ih
@@ -167,7 +167,7 @@ asymetricThinningScheme(
 template < typename TComplex>
 DGtal::ThinningWithSplits<TComplex>
 DGtal::functions::
-asymetricThinningSchemeWithSplits(
+thinningSchemeWithSplits(
     TComplex & vc ,
     std::function<
     std::pair<typename TComplex::Cell, typename TComplex::Data>(
@@ -180,6 +180,7 @@ asymetricThinningSchemeWithSplits(
     > Skel,
     size_t requested_number_of_splits,
     size_t wide_of_block_sub_complex,
+    uint32_t persistence,
     size_t number_of_threads,
     bool closeVoxels,
     bool saveMemory,
@@ -193,7 +194,8 @@ asymetricThinningSchemeWithSplits(
   merged_complex = TComplex(kspace);
   // first split the domain
   splitted_complexes = splitComplex(vc, requested_number_of_splits);
-  const auto number_of_splits = splitted_complexes.number_of_splits;
+  const auto & number_of_splits = splitted_complexes.number_of_splits;
+  thin_complexes.resize(number_of_splits,TComplex(kspace));
   const auto & lowerBound = kspace.lowerBound();
   const auto & upperBound = kspace.upperBound();
   // For getBorderVoxels
@@ -201,6 +203,16 @@ asymetricThinningSchemeWithSplits(
   const typename TComplex::Point wide_point{wide_int, wide_int, wide_int};
   // Set borders as FIXED
   const auto fixed_data = TComplex::FIXED;
+  //----------------- Thinning splitted_complexes ------------------//
+
+  auto nthreads = number_of_threads;
+#ifdef WITH_OPENMP
+  if(number_of_threads == 0) nthreads = omp_get_num_procs();
+  omp_set_num_threads(nthreads);
+#endif
+#ifdef WITH_OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
   for(size_t split = 0; split < number_of_splits; ++split) {
     auto & sc = splitted_complexes.sub_complexes[split];
     const auto & sub_lowerBound = sc.space().lowerBound();
@@ -211,10 +223,14 @@ asymetricThinningSchemeWithSplits(
     setBorderData(sc, border_iterators, fixed_data);
     // perform thinning in each subcomplex
     // TODO use threads here to do it in parallel
-    thin_complexes.emplace_back(asymetricThinningScheme(sc, Select, Skel, verbose));
+    if(!persistence) {
+      thin_complexes[split] = asymetricThinningScheme(sc, Select, Skel, verbose);
+    } else {
+      thin_complexes[split] = persistenceAsymetricThinningScheme(sc, Select, Skel, persistence, verbose);
+    }
     if(saveMemory) sc.clear();
   }
-  // thin_complexes[0] = asymetricThinningScheme(vc, Select, Skel, verbose);
+  //----------------------- Border complexes ----------------------//
   // Thin on complexes around blocks
   auto region_size = upperBound - lowerBound;
   const auto & splits = splitted_complexes.splits;
@@ -225,7 +241,18 @@ asymetricThinningSchemeWithSplits(
   };
   // Blocks per dimension
   auto & block_complexes = out.block_complexes;
-  auto & thin_block_complexes = out.thin_block_complexes;
+
+  // Get the number of blocks (for multi-threading allocation)
+  size_t number_of_block_complexes = 0;
+  for(size_t dim = 0; dim < kspace.dimension; ++dim) {
+    for(size_t split = 1; split < splits[dim]; ++split) {
+      number_of_block_complexes++;
+    }
+  }
+  using PointPair = std::array<typename TComplex::Point, 2>;
+  std::vector<PointPair> block_lower_upper_bounds;
+  block_lower_upper_bounds.reserve(number_of_block_complexes);
+
   const auto wide_block = wide_of_block_sub_complex + 1;
   for(size_t dim = 0; dim < kspace.dimension; ++dim) {
     for(size_t split = 1; split < splits[dim]; ++split) {
@@ -240,16 +267,34 @@ asymetricThinningSchemeWithSplits(
       if(sub_lowerBound[dim] < lowerBound[dim]) sub_lowerBound[dim] = lowerBound[dim];
       if(sub_upperBound[dim] > upperBound[dim]) sub_upperBound[dim] = upperBound[dim];
 
-      // mark voxels already skeletonized as fixed (in the border)
-      block_complexes.emplace_back(extractSubComplex(vc, sub_lowerBound, sub_upperBound));
-      auto & bc = block_complexes.back();
-      const auto border_iterators =
-        getBorderVoxels(bc, sub_lowerBound, sub_upperBound,
-            nullptr, &lowerBound, &upperBound);
-      setBorderData(bc, border_iterators, fixed_data);
-      thin_block_complexes.emplace_back(asymetricThinningScheme(bc, Select, Skel, verbose));
-    if(saveMemory) bc.clear();
+      block_lower_upper_bounds.emplace_back(PointPair({sub_lowerBound, sub_upperBound}));
     }
+  }
+
+  block_complexes.resize(number_of_block_complexes, TComplex(kspace));
+  auto & thin_block_complexes = out.thin_block_complexes;
+  thin_block_complexes.resize(number_of_splits, TComplex(kspace));
+
+  ASSERT(block_lower_upper_bounds.size() == number_of_block_complexes);
+#ifdef WITH_OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
+  for(size_t block_i = 0; block_i < number_of_block_complexes; block_i++) {
+    const auto & sub_lowerBound = block_lower_upper_bounds[block_i][0];
+    const auto & sub_upperBound = block_lower_upper_bounds[block_i][1];
+    block_complexes[block_i] = extractSubComplex(vc, sub_lowerBound, sub_upperBound);
+    auto & bc = block_complexes[block_i];
+    // mark voxels already skeletonized as fixed (in the border)
+    const auto border_iterators =
+      getBorderVoxels(bc, sub_lowerBound, sub_upperBound,
+          nullptr, &lowerBound, &upperBound);
+    setBorderData(bc, border_iterators, fixed_data);
+    if(!persistence) {
+      thin_block_complexes[block_i] = asymetricThinningScheme(bc, Select, Skel, verbose);
+    } else {
+      thin_block_complexes[block_i] = persistenceAsymetricThinningScheme(bc, Select, Skel, persistence, verbose);
+    }
+    if(saveMemory) bc.clear();
   }
   //----------------------- Merge ----------------------//
   // We are only interested in spels, so we clear the cells in

--- a/src/DGtal/topology/VoxelComplexFunctions.ih
+++ b/src/DGtal/topology/VoxelComplexFunctions.ih
@@ -223,16 +223,35 @@ thinningSchemeWithSplits(
     const auto border_iterators =
       getBorderVoxels(sc, sub_lowerBound, sub_upperBound,
           &wide_point, &lowerBound, &upperBound);
-    if(verbose) trace.info() << "#split: " << split << std::endl;
-    if(verbose) trace.info() << "wide_point " << wide_point << std::endl;
-    if(verbose) trace.info() << "#fixed border_iterators: " << border_iterators.size() << std::endl;
+    if(verbose) {
+      trace.info() << "#split: " << split << std::endl;
+      trace.info() << "wide_point " << wide_point << std::endl;
+      trace.info() << "#fixed border_iterators: " << border_iterators.size() << std::endl;
+      const auto compare_its = [](
+          const typename TComplex::CellMapIterator &a,
+          const typename TComplex::CellMapIterator &b)
+      {
+        return a->first < b->first;
+      };
+      const auto max_fixed_point =
+        *std::max_element( border_iterators.begin(), border_iterators.end(), compare_its);
+      const auto min_fixed_point =
+        *std::min_element( border_iterators.begin(), border_iterators.end(), compare_its);
+      trace.info() << "sub_lowerBound: " << sub_lowerBound;
+      trace.info() << " sub_upperBound: " << sub_upperBound;
+      trace.info() << " min_point of fixed_border: " << min_fixed_point->first;
+      trace.info() << " max_point of fixed_border: " << max_fixed_point->first << std::endl;
+    }
     setBorderData(sc, border_iterators, fixed_data);
     // perform thinning in each subcomplex
+    // TODO remove
+    verbose = false;
     if(persistence == 0) {
       thin_complexes[split] = asymetricThinningScheme(sc, Select, Skel, verbose);
     } else {
       thin_complexes[split] = persistenceAsymetricThinningScheme(sc, Select, Skel, persistence, verbose);
     }
+    verbose = true;
     if(saveMemory) sc.clear();
   }
   if(verbose) trace.endBlock();
@@ -259,7 +278,6 @@ thinningSchemeWithSplits(
   std::vector<PointPair> block_lower_upper_bounds;
   block_lower_upper_bounds.reserve(number_of_block_complexes);
 
-  const auto wide_block = wide_of_block_sub_complex + 1;
   for(size_t dim = 0; dim < kspace.dimension; ++dim) {
     for(size_t split = 1; split < splits[dim]; ++split) {
       auto sub_lowerBound = lowerBound;
@@ -267,14 +285,28 @@ thinningSchemeWithSplits(
       auto sub_upperBound = upperBound;
       sub_upperBound[dim] = sub_lowerBound[dim];
       if(wide_of_block_sub_complex) {
-        sub_lowerBound[dim] -= wide_block;
-        sub_upperBound[dim] += wide_block;
+        sub_lowerBound[dim] -= wide_of_block_sub_complex + 1;
+        sub_upperBound[dim] += wide_of_block_sub_complex;
       }
       if(sub_lowerBound[dim] < lowerBound[dim]) sub_lowerBound[dim] = lowerBound[dim];
       if(sub_upperBound[dim] > upperBound[dim]) sub_upperBound[dim] = upperBound[dim];
 
       block_lower_upper_bounds.emplace_back(PointPair({sub_lowerBound, sub_upperBound}));
     }
+  }
+  if(verbose) {
+    trace.beginBlock("thin_complexes bounds");
+    for(const auto & tc : thin_complexes) {
+      trace.info() << " subcomplex lowerBound: " << tc.space().lowerBound();
+      trace.info() << " upperBound: " << tc.space().upperBound() << std::endl;
+    }
+    trace.endBlock();
+    trace.beginBlock("block_lower_upper_bounds");
+    for(const auto & block_lower_upper_bound : block_lower_upper_bounds) {
+      trace.info() << " block lowerBound: " << block_lower_upper_bound[0];
+      trace.info() << " upperBound: " << block_lower_upper_bound[1] << std::endl;
+    }
+    trace.endBlock();
   }
 
   block_complexes.resize(number_of_block_complexes, TComplex(kspace));

--- a/src/DGtal/topology/VoxelComplexFunctions.ih
+++ b/src/DGtal/topology/VoxelComplexFunctions.ih
@@ -33,6 +33,7 @@
 #include <DGtal/topology/DigitalTopology.h>
 #include <random>
 #include <DGtal/topology/SplitFunctions.h>
+#include <boost/core/ignore_unused.hpp>
 //////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -206,6 +207,7 @@ thinningSchemeWithSplits(
   //----------------- Thinning splitted_complexes ------------------//
 
   auto nthreads = number_of_threads;
+  boost::ignore_unused(nthreads);
 #ifdef WITH_OPENMP
   if(number_of_threads == 0) nthreads = omp_get_num_procs();
   omp_set_num_threads(nthreads);
@@ -274,6 +276,7 @@ thinningSchemeWithSplits(
   block_complexes.resize(number_of_block_complexes, TComplex(kspace));
   auto & thin_block_complexes = out.thin_block_complexes;
   thin_block_complexes.resize(number_of_splits, TComplex(kspace));
+  const auto nullptr_point = static_cast<typename TComplex::Point *>(nullptr);
 
   ASSERT(block_lower_upper_bounds.size() == number_of_block_complexes);
 #ifdef WITH_OPENMP
@@ -287,7 +290,7 @@ thinningSchemeWithSplits(
     // mark voxels already skeletonized as fixed (in the border)
     const auto border_iterators =
       getBorderVoxels(bc, sub_lowerBound, sub_upperBound,
-          nullptr, &lowerBound, &upperBound);
+          nullptr_point, &lowerBound, &upperBound);
     setBorderData(bc, border_iterators, fixed_data);
     if(!persistence) {
       thin_block_complexes[block_i] = asymetricThinningScheme(bc, Select, Skel, verbose);
@@ -326,7 +329,7 @@ thinningSchemeWithSplits(
     const auto & sub_upperBound = tbc.space().upperBound();
     const auto border_iterators =
       getBorderVoxels(tbc, sub_lowerBound, sub_upperBound,
-          nullptr, &lowerBound, &upperBound);
+          nullptr_point, &lowerBound, &upperBound);
     for(auto border_it = border_iterators.begin();
         border_it != border_iterators.end(); ++border_it) {
       tbc.erase((*border_it)->first);

--- a/src/DGtal/topology/VoxelComplexFunctions.ih
+++ b/src/DGtal/topology/VoxelComplexFunctions.ih
@@ -381,6 +381,10 @@ persistenceAsymetricThinningScheme(
     bool verbose )
 {
   if(verbose) trace.beginBlock("Persistence asymetricThinningScheme");
+  static_assert( boost::is_base_of< CubicalCellDataWithBirthDate, // base
+        typename TComplex::Data >::value, // derived
+        "Cell data needs a persistence value,"
+        " use CubicalCellDataWithBirthDate instead of default value.");
 
   using Cell = typename TComplex::Cell;
   using Data = typename TComplex::Data;
@@ -404,6 +408,14 @@ persistenceAsymetricThinningScheme(
   K.copySimplicityTable(vc);
   x_y.copySimplicityTable(vc);
 
+  // Initialize the constraint set
+  for (auto it = vc.begin(3), itE = vc.end(3) ; it != itE ; ++it ){
+    const auto &constraint_voxel = it->first ;
+    if( Skel(vc, constraint_voxel) == true || it->second.data == TComplex::FIXED){
+      K.insertVoxelCell(constraint_voxel);
+    }
+  }
+
   bool stability{false};
   uint64_t generation{0};
   auto xsize =  X.nbCells(3);
@@ -415,7 +427,8 @@ persistenceAsymetricThinningScheme(
       trace.info() << "Initial Voxels at generation: " << generation <<
         " ; X.nbCells(3): " << xsize << std::endl;
   }
-    // cubical cell data (aka, the birth_date) is initialized to zero already.
+    // member persistence of CubicalCellDataWithBirthDate
+    // (aka, the birth_date) is initialized to zero already.
   do {
     ++generation;
     // Update birth_date for our Skel function. (isIsthmus for example)
@@ -424,9 +437,10 @@ persistenceAsymetricThinningScheme(
       if (K.findCell(3, it->first) != K.end(3))
         continue;
       auto & voxel = it->first ;
-      auto & ccdata = it->second.data ;
-      if( Skel(X, voxel) == true && ccdata == 0)
-        ccdata = generation;
+      // auto & ccdata = it->second.data ;
+      auto & cbirth_date = it->second.birth_date;
+      if( Skel(X, voxel) == true && cbirth_date == 0)
+        cbirth_date = generation;
     }
     Y = K ;
     x_y = X; //optimization instead of x_y = X-Y, use x_y -= Y;
@@ -459,10 +473,11 @@ persistenceAsymetricThinningScheme(
     for (auto it = Y.begin(3), itE = Y.end(3) ; it != itE ; ++it ){
         auto & voxel = it->first;
         auto & ccdata = it->second.data;
+        auto & cbirth_date = it->second.birth_date;
         bool is_skel = Skel(X, voxel);
-        bool is_persistent_enough = (generation + 1 - ccdata) >= persistence;
-        if (is_skel && is_persistent_enough)
-          K.insertVoxelCell(voxel, close_it, ccdata);
+        bool is_persistent_enough = (generation + 1 - cbirth_date) >= persistence;
+        if ((is_skel || ccdata == TComplex::FIXED) && is_persistent_enough)
+          K.insertVoxelCell(voxel, close_it, typename TComplex::Data(ccdata, cbirth_date));
     }
 
     if(verbose){

--- a/tests/topology/CMakeLists.txt
+++ b/tests/topology/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(DGTAL_TESTS_SRC
    testParDirCollapse
    testHalfEdgeDataStructure
    testIndexedDigitalSurface
+   testSplitFunctions
 )
 
 FOREACH(FILE ${DGTAL_TESTS_SRC})

--- a/tests/topology/testSplitFunctions.cpp
+++ b/tests/topology/testSplitFunctions.cpp
@@ -1,0 +1,98 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file testSplitFunctions.cpp
+ * @ingroup Tests
+ * @author Pablo Hernandez-Cerdan (\c pablo.hernandez.cerdan@outlook.com)
+ *
+ * @date 2019/01/08
+ *
+ * Testing class for SplitFunctions
+ *
+ * This file is part of the DGtal library.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+#include "DGtal/base/Common.h"
+#include "DGtal/helpers/StdDefs.h"
+#include "DGtal/topology/SplitFunctions.h"
+///////////////////////////////////////////////////////////////////////////////
+using namespace std;
+using namespace DGtal;
+
+#define INBLOCK_TEST(x) \
+  nbok += ( x ) ? 1 : 0; \
+  nb++; \
+  trace.info() << "(" << nbok << "/" << nb << ") " \
+         << #x << std::endl;
+
+bool testComputeSplitsEasy() {
+    unsigned int nbok = 0;
+    unsigned int nb = 0;
+    using Point = DGtal::Z3i::Point;
+    Point lowerBound = {0,0,0};
+    Point upperBound = {4,6,8};
+    size_t requested_number_of_splits = 2;
+    std::vector<unsigned int> splits(lowerBound.dimension);
+    trace.beginBlock("computeSplits Easy");
+    trace.info() << "lowerBound: " << lowerBound << std::endl;
+    trace.info() << "upperBound: " << upperBound << std::endl;
+    auto number_of_splits = functions::computeSplits(
+            requested_number_of_splits,
+            lowerBound, upperBound,
+            splits.data());
+    trace.info() << "number_of_splits: " << number_of_splits << std::endl;
+    trace.info() << "splits: " << splits[ 0 ] << ", " << splits[ 1 ] << ", "
+                 << splits[ 2 ] << std::endl;
+    INBLOCK_TEST( number_of_splits == requested_number_of_splits );
+    INBLOCK_TEST( splits[0] == 1 );
+    INBLOCK_TEST( splits[1] == 1 );
+    INBLOCK_TEST( splits[2] == 2 );
+    trace.endBlock();
+    trace.beginBlock("getSplit Easy");
+    for (size_t split_index = 0; split_index < number_of_splits; split_index++) {
+        auto outputBounds =
+            DGtal::functions::getSplit(split_index, requested_number_of_splits,
+                    lowerBound, upperBound);
+        const auto & outputLowerBound = outputBounds[0];
+        const auto & outputUpperBound = outputBounds[1];
+        trace.info() << "split_index: " << split_index << std::endl;
+        trace.info() << "outputLowerBound: " << outputLowerBound << std::endl;
+        trace.info() << "outputUpperBound: " << outputUpperBound << std::endl;
+    }
+    size_t split_index = 1;
+    auto outputBounds =
+        DGtal::functions::getSplit(split_index, requested_number_of_splits,
+                lowerBound, upperBound);
+    const auto & outputLowerBound = outputBounds[0];
+    const auto & outputUpperBound = outputBounds[1];
+    INBLOCK_TEST( outputLowerBound[2] == 4 );
+    INBLOCK_TEST( outputUpperBound[2] == 8 );
+    trace.endBlock();
+    return nbok == nb;
+};
+
+int main()
+{
+  trace.beginBlock ( "Testing SplitFunctions" );
+
+  bool res = testComputeSplitsEasy();
+
+  trace.emphase() << ( res ? "Passed." : "Error." ) << endl;
+  trace.endBlock();
+  return res ? 0 : 1;
+}

--- a/tests/topology/testSplitFunctions.cpp
+++ b/tests/topology/testSplitFunctions.cpp
@@ -83,7 +83,7 @@ TEST_CASE("computeSplitsEasy", "[computeSplits, getSplit]") {
 }
 ////////////////////// splitComplex ///////////////////////////
 // Fixture for a X
-struct Fixture_X {
+struct Fixture_X_with_tight_bounds {
     ///////////////////////////////////////////////////////////
     // type aliases
     ///////////////////////////////////////////////////////////
@@ -108,7 +108,7 @@ struct Fixture_X {
     ///////////////////////////////////////////////////////////
     // Constructor
     ///////////////////////////////////////////////////////////
-    Fixture_X() : complex_fixture(ks_fixture), set_fixture(create_set()) {
+    Fixture_X_with_tight_bounds() : complex_fixture(ks_fixture), set_fixture(create_set()) {
         create_complex_from_set(set_fixture);
     }
 
@@ -118,8 +118,9 @@ struct Fixture_X {
     FixtureDigitalSet create_set() {
         using namespace DGtal;
 
-        Point p1(-16, -16, -16);
-        Point p2(16, 16, 16);
+        // with_tight_bounds
+        Point p1(-6, -6, -1);
+        Point p2(6, 6, 1);
         Domain domain(p1, p2);
 
         FixtureDigitalSet a_set(domain);
@@ -176,7 +177,7 @@ struct Fixture_X {
     }
 };
 
-TEST_CASE_METHOD(Fixture_X, "splitComplex", "[parallel]") {
+TEST_CASE_METHOD(Fixture_X_with_tight_bounds, "splitComplex", "[parallel]") {
     using namespace DGtal::functions;
     auto & vc = complex_fixture;
     // CHECK(vc.nbCells(0) == 528);
@@ -211,8 +212,8 @@ TEST_CASE_METHOD(Fixture_X, "splitComplex", "[parallel]") {
             CHECK(sc.nbCells(3) != 0);
             trace.info() << "lowerBound S0" <<  sc.space().lowerBound() << std::endl;
             trace.info() << "upperBound S0" <<  sc.space().upperBound() << std::endl;
-            CHECK(sc.space().lowerBound() == typename KSpace::Point(-16,-16,-16));
-            CHECK(sc.space().upperBound() == typename KSpace::Point(-1,16,16));
+            CHECK(sc.space().lowerBound() == typename KSpace::Point(-6,-6,-1));
+            CHECK(sc.space().upperBound() == typename KSpace::Point(-1,6,1));
             CHECK(sc.space().lowerBound() == out.splits_domain[sub_index][0]);
             CHECK(sc.space().upperBound() == out.splits_domain[sub_index][1]);
         }
@@ -225,8 +226,8 @@ TEST_CASE_METHOD(Fixture_X, "splitComplex", "[parallel]") {
             CHECK(sc.nbCells(3) != 0);
             trace.info() << "lowerBound S1" <<  sc.space().lowerBound() << std::endl;
             trace.info() << "upperBound S1" <<  sc.space().upperBound() << std::endl;
-            CHECK(sc.space().lowerBound() == typename KSpace::Point(0,-16,-16));
-            CHECK(sc.space().upperBound() == typename KSpace::Point(16,16,16));
+            CHECK(sc.space().lowerBound() == typename KSpace::Point(0,-6,-1));
+            CHECK(sc.space().upperBound() == typename KSpace::Point(6,6,1));
             CHECK(sc.space().lowerBound() == out.splits_domain[sub_index][0]);
             CHECK(sc.space().upperBound() == out.splits_domain[sub_index][1]);
             // Check cell exist in sub_complex
@@ -256,28 +257,28 @@ TEST_CASE_METHOD(Fixture_X, "splitComplex", "[parallel]") {
             auto & sc = sub_complexes[sub_index];
             trace.info() << "lowerBound S0" <<  sc.space().lowerBound() << std::endl;
             trace.info() << "upperBound S0" <<  sc.space().upperBound() << std::endl;
-            const auto sc_expected_lowerBound = typename KSpace::Point(-16,-16,-16);
-            const auto sc_expected_upperBound = typename KSpace::Point(0,16,16);
+            const auto sc_expected_lowerBound = typename KSpace::Point(-6,-6,-1);
+            const auto sc_expected_upperBound = typename KSpace::Point(0,6,1);
             CHECK(sc.space().lowerBound() == sc_expected_lowerBound);
             CHECK(sc.space().upperBound() == sc_expected_upperBound);
             CHECK(out.splits_domain_with_ghost_layers[sub_index][0] == sc_expected_lowerBound);
             CHECK(out.splits_domain_with_ghost_layers[sub_index][1] == sc_expected_upperBound);
-            CHECK(out.splits_domain[sub_index][0] == typename KSpace::Point(-16,-16,-16));
-            CHECK(out.splits_domain[sub_index][1] == typename KSpace::Point(-1,16,16));
+            CHECK(out.splits_domain[sub_index][0] == typename KSpace::Point(-6,-6,-1));
+            CHECK(out.splits_domain[sub_index][1] == typename KSpace::Point(-1,6,1));
         }
         {
             size_t sub_index = 1;
             auto & sc = sub_complexes[sub_index];
             trace.info() << "lowerBound S1" <<  sc.space().lowerBound() << std::endl;
             trace.info() << "upperBound S1" <<  sc.space().upperBound() << std::endl;
-            const auto sc_expected_lowerBound = typename KSpace::Point(-1,-16,-16);
-            const auto sc_expected_upperBound = typename KSpace::Point(16, 16, 16);
+            const auto sc_expected_lowerBound = typename KSpace::Point(-1,-6,-1);
+            const auto sc_expected_upperBound = typename KSpace::Point(6, 6, 1);
             CHECK(sc.space().lowerBound() == sc_expected_lowerBound);
             CHECK(sc.space().upperBound() == sc_expected_upperBound);
             CHECK(out.splits_domain_with_ghost_layers[sub_index][0] == sc_expected_lowerBound);
             CHECK(out.splits_domain_with_ghost_layers[sub_index][1] == sc_expected_upperBound);
-            CHECK(out.splits_domain[sub_index][0] == typename KSpace::Point(0,-16,-16));
-            CHECK(out.splits_domain[sub_index][1] == typename KSpace::Point(16,16,16));
+            CHECK(out.splits_domain[sub_index][0] == typename KSpace::Point(0,-6,-1));
+            CHECK(out.splits_domain[sub_index][1] == typename KSpace::Point(6,6,1));
         }
         trace.endBlock();
     }

--- a/tests/topology/testSplitFunctions.cpp
+++ b/tests/topology/testSplitFunctions.cpp
@@ -30,19 +30,16 @@
 #include "DGtal/base/Common.h"
 #include "DGtal/helpers/StdDefs.h"
 #include "DGtal/topology/SplitFunctions.h"
+#include "DGtalCatch.h"
+#include "DGtal/topology/KhalimskyCellHashFunctions.h"
+#include "DGtal/topology/VoxelComplex.h"
+#include "DGtal/topology/VoxelComplexFunctions.h"
+// #include <DGtal/io/viewers/Viewer3D.h>
 ///////////////////////////////////////////////////////////////////////////////
 using namespace std;
 using namespace DGtal;
 
-#define INBLOCK_TEST(x) \
-  nbok += ( x ) ? 1 : 0; \
-  nb++; \
-  trace.info() << "(" << nbok << "/" << nb << ") " \
-         << #x << std::endl;
-
-bool testComputeSplitsEasy() {
-    unsigned int nbok = 0;
-    unsigned int nb = 0;
+TEST_CASE("computeSplitsEasy", "[computeSplits, getSplit]") {
     using Point = DGtal::Z3i::Point;
     Point lowerBound = {0,0,0};
     Point upperBound = {4,6,8};
@@ -58,10 +55,10 @@ bool testComputeSplitsEasy() {
     trace.info() << "number_of_splits: " << number_of_splits << std::endl;
     trace.info() << "splits: " << splits[ 0 ] << ", " << splits[ 1 ] << ", "
                  << splits[ 2 ] << std::endl;
-    INBLOCK_TEST( number_of_splits == requested_number_of_splits );
-    INBLOCK_TEST( splits[0] == 1 );
-    INBLOCK_TEST( splits[1] == 1 );
-    INBLOCK_TEST( splits[2] == 2 );
+    CHECK( number_of_splits == requested_number_of_splits );
+    CHECK( splits[0] == 1 );
+    CHECK( splits[1] == 1 );
+    CHECK( splits[2] == 2 );
     trace.endBlock();
     trace.beginBlock("getSplit Easy");
     for (size_t split_index = 0; split_index < number_of_splits; split_index++) {
@@ -80,19 +77,177 @@ bool testComputeSplitsEasy() {
                 lowerBound, upperBound);
     const auto & outputLowerBound = outputBounds[0];
     const auto & outputUpperBound = outputBounds[1];
-    INBLOCK_TEST( outputLowerBound[2] == 4 );
-    INBLOCK_TEST( outputUpperBound[2] == 8 );
+    CHECK( outputLowerBound[2] == 4 );
+    CHECK( outputUpperBound[2] == 8 );
     trace.endBlock();
-    return nbok == nb;
+}
+////////////////////// splitComplex ///////////////////////////
+// Fixture for a X
+struct Fixture_X {
+    ///////////////////////////////////////////////////////////
+    // type aliases
+    ///////////////////////////////////////////////////////////
+    using Point = DGtal::Z3i::Point;
+    using Domain = DGtal::Z3i::Domain;
+    using KSpace = DGtal::Z3i::KSpace;
+
+    using FixtureDigitalTopology = DGtal::Z3i::DT26_6;
+    using FixtureDigitalSet = DGtal::DigitalSetByAssociativeContainer<
+        DGtal::Z3i::Domain,
+        std::unordered_set<typename DGtal::Z3i::Domain::Point>>;
+    using FixtureMap = std::unordered_map<KSpace::Cell, CubicalCellData>;
+    using FixtureComplex = DGtal::VoxelComplex<KSpace, FixtureMap>;
+
+    ///////////////////////////////////////////////////////////
+    // fixture data
+    FixtureComplex complex_fixture;
+    FixtureDigitalSet set_fixture;
+    KSpace ks_fixture; // needed because ConstAlias in CC constructor.
+    ///////////////////////////////////////////////////////////
+
+    ///////////////////////////////////////////////////////////
+    // Constructor
+    ///////////////////////////////////////////////////////////
+    Fixture_X() : complex_fixture(ks_fixture), set_fixture(create_set()) {
+        create_complex_from_set(set_fixture);
+    }
+
+    ///////////////////////////////////////////////////////////
+    // Function members
+    ///////////////////////////////////////////////////////////
+    FixtureDigitalSet create_set() {
+        using namespace DGtal;
+
+        Point p1(-16, -16, -16);
+        Point p2(16, 16, 16);
+        Domain domain(p1, p2);
+
+        FixtureDigitalSet a_set(domain);
+        std::vector<Point> center_set;
+        center_set.reserve(9);
+
+        Point c00(0, 0, 0);
+        center_set.push_back(c00);
+        Point c01x(-1, 0, 0);
+        center_set.push_back(c01x);
+        Point c10x(1, 0, 0);
+        center_set.push_back(c10x);
+        Point c02x(-2, 0, 0);
+        center_set.push_back(c02x);
+        Point c20x(2, 0, 0);
+        center_set.push_back(c20x);
+
+        Point c01y(0, -1, 0);
+        center_set.push_back(c01y);
+        Point c10y(0, 1, 0);
+        center_set.push_back(c10y);
+        Point c02y(0, -2, 0);
+        center_set.push_back(c02y);
+        Point c20y(0, 2, 0);
+        center_set.push_back(c20y);
+
+        Point z_pos(0, 0, 1);
+        int branch_length(4);
+        std::vector<Point> diagonals;
+        diagonals.reserve(6);
+        for (const auto &p : center_set) {
+            diagonals.clear();
+            for (int l = 0; l <= branch_length; ++l) {
+                diagonals.push_back({l, l, 0});
+                diagonals.push_back({l, -l, 0});
+                diagonals.push_back({-l, l, 0});
+                diagonals.push_back({-l, -l, 0});
+                for (int z = -1; z <= 1; ++z)
+                    for (const auto &d : diagonals)
+                        a_set.insert(p + d + (z * z_pos));
+            }
+        }
+
+		return a_set;
+    }
+
+    FixtureComplex &create_complex_from_set(FixtureDigitalSet &input_set) {
+
+        ks_fixture.init(input_set.domain().lowerBound(),
+                        input_set.domain().upperBound(), true);
+        complex_fixture = FixtureComplex(ks_fixture);
+        complex_fixture.construct(input_set);
+        return complex_fixture;
+    }
 };
 
-int main()
-{
-  trace.beginBlock ( "Testing SplitFunctions" );
-
-  bool res = testComputeSplitsEasy();
-
-  trace.emphase() << ( res ? "Passed." : "Error." ) << endl;
-  trace.endBlock();
-  return res ? 0 : 1;
+TEST_CASE_METHOD(Fixture_X, "splitComplex", "[parallel]") {
+    using namespace DGtal::functions;
+    auto & vc = complex_fixture;
+    // CHECK(vc.nbCells(0) == 528);
+    // CHECK(vc.nbCells(1) == 1276);
+    // CHECK(vc.nbCells(2) == 1016);
+    // CHECK(vc.nbCells(3) == 267);
+    // Modify data of a cell to check if data is copied to sub complexes
+    Point p{2, 0, 0};
+    const auto modified_cell = vc.space().uSpel(p);
+    const auto modified_cell_dim = vc.space().uDim(modified_cell);
+    auto it_cell= vc.findCell(modified_cell_dim, modified_cell);
+    CHECK(it_cell != vc.end(modified_cell_dim));
+    DGtal::uint32_t magic_number = 15;
+    it_cell->second.data = magic_number;
+    size_t requested_number_of_splits = 2;
+    SECTION("SplitComplex")  {
+        trace.beginBlock("SplitComplex");
+        trace.info() << "lowerBound" <<  vc.space().lowerBound() << std::endl;
+        trace.info() << "upperBound" <<  vc.space().upperBound() << std::endl;
+        auto sub_complexes = splitComplex(vc, requested_number_of_splits);
+        CHECK(sub_complexes.size() == requested_number_of_splits);
+        {
+            size_t sub_index = 0;
+            auto & sc = sub_complexes[sub_index];
+            CHECK(sc.nbCells(0) != 0);
+            CHECK(sc.nbCells(1) != 0);
+            CHECK(sc.nbCells(2) != 0);
+            CHECK(sc.nbCells(3) != 0);
+            trace.info() << "lowerBound S0" <<  sc.space().lowerBound() << std::endl;
+            trace.info() << "upperBound S0" <<  sc.space().upperBound() << std::endl;
+        }
+        {
+            size_t sub_index = 1;
+            auto & sc = sub_complexes[sub_index];
+            CHECK(sc.nbCells(0) != 0);
+            CHECK(sc.nbCells(1) != 0);
+            CHECK(sc.nbCells(2) != 0);
+            CHECK(sc.nbCells(3) != 0);
+            trace.info() << "lowerBound S1" <<  sc.space().lowerBound() << std::endl;
+            trace.info() << "upperBound S1" <<  sc.space().upperBound() << std::endl;
+            // Check cell exist in sub_complex
+            auto sc_it_cell = sc.findCell(it_cell->first);
+            CHECK(sc_it_cell != sc.end(modified_cell_dim));
+            // Check data is copied into sub_complexes
+            CHECK(sc[modified_cell].data == magic_number);
+        }
+        // SECTION( "visualize the split" ){
+        //     int argc(1);
+        //     char** argv(nullptr);
+        //     QApplication app(argc, argv);
+        //     Viewer3D<> viewer(vc.space());
+        //     viewer.show();
+        //
+        //     viewer.setFillColor(Color(200, 0, 0, 100));
+        //     auto & sc0 = sub_complexes[0];
+        //     for ( auto it = sc0.begin(3); it!= sc0.end(3); ++it )
+        //         viewer << it->first;
+        //     viewer.setFillColor(Color(0, 0, 100, 100));
+        //     auto & sc1 = sub_complexes[1];
+        //     for ( auto it = sc1.begin(3); it!= sc1.end(3); ++it )
+        //         viewer << it->first;
+        //
+        //     // All kspace voxels
+        //     viewer.setFillColor(Color(40, 40, 40, 10));
+        //     for ( auto it = vc.begin(3); it!= vc.end(3); ++it )
+        //         viewer << it->first;
+        //
+        //     viewer << Viewer3D<>::updateDisplay;
+        //     app.exec();
+        // }
+        trace.endBlock();
+    }
 }
+////////////////////// end splitComplex ////////////////////////

--- a/tests/topology/testSplitFunctions.cpp
+++ b/tests/topology/testSplitFunctions.cpp
@@ -34,7 +34,7 @@
 #include "DGtal/topology/KhalimskyCellHashFunctions.h"
 #include "DGtal/topology/VoxelComplex.h"
 #include "DGtal/topology/VoxelComplexFunctions.h"
-#include <DGtal/io/viewers/Viewer3D.h>
+// #include <DGtal/io/viewers/Viewer3D.h>
 ///////////////////////////////////////////////////////////////////////////////
 using namespace std;
 using namespace DGtal;
@@ -295,8 +295,9 @@ TEST_CASE_METHOD(Fixture_X, "splitComplex", "[parallel]") {
             const auto sub_upperBound = sc.space().upperBound();
             trace.info() << "lowerBound S0" <<  sub_lowerBound << std::endl;
             trace.info() << "upperBound S0" <<  sub_upperBound << std::endl;
+            const auto nullptr_point = static_cast<Point *>(nullptr);
             auto border_iterators =
-                getBorderVoxels(sc, sub_lowerBound, sub_upperBound, nullptr,
+                getBorderVoxels(sc, sub_lowerBound, sub_upperBound, nullptr_point,
                         &lowerBound, &upperBound);
             CHECK(border_iterators.size() == 15);
             const auto sc_expected_fixed = typename KSpace::Point(0,0,0);
@@ -313,30 +314,30 @@ TEST_CASE_METHOD(Fixture_X, "splitComplex", "[parallel]") {
             std::cout << coFaces.size() << std::endl;
             }
 
-            SECTION( "visualize the split" ){
-                int argc(1);
-                char** argv(nullptr);
-                QApplication app(argc, argv);
-                Viewer3D<> viewer(vc.space());
-                viewer.show();
-
-                viewer.setFillColor(Color(200, 0, 0, 100));
-                auto & sc0 = sub_complexes[0];
-                for ( auto it = sc0.begin(3); it!= sc0.end(3); ++it )
-                    viewer << it->first;
-                viewer.setFillColor(Color(0, 0, 100, 100));
-                auto & sc1 = sub_complexes[1];
-                for ( auto it = sc1.begin(3); it!= sc1.end(3); ++it )
-                    viewer << it->first;
-
-                // All kspace voxels
-                viewer.setFillColor(Color(40, 40, 40, 10));
-                for ( auto it = vc.begin(3); it!= vc.end(3); ++it )
-                    viewer << it->first;
-
-                viewer << Viewer3D<>::updateDisplay;
-                app.exec();
-            }
+            // SECTION( "visualize the split" ){
+            //     int argc(1);
+            //     char** argv(nullptr);
+            //     QApplication app(argc, argv);
+            //     Viewer3D<> viewer(vc.space());
+            //     viewer.show();
+            //
+            //     viewer.setFillColor(Color(200, 0, 0, 100));
+            //     auto & sc0 = sub_complexes[0];
+            //     for ( auto it = sc0.begin(3); it!= sc0.end(3); ++it )
+            //         viewer << it->first;
+            //     viewer.setFillColor(Color(0, 0, 100, 100));
+            //     auto & sc1 = sub_complexes[1];
+            //     for ( auto it = sc1.begin(3); it!= sc1.end(3); ++it )
+            //         viewer << it->first;
+            //
+            //     // All kspace voxels
+            //     viewer.setFillColor(Color(40, 40, 40, 10));
+            //     for ( auto it = vc.begin(3); it!= vc.end(3); ++it )
+            //         viewer << it->first;
+            //
+            //     viewer << Viewer3D<>::updateDisplay;
+            //     app.exec();
+            // }
         }
         trace.endBlock();
     }

--- a/tests/topology/testVoxelComplex.cpp
+++ b/tests/topology/testVoxelComplex.cpp
@@ -909,11 +909,12 @@ struct Fixture_X {
     Fixture_X() : complex_fixture(ks_fixture), set_fixture(create_set()) {
         create_complex_from_set(set_fixture);
     }
+    virtual ~Fixture_X(){};
 
     ///////////////////////////////////////////////////////////
     // Function members
     ///////////////////////////////////////////////////////////
-    FixtureDigitalSet create_set() {
+    virtual FixtureDigitalSet create_set() {
         using namespace DGtal;
 
         Point p1(-16, -16, -16);
@@ -964,7 +965,7 @@ struct Fixture_X {
 		return a_set;
     }
 
-    FixtureComplex &create_complex_from_set(FixtureDigitalSet &input_set) {
+    virtual FixtureComplex &create_complex_from_set(FixtureDigitalSet &input_set) {
 
         ks_fixture.init(input_set.domain().lowerBound(),
                         input_set.domain().upperBound(), true);
@@ -1132,8 +1133,26 @@ TEST_CASE_METHOD(Fixture_X, "X DistanceMap", "[x][distance][thin]") {
         trace.endBlock();
     }
 }
+struct Fixture_X_with_tight_domain : public Fixture_X {
+    using Parent = Fixture_X;
+    Fixture_X_with_tight_domain() : Parent() {
+        create_complex_from_set(set_fixture);
+    };
 
-TEST_CASE_METHOD(Fixture_X, "X DistanceMap With Splits", "[x][distance][thin][splits]") {
+    virtual FixtureComplex &create_complex_from_set(FixtureDigitalSet &input_set) {
+
+        // tight domain
+        Point p1(-6, -6, -1);
+        Point p2(6, 6, 1);
+
+        ks_fixture.init(p1, p2, true);
+        complex_fixture = FixtureComplex(ks_fixture);
+        complex_fixture.construct(input_set);
+        return complex_fixture;
+    }
+};
+
+TEST_CASE_METHOD(Fixture_X_with_tight_domain, "X DistanceMap With Splits", "[x][distance][thin][splits]") {
     using namespace DGtal::functions;
     auto &vc = complex_fixture;
     vc.setSimplicityTable(functions::loadTable(simplicity::tableSimple26_6));

--- a/tests/topology/testVoxelComplex.cpp
+++ b/tests/topology/testVoxelComplex.cpp
@@ -875,7 +875,7 @@ TEST_CASE_METHOD(Fixture_isthmus, "Persistence thin",
         };
         auto vc_new = persistenceAsymetricThinningScheme<FixtureComplex>(
             vc, selectRandom<FixtureComplex>, isthmusTable, 0);
-        CHECK(vc_new.nbCells(3) == 3);
+        CHECK(vc_new.nbCells(3) == 4);
     }
 }
 

--- a/tests/topology/testVoxelComplex.cpp
+++ b/tests/topology/testVoxelComplex.cpp
@@ -622,7 +622,7 @@ struct Fixture_isthmus {
     using FixtureDigitalSet = DGtal::DigitalSetByAssociativeContainer<
         DGtal::Z3i::Domain,
         std::unordered_set<typename DGtal::Z3i::Domain::Point>>;
-    using FixtureMap = std::unordered_map<KSpace::Cell, CubicalCellData>;
+    using FixtureMap = std::unordered_map<KSpace::Cell, CubicalCellDataWithBirthDate>;
     using FixtureComplex = DGtal::VoxelComplex<KSpace, FixtureMap>;
 
     ///////////////////////////////////////////////////////////
@@ -803,7 +803,7 @@ TEST_CASE_METHOD(Fixture_isthmus, "Thin complex", "[isthmus][thin][function]") {
     SECTION("with skelIsthmus") {
         auto vc_new = asymetricThinningScheme<FixtureComplex>(
             vc, selectRandom<FixtureComplex>, skelIsthmus<FixtureComplex>);
-        CHECK(vc_new.nbCells(3) == 3);
+        CHECK(vc_new.nbCells(3) == 4);
     }
 }
 //
@@ -893,8 +893,8 @@ struct Fixture_X {
     using FixtureDigitalSet = DGtal::DigitalSetByAssociativeContainer<
         DGtal::Z3i::Domain,
         std::unordered_set<typename DGtal::Z3i::Domain::Point>>;
-    using FixtureMap = std::unordered_map<KSpace::Cell, CubicalCellData>;
-    using FixtureComplex = DGtal::VoxelComplex<KSpace>;
+    using FixtureMap = std::unordered_map<KSpace::Cell, CubicalCellDataWithBirthDate>;
+    using FixtureComplex = DGtal::VoxelComplex<KSpace, FixtureMap>;
 
     ///////////////////////////////////////////////////////////
     // fixture data

--- a/tests/topology/testVoxelComplex.cpp
+++ b/tests/topology/testVoxelComplex.cpp
@@ -46,7 +46,7 @@
 #include "DGtal/kernel/BasicPointPredicates.h"
 #include "DGtal/topology/NeighborhoodConfigurations.h"
 #include "DGtal/topology/tables/NeighborhoodTables.h"
-#include <DGtal/io/viewers/Viewer3D.h>
+// #include <DGtal/io/viewers/Viewer3D.h>
 ///////////////////////////////////////////////////////////////////////////////
 
 using namespace std;
@@ -1076,25 +1076,25 @@ TEST_CASE_METHOD(Fixture_X, "X DistanceMap", "[x][distance][thin]") {
         SECTION("asymetricThinning"){
             auto vc_new = asymetricThinningScheme<FixtureComplex>(
                     vc, selectDistMax, skelEnd<FixtureComplex>, verbose);
-            SECTION( "visualize the thining" ){
-                int argc(1);
-                char** argv(nullptr);
-                QApplication app(argc, argv);
-                Viewer3D<> viewer(ks_fixture);
-                viewer.show();
-
-                viewer.setFillColor(Color(200, 200, 200, 100));
-                for ( auto it = vc_new.begin(3); it!= vc_new.end(3); ++it )
-                    viewer << it->first;
-
-                // All kspace voxels
-                viewer.setFillColor(Color(40, 40, 40, 10));
-                for ( auto it = vc.begin(3); it!= vc.end(3); ++it )
-                    viewer << it->first;
-
-                viewer << Viewer3D<>::updateDisplay;
-                app.exec();
-            }
+            // SECTION( "visualize the thining" ){
+            //     int argc(1);
+            //     char** argv(nullptr);
+            //     QApplication app(argc, argv);
+            //     Viewer3D<> viewer(ks_fixture);
+            //     viewer.show();
+            //
+            //     viewer.setFillColor(Color(200, 200, 200, 100));
+            //     for ( auto it = vc_new.begin(3); it!= vc_new.end(3); ++it )
+            //         viewer << it->first;
+            //
+            //     // All kspace voxels
+            //     viewer.setFillColor(Color(40, 40, 40, 10));
+            //     for ( auto it = vc.begin(3); it!= vc.end(3); ++it )
+            //         viewer << it->first;
+            //
+            //     viewer << Viewer3D<>::updateDisplay;
+            //     app.exec();
+            // }
         }
         SECTION("persistenceThinning"){
             auto table = *functions::loadTable(isthmusicity::tableOneIsthmus);
@@ -1151,7 +1151,7 @@ TEST_CASE_METHOD(Fixture_X, "X DistanceMap With Splits", "[x][distance][thin][sp
         auto selectDistMax = [&dt](const FixtureComplex::Clique &clique) {
             return selectMaxValue<DT, FixtureComplex>(dt, clique);
         };
-        SECTION("asymetricThinningSchemeWithSplits"){
+        SECTION("thinningSchemeWithSplits"){
             const size_t requested_number_of_splits = 4;
             typename DT::Value maxv = 0.0;
             for(auto it = dt.constRange().begin(),
@@ -1162,18 +1162,21 @@ TEST_CASE_METHOD(Fixture_X, "X DistanceMap With Splits", "[x][distance][thin][sp
             const size_t wide_of_block_sub_complex = std::floor<size_t>(maxv);
             trace.info() << "Max DistanceMap value: " << maxv << std::endl;
             trace.info() << "wide_of_block_sub_complex: " << wide_of_block_sub_complex << std::endl;
-            const size_t number_of_threads = 1; // TODO UNUSED for now
-            auto out = asymetricThinningSchemeWithSplits<FixtureComplex>(
+            const size_t number_of_threads = 0; // 0 is equivalent to max threads
+            const DGtal::uint32_t persistence = 0;
+            const bool closeVoxels = true;
+            const bool saveMemory = false;
+
+            auto out = thinningSchemeWithSplits<FixtureComplex>(
                     vc, selectDistMax, skelEnd<FixtureComplex>,
                     requested_number_of_splits,
                     wide_of_block_sub_complex,
+                    persistence,
                     number_of_threads,
+                    closeVoxels,
+                    saveMemory,
                     verbose);
-            auto & sc = out.splitted_complexes.sub_complexes;
-            auto & tc = out.thin_complexes;
-            auto & bc = out.block_complexes;
-            auto & tbc = out.thin_block_complexes;
-            auto & merged_complex = out.merged_complex;
+            // auto & vc_new = out.merged_complex;
             // SECTION( "visualize the thining" ){
             //     int argc(1);
             //     char** argv(nullptr);
@@ -1181,21 +1184,8 @@ TEST_CASE_METHOD(Fixture_X, "X DistanceMap With Splits", "[x][distance][thin][sp
             //     Viewer3D<> viewer(ks_fixture);
             //     viewer.show();
             //
-            //     viewer.setFillColor(Color(0, 200, 0, 100));
-            //     for ( auto it = tc[0].begin(3); it!= tc[0].end(3); ++it )
-            //         viewer << it->first;
-            //     // Draw the original sub_complex
-            //     viewer.setFillColor(Color(0, 100, 0, 20));
-            //     for ( auto it = sc[0].begin(3); it!= sc[0].end(3); ++it )
-            //         viewer << it->first;
-            //
-            //     // Draw the second sub_complex
-            //     viewer.setFillColor(Color(0, 0, 200, 100));
-            //     for ( auto it = tc[1].begin(3); it!= tc[1].end(3); ++it )
-            //         viewer << it->first;
-            //     // Draw the original sub_complex
-            //     viewer.setFillColor(Color(0, 0, 100, 20));
-            //     for ( auto it = sc[1].begin(3); it!= sc[1].end(3); ++it )
+            //     viewer.setFillColor(Color(200, 200, 200, 100));
+            //     for ( auto it = vc_new.begin(3); it!= vc_new.end(3); ++it )
             //         viewer << it->first;
             //
             //     // All kspace voxels
@@ -1206,57 +1196,6 @@ TEST_CASE_METHOD(Fixture_X, "X DistanceMap With Splits", "[x][distance][thin][sp
             //     viewer << Viewer3D<>::updateDisplay;
             //     app.exec();
             // }
-            // SECTION( "visualize the blocks" ){
-            //     int argc(1);
-            //     char** argv(nullptr);
-            //     QApplication app(argc, argv);
-            //     Viewer3D<> viewer(ks_fixture);
-            //     viewer.show();
-            //
-            //     viewer.setFillColor(Color(0, 200, 0, 100));
-            //     for ( auto it = tbc[0].begin(3); it!= tbc[0].end(3); ++it )
-            //         viewer << it->first;
-            //     // Draw the original sub_complex
-            //     viewer.setFillColor(Color(0, 100, 0, 20));
-            //     for ( auto it = bc[0].begin(3); it!= bc[0].end(3); ++it )
-            //         viewer << it->first;
-            //
-            //     // Draw the second sub_complex
-            //     viewer.setFillColor(Color(0, 0, 200, 100));
-            //     for ( auto it = tbc[1].begin(3); it!= tbc[1].end(3); ++it )
-            //         viewer << it->first;
-            //     // Draw the original sub_complex
-            //     viewer.setFillColor(Color(0, 0, 100, 20));
-            //     for ( auto it = bc[1].begin(3); it!= bc[1].end(3); ++it )
-            //         viewer << it->first;
-            //
-            //     // All kspace voxels
-            //     viewer.setFillColor(Color(40, 40, 40, 10));
-            //     for ( auto it = vc.begin(3); it!= vc.end(3); ++it )
-            //         viewer << it->first;
-            //
-            //     viewer << Viewer3D<>::updateDisplay;
-            //     app.exec();
-            // }
-            SECTION( "visualize the merged_block" ){
-                int argc(1);
-                char** argv(nullptr);
-                QApplication app(argc, argv);
-                Viewer3D<> viewer(ks_fixture);
-                viewer.show();
-
-                viewer.setFillColor(Color(0, 200, 0, 100));
-                for ( auto it = merged_complex.begin(3); it!= merged_complex.end(3); ++it )
-                    viewer << it->first;
-
-                // All kspace voxels
-                viewer.setFillColor(Color(40, 40, 40, 10));
-                for ( auto it = vc.begin(3); it!= vc.end(3); ++it )
-                    viewer << it->first;
-
-                viewer << Viewer3D<>::updateDisplay;
-                app.exec();
-            }
         }
         trace.endBlock();
     }


### PR DESCRIPTION
# PR Description

Given a domain defined by lower and upper bound points and
`requested_number_of_splits` implements two functions:
- computeSplits returns the number of splits that the
region can hold (lesser or equal than the requested)
- getSplit returns the ith split defined by the outputLowerBound and
outputUpperBound of the split region.

Implementation acquired from ITK: itkImageRegionSplitterMultidimensional.cxx
https://github.com/InsightSoftwareConsortium/ITK/blob/f971477cdacff22a861dfcbaccd89c0cf2755af7/Modules/Core/Common/src/itkImageRegionSplitterMultidimensional.cxx


# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)