### PR TITLE
Make testVoxelComplex faster

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -40,6 +40,8 @@
   - Provides partial flip, split and merge operations for half-edge data structures
     and triangulated surfaces (Jacques-Olivier Lachaud,
     [#1428](https://github.com/DGtal-team/DGtal/pull/1428))
+  - Makes testVoxelComplex faster, reducing the size of the test fixture
+    (Pablo Hernandez-Cerdan, [#1451](https://github.com/DGtal-team/DGtal/pull/1451))
 
 - *Shapes package*
   - Fix Lemniscate definition following Bernoulli's definition

--- a/tests/topology/testVoxelComplex.cpp
+++ b/tests/topology/testVoxelComplex.cpp
@@ -880,7 +880,7 @@ TEST_CASE_METHOD(Fixture_isthmus, "Persistence thin",
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// Fixture for a thick X
+// Fixture for an X
 struct Fixture_X {
     ///////////////////////////////////////////////////////////
     // type aliases
@@ -916,8 +916,8 @@ struct Fixture_X {
     FixtureDigitalSet create_set() {
         using namespace DGtal;
 
-        Point p1(-30, -30, -30);
-        Point p2(30, 30, 30);
+        Point p1(-16, -16, -16);
+        Point p2(16, 16, 16);
         Domain domain(p1, p2);
 
         FixtureDigitalSet a_set(domain);
@@ -945,7 +945,7 @@ struct Fixture_X {
         center_set.push_back(c20y);
 
         Point z_pos(0, 0, 1);
-        int branch_length(10);
+        int branch_length(4);
         std::vector<Point> diagonals;
         diagonals.reserve(6);
         for (const auto &p : center_set) {
@@ -955,7 +955,7 @@ struct Fixture_X {
                 diagonals.push_back({l, -l, 0});
                 diagonals.push_back({-l, l, 0});
                 diagonals.push_back({-l, -l, 0});
-                for (int z = -2; z <= 2; ++z)
+                for (int z = -1; z <= 1; ++z)
                     for (const auto &d : diagonals)
                         a_set.insert(p + d + (z * z_pos));
             }


### PR DESCRIPTION
Make testVoxelComplex faster

Reducing the amount of spels of Fixture_X by more than half.


# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)