### PR TITLE
Add public function .data() to PointVector

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,9 @@
   - DGtal can be compiled and used as a project (git) submodule (David
   Coeurjolly [#1444](https://github.com/DGtal-team/DGtal/pull/1444))
   
+- *Kernel package*
+  - Add .data() function to PointVector to expose internal array data.
+    (Pablo Hernandez-Cerdan,[#1452](https://github.com/DGtal-team/DGtal/pull/1452))
 
 - *DEC*
   - Add discrete calculus model of Ambrosio-Tortorelli functional in

--- a/src/DGtal/kernel/PointVector.h
+++ b/src/DGtal/kernel/PointVector.h
@@ -971,6 +971,14 @@ namespace DGtal
      **/
     ConstReverseIterator rend() const;
 
+    /**
+     * PointVector data() access to raw data of a std container
+     *
+     * @return container.data()
+     */
+    inline const Component* data() const noexcept;
+    inline Component* data() noexcept;
+
     // ----------------------- Array services ------------------------------
   public:
     /**

--- a/src/DGtal/kernel/PointVector.ih
+++ b/src/DGtal/kernel/PointVector.ih
@@ -271,6 +271,22 @@ DGtal::PointVector<dim, TComponent, TContainer>::size()
 //------------------------------------------------------------------------------
 template<DGtal::Dimension dim, typename TComponent, typename TContainer>
 inline
+const typename DGtal::PointVector<dim, TComponent, TContainer>::Component *
+DGtal::PointVector<dim, TComponent, TContainer>::data() const noexcept
+{
+  return myArray.data();
+}
+//------------------------------------------------------------------------------
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
+inline
+typename DGtal::PointVector<dim, TComponent, TContainer>::Component *
+DGtal::PointVector<dim, TComponent, TContainer>::data() noexcept
+{
+  return myArray.data();
+}
+//------------------------------------------------------------------------------
+template<DGtal::Dimension dim, typename TComponent, typename TContainer>
+inline
 const typename DGtal::PointVector<dim, TComponent, TContainer>::Component &
 DGtal::PointVector<dim, TComponent, TContainer>::operator[]( Dimension i ) const
 {

--- a/tests/kernel/testPointVector.cpp
+++ b/tests/kernel/testPointVector.cpp
@@ -98,6 +98,12 @@ TEST_CASE( "2D Point Vector Unit tests" )
       COMPARE_VALUE_AND_TYPE( p3.crossProduct(p1), p3_3d.crossProduct(p1_3d) );
       COMPARE_VALUE_AND_TYPE( crossProduct(p3, p1), crossProduct(p3_3d, p1_3d) );
     }
+  SECTION("Access data() of internal container")
+    {
+      const auto d = p1_3d.data();
+      CHECK(d[0] == p1[0]);
+      CHECK(d[1] == p1[1]);
+    }
 }
 
 TEST_CASE( "3D Point Vector Unit tests" )


### PR DESCRIPTION
# PR Description

Adds data() to PointVector that returns myArray.data()

This allows to facilitate interoperability of PointVector in other
libraries where raw arrays are used.

PointVector already has functions begin(), rbegin(), that are tied
to the use of std containers. data() was missing.

Note that in c++17 data() is constexpr. But there is no value to add
the complexity of handling both cases in the definition.

Closes #1399

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)