### PR TITLE
CMake: Remove usage of inexistent cmake/src/ITKcpp11Bug/

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -113,6 +113,8 @@
 - *Build*
   - Removing the homemade CPP11 checks, using cmake macro instead
   (David Coeurjolly, [#1446](https://github.com/DGtal-team/DGtal/pull/1446))
+  - Removes the check for CPP11 when building WITH_ITK
+  (Pablo Hernandez-Cerdan, [#1453](https://github.com/DGtal-team/DGtal/pull/1453))
   
 
 # DGtal 1.0

--- a/cmake/CheckDGtalOptionalDependencies.cmake
+++ b/cmake/CheckDGtalOptionalDependencies.cmake
@@ -210,21 +210,6 @@ IF(WITH_ITK)
     ADD_DEFINITIONS(" -DWITH_ITK ")
     SET(DGtalLibInc ${DGtalLibInc} ${ITK_INCLUDE_DIRS})
 
-
-    ## We test if ITK build accepts cpp11 compilers
-    try_compile( CPP11_ITK
-      ${CMAKE_BINARY_DIR}/CMakeTmp
-      ${CMAKE_SOURCE_DIR}/cmake/src/ITKcpp11Bug/
-      ITKCPP11BUG
-      CMAKE_FLAGS "-DITK_DIR=${ITK_DIR}"
-      OUTPUT_VARIABLE OUTPUT )
-    if ( CPP11_ITK )
-      message(STATUS "ITK accepts [c++11]" )
-    else ( CPP11_ITK )
-      message(STATUS "ITK does not accept [c++11]" )
-      MESSAGE(FATAL_ERROR "ITK was found but it appears that the package was not built with std-cpp11 extension and DGtal will not compile.")
-    endif ( CPP11_ITK )
-
     # -------------------------------------------------------------------------
     # This test is for instance used for ITK v3.x. ITK forces a limited
     # template depth. We remove this option.


### PR DESCRIPTION
in CheckDGtalOptionalDependencies when ITK is enabled

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [NA] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [NA] All continuous integration tests pass (Travis & appveyor)