### PR TITLE
Fixing various links in moduleCellularTopology.dox

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -98,7 +98,7 @@
   associated example exampleSurfaceATnormals.cpp (Jacques-Olivier
   Lachaud,[#1442](https://github.com/DGtal-team/DGtal/pull/1442))
 
-- *doc*
+- *Documentation*
   - Promoting the `Shortcuts` documentation page on the main page. (David
     Coeurjolly [#1417](https://github.com/DGtal-team/DGtal/pull/1417))
   - Fixing the `doxyfiles` to have the table of contents of module pages (David
@@ -109,6 +109,9 @@
     (Roland Denis [#1424](https://github.com/DGtal-team/DGtal/pull/1434))
   - CSS edit to enhance the readability of code snippets (David
     Coeurjolly [#1438](https://github.com/DGtal-team/DGtal/pull/1438))
+  - Fixing various links in moduleCellularTopology. Fixing #1454.
+    Removing dead links to ImaGene project.
+    (Roland Denis [#1455](https://github.com/DGtal-team/DGtal/pull/1455))
 
 - *Build*
   - Removing the homemade CPP11 checks, using cmake macro instead

--- a/src/DGtal/arithmetic/IntegerComputer.h
+++ b/src/DGtal/arithmetic/IntegerComputer.h
@@ -72,8 +72,7 @@ It is a model of boost::CopyConstructible,
 boost::DefaultConstructible, boost::Assignable. All its member data are
 \b mutable.
 
-It is a backport of <a
-href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+It is a backport of \e ImaGene.
 
 @tparam TInteger any model of integer (CInteger), like \c int, \c long int,
 \c int64_t, \c BigInteger (when GMP is installed).

--- a/src/DGtal/arithmetic/LatticePolytope2D.h
+++ b/src/DGtal/arithmetic/LatticePolytope2D.h
@@ -72,8 +72,7 @@ namespace DGtal
      It contains no more data than the sequence of points, except mutable
      data for intermediate computations.
 
-     It is a backport of <a
-     href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+     It is a backport of \e ImaGene.
 
      @tparam TSpace an arbitrary 2-dimensional model of CSpace.
      @tparam TSequence a model of boost::Sequence whose elements are points (TSpace::Point). Default is list of points.

--- a/src/DGtal/arithmetic/LightSternBrocot.h
+++ b/src/DGtal/arithmetic/LightSternBrocot.h
@@ -129,8 +129,7 @@ namespace DGtal
 
        @see LightSternBrocot::fraction
 
-       Essentially a backport from <a
-       href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+       Essentially a backport from \e ImaGene.
     */
     struct Node {
 

--- a/src/DGtal/arithmetic/SternBrocot.h
+++ b/src/DGtal/arithmetic/SternBrocot.h
@@ -95,8 +95,7 @@ namespace DGtal
 
        @see SternBrocot::fraction
 
-       Essentially a backport from <a
-       href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+       Essentially a backport from \e ImaGene.
     */
     struct Node {
 

--- a/src/DGtal/arithmetic/doc/moduleIrreducibleFraction.dox
+++ b/src/DGtal/arithmetic/doc/moduleIrreducibleFraction.dox
@@ -18,8 +18,7 @@ fractions are provided. They are based on the Stern-Brocot tree
 structure. With these fractions, amortized constant time operations
 are provided for computing reduced fractions.
 
-Part of the code is a backport from <a
-href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>. \cite ImaGene
+Part of the code is a backport from \e ImaGene. \cite ImaGene
 [TOC]
 
 \section dgtal_irrfrac_sec1 Introduction to positive irreducible fraction.

--- a/src/DGtal/arithmetic/doc/packageArithmetic.dox
+++ b/src/DGtal/arithmetic/doc/packageArithmetic.dox
@@ -57,8 +57,7 @@ subsegments. Furthermore, since 0.6, it provides classes for
 representing 2D lattice polytopes (convex integer polygons) as well as
 methods to perform linear integer programming in the plane.
 
-Parts of this package are backports from
-[ImaGene](https://gforge.liris.cnrs.fr/projects/imagene): class
+Parts of this package are backports from ImaGene: class
 IntegerComputer, class SternBrocot (written with Xavier Provençal),
 algorithms StandardDSLQ0::smartDSS and StandardDSLQ0::reversedSmartDSS
 (written with Mouhammad Said), class ConvexIntegerPolygon (written

--- a/src/DGtal/doc/global.bib
+++ b/src/DGtal/doc/global.bib
@@ -742,8 +742,7 @@ year = 2009
 }
 
 @Misc{ImaGene,
-   title =       {ImaGene, {Gen}eric Digital {Ima}ge Library },
-   note =        {https://gforge.liris.cnrs.frs/projects/imagene}
+   title =       {ImaGene, {Gen}eric Digital {Ima}ge Library }
 }
 
 

--- a/src/DGtal/doc/mainpage.dox
+++ b/src/DGtal/doc/mainpage.dox
@@ -89,6 +89,6 @@ information.
    @defgroup Examples DGtal Examples
 
 
-[imagene]: https://gforge.liris.cnrs.fr/projects/imagene "ImaGene"
+[imagene]: "ImaGene"
 
  */

--- a/src/DGtal/geometry/curves/AlphaThickSegmentComputer.h
+++ b/src/DGtal/geometry/curves/AlphaThickSegmentComputer.h
@@ -117,8 +117,7 @@ namespace DGtal
  * @note You can also construct the segment by using an input point iterator in initialisation (see @ref moduleAlphaThickSegmentReco for more details)
  *
  * The proposed implementation is mainly a backport from
- * [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene) with some
- * various refactoring.
+ * ImaGene with some various refactoring.
  */
 
 

--- a/src/DGtal/geometry/doc/moduleAlphaThickSegmentReco.dox
+++ b/src/DGtal/geometry/doc/moduleAlphaThickSegmentReco.dox
@@ -33,8 +33,7 @@ be detected from points which are not necessarily connected nor
 necessarily digital points (RealPoint for instance).
 
 @note The proposed implementation is mainly a backport from
- [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene) with some
- various refactoring.
+ ImaGene with some various refactoring.
 
 
 [TOC]

--- a/src/DGtal/geometry/surfaces/COBAGenericNaivePlaneComputer.h
+++ b/src/DGtal/geometry/surfaces/COBAGenericNaivePlaneComputer.h
@@ -99,7 +99,7 @@ namespace DGtal
    * BigInteger/GMP integers. For huge diameters, the slow-down is
    * polylogarithmic with the diameter.
    *
-   * Essentially a backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * Essentially a backport from ImaGene.
    *
    @code
    typedef SpaceND<3,int> Z3;

--- a/src/DGtal/geometry/surfaces/COBANaivePlaneComputer.h
+++ b/src/DGtal/geometry/surfaces/COBANaivePlaneComputer.h
@@ -107,7 +107,7 @@ namespace DGtal
    * BigInteger/GMP integers. For huge diameters, the slow-down is
    * polylogarithmic with respect to the diameter.
    *
-   * Essentially a backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * Essentially a backport from ImaGene.
    *
    @code
    typedef SpaceND<3,int> Z3;

--- a/src/DGtal/math/MultiStatistics.h
+++ b/src/DGtal/math/MultiStatistics.h
@@ -61,8 +61,7 @@ namespace DGtal
  * 
  *
  * The proposed implementation is mainly a backport from
- * [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene) with some
- * various refactoring.
+ * ImaGene with some various refactoring.
  */
 class MultiStatistics
 {

--- a/src/DGtal/math/OrderedLinearRegression.h
+++ b/src/DGtal/math/OrderedLinearRegression.h
@@ -60,7 +60,7 @@ namespace DGtal
    * with interval trust from the left to the right (resp. from the
    * right to the left) of the data.
    *
-   * @note  backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * @note  backport from ImaGene.
    */
   class OrderedLinearRegression
   {

--- a/src/DGtal/math/Profile.h
+++ b/src/DGtal/math/Profile.h
@@ -129,8 +129,7 @@ namespace DGtal
    * @tparam TValue the type value stored in the profile.  
    * 
    * The proposed implementation is mainly a backport from
-   * [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene) with some
-   * various refactoring.
+   * ImaGene with some various refactoring.
    */
 
   template<typename TValueFunctor = functors::Identity, typename TValue = double >

--- a/src/DGtal/math/Signal.h
+++ b/src/DGtal/math/Signal.h
@@ -155,8 +155,7 @@ namespace DGtal
      @tparam TValue the type chosen for each sample (generally float
      or double).
      
-     This class is a backport from
-     [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+     This class is a backport from ImaGene.
   */
   template <typename TValue>
   class Signal

--- a/src/DGtal/math/SimpleLinearRegression.h
+++ b/src/DGtal/math/SimpleLinearRegression.h
@@ -68,7 +68,7 @@ namespace DGtal
    * also performs some tests to check if the data corresponds to a
    * linear model.
    *
-   * @note  backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * @note  backport from ImaGene.
    */
   class SimpleLinearRegression
   {

--- a/src/DGtal/math/Statistic.h
+++ b/src/DGtal/math/Statistic.h
@@ -59,7 +59,7 @@ namespace DGtal
     efficiency. For multiple variables, sample storage and others,
     see Statistics class.
 
-    Backported from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene). \cite Lachaud03b
+    Backported from ImaGene. \cite Lachaud03b
     
     @see testStatistics.cpp
 

--- a/src/DGtal/math/Statistic.ih
+++ b/src/DGtal/math/Statistic.ih
@@ -23,7 +23,7 @@
  *
  * Implementation of inline methods defined in Statistics.h
  * 
- * BAckport from ImaGene
+ * Backport from ImaGene
  *
  * This file is part of the DGtal library.
  */

--- a/src/DGtal/shapes/parametric/AccFlower2D.h
+++ b/src/DGtal/shapes/parametric/AccFlower2D.h
@@ -58,7 +58,7 @@ namespace DGtal
    * \brief Aim: Model of the concept StarShaped
    * represents any accelerated flower in the plane.
    *
-   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * NB: A backport from ImaGene.
    */
   template <typename TSpace>
   class AccFlower2D final:  public StarShaped2D<TSpace>

--- a/src/DGtal/shapes/parametric/Ellipse2D.h
+++ b/src/DGtal/shapes/parametric/Ellipse2D.h
@@ -58,7 +58,7 @@ namespace DGtal
    * \brief Aim: Model of the concept StarShaped
    * represents any ellipse in the plane.
    *
-   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * NB: A backport from ImaGene.
    */
   template <typename TSpace>
   class Ellipse2D final:  public StarShaped2D<TSpace>

--- a/src/DGtal/shapes/parametric/Flower2D.h
+++ b/src/DGtal/shapes/parametric/Flower2D.h
@@ -58,7 +58,7 @@ namespace DGtal
    * \brief Aim: Model of the concept StarShaped
    * represents any flower with k-petals in the plane.
    *
-   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * NB: A backport from ImaGene.
    */
   template <typename TSpace>
   class Flower2D final:  public StarShaped2D<TSpace>

--- a/src/DGtal/shapes/parametric/NGon2D.h
+++ b/src/DGtal/shapes/parametric/NGon2D.h
@@ -57,7 +57,7 @@ namespace DGtal
    * \brief Aim: Model of the concept StarShaped
    * represents any regular k-gon in the plane.
    *
-   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * NB: A backport from ImaGene.
    */
   template <typename TSpace>
   class NGon2D final:  public StarShaped2D<TSpace>

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -65,7 +65,7 @@ namespace DGtal
    * StarShaped2D and its derived classes are models of
    * CEuclideanBoundedShape and CEuclideanOrientedShape.
    *
-   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * NB: A backport from ImaGene.
    *
    *
    * @tparam TSpace space in which the shape is defined.

--- a/src/DGtal/shapes/parametric/StarShaped3D.h
+++ b/src/DGtal/shapes/parametric/StarShaped3D.h
@@ -62,7 +62,7 @@ namespace DGtal
    * StarShaped3D and its derived classes are models of
    * CEuclideanBoundedShape and CEuclideanOrientedShape.
    *
-   * NB: A backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * NB: A backport from ImaGene.
    *
    *
    * @tparam TSpace space in which the shape is defined.

--- a/src/DGtal/topology/KhalimskyPreSpaceND.h
+++ b/src/DGtal/topology/KhalimskyPreSpaceND.h
@@ -368,7 +368,7 @@ namespace DGtal
    *
    * @tparam dim the dimension of the digital space.
    * @tparam TInteger the Integer class used to specify the arithmetic computations (default type = int32).
-   * @note Essentially a backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * @note Essentially a backport from ImaGene.
    * @see KhalimskySpaceND
    *
    */

--- a/src/DGtal/topology/KhalimskySpaceND.h
+++ b/src/DGtal/topology/KhalimskySpaceND.h
@@ -379,7 +379,7 @@ namespace DGtal
    *
    * @tparam dim the dimension of the digital space.
    * @tparam TInteger the Integer class used to specify the arithmetic computations (default type = int32).
-   * @note Essentially a backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * @note Essentially a backport from ImaGene.
    *
    * @warning Periodic Khalimsky space and per-dimension closure specification are new features.
    * Therefore, there is no guarantee that it is compatible with the whole DGtal library.

--- a/src/DGtal/topology/SurfelAdjacency.h
+++ b/src/DGtal/topology/SurfelAdjacency.h
@@ -59,7 +59,7 @@ namespace DGtal
      
      @tparam dim the number of dimension of the space.
 
-     NB: backported from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+     NB: backported from ImaGene.
   */
   template <Dimension dim>
   class SurfelAdjacency

--- a/src/DGtal/topology/SurfelNeighborhood.h
+++ b/src/DGtal/topology/SurfelNeighborhood.h
@@ -62,7 +62,7 @@ namespace DGtal
    * @tparam TKSpace the type of celluler grid space (for instance, a
    * KhalimskySpaceND).
    *
-   * Essentially a backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+   * Essentially a backport from ImaGene.
    */
   template <typename TKSpace>
   class SurfelNeighborhood

--- a/src/DGtal/topology/UmbrellaComputer.h
+++ b/src/DGtal/topology/UmbrellaComputer.h
@@ -78,8 +78,7 @@ namespace DGtal
     
      Uses delegation with DigitalSurfaceTracker.
 
-     Essentially a backport from
-     [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+     Essentially a backport from ImaGene.
 
      @tparam TDigitalSurfaceTracker the type of the domain in which shapes are created.
    */

--- a/src/DGtal/topology/doc/moduleCellularTopology.dox
+++ b/src/DGtal/topology/doc/moduleCellularTopology.dox
@@ -16,8 +16,7 @@ namespace DGtal {
 This part of the manual describes how to define cellular grid space
 or cartesian cubic spaces, as well as the main objects living in
 these spaces. A lot of the ideas, concepts, algorithms,
-documentation and code is a backport from <a
-href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+documentation and code is a backport from \e ImaGene.
 
 
 
@@ -114,8 +113,7 @@ and methods to manipulate cells of arbitrary dimension. Models of
 
 1. the KhalimskySpaceND template class, that allows per-dimension closure specification (open, closed or periodic).
 2. the --- yet to come --- CodedKhalimskySpaceND class, a backport
-from class KnSpace of <a
-href="http://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+from class KnSpace of \e ImaGene.
 
 The inner types are:
 - \ref KhalimskySpaceND::Integer "Integer": the type for representing a coordinate or component in this space.

--- a/src/DGtal/topology/doc/moduleCellularTopology.dox
+++ b/src/DGtal/topology/doc/moduleCellularTopology.dox
@@ -108,9 +108,9 @@ cellular grid space \f$\mathbf{F}^2\f$.
 Instead of chosing a specific implementation of a cellular grid
 space, we keep the genericity and efficiency objective of DGtal by
 defining a cellular grid space as the concept
-concepts::CCellularGridSpaceND. It provides a set of types (Cell, SCell, etc)
+\ref concepts::CCellularGridSpaceND "CCellularGridSpaceND". It provides a set of types (Cell, SCell, etc)
 and methods to manipulate cells of arbitrary dimension. Models of
-CCellularGridSpaceND are:
+\ref concepts::CCellularGridSpaceND "CCellularGridSpaceND" are:
 
 1. the KhalimskySpaceND template class, that allows per-dimension closure specification (open, closed or periodic).
 2. the --- yet to come --- CodedKhalimskySpaceND class, a backport
@@ -118,24 +118,24 @@ from class KnSpace of <a
 href="http://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
 
 The inner types are:
-- Integer: the type for representing a coordinate or component in this space.
-- Size: the type for representing a size (unsigned)
-- Cell: the type of unsigned cells
-- SCell: the type of signed cells
-- Sign: the sign type for cells
-- DirIterator: the type for iterating over directions of a cell
-- Point: the type for representing a digital point in this space
-- Vector: the type for representing a digital vector in this space
-- Space: the associated digital space type
-- KhalimskySpace: this cellular grid space
-- Cells: a sequence of unsigned cells
-- SCells: a sequence of signed cells
-- \e CellSet: a set container that stores unsigned cells (efficient for queries like \c find, model of boost::UniqueAssociativeContainer and boost::SimpleAssociativeContainer).
-- \e SCellSet: a set container that stores signed cells (efficient for queries like \c find, model of boost::UniqueAssociativeContainer and boost::SimpleAssociativeContainer).
-- \e SurfelSet: a set container that stores surfels, i.e. signed n-1-cells (efficient for queries like \c find, model of boost::UniqueAssociativeContainer and boost::SimpleAssociativeContainer).
-- \e CellMap<Value>: an associative container Cell->Value rebinder type (efficient for key queries). Use as \c typename X::template CellMap<Value>::Type, which is a model of boost::UniqueAssociativeContainer and boost::PairAssociativeContainer.
-- \e SCellMap<Value>: an associative container SCell->Value rebinder type (efficient for key queries). Use as \c typename X::template SCellMap<Value>::Type, which is a model of boost::UniqueAssociativeContainer and boost::PairAssociativeContainer.
-- \e SurfelMap<Value>: an associative container Surfel->Value rebinder type (efficient for key queries). Use as \c typename X::template SurfelMap<Value>::Type, which is a model of boost::UniqueAssociativeContainer and boost::PairAssociativeContainer.
+- \ref KhalimskySpaceND::Integer "Integer": the type for representing a coordinate or component in this space.
+- \ref KhalimskySpaceND::Size "Size": the type for representing a size (unsigned)
+- \ref KhalimskySpaceND::Cell "Cell": the type of unsigned cells
+- \ref KhalimskySpaceND::SCell "SCell": the type of signed cells
+- \ref KhalimskySpaceND::Sign "Sign": the sign type for cells
+- \ref KhalimskySpaceND::DirIterator "DirIterator": the type for iterating over directions of a cell
+- \ref KhalimskySpaceND::Point "Point": the type for representing a digital point in this space
+- \ref KhalimskySpaceND::Vector "Vector": the type for representing a digital vector in this space
+- \ref KhalimskySpaceND::Space "Space": the associated digital space type
+- \ref KhalimskySpaceND::CellularGridSpace "CellularGridSpace": this cellular grid space
+- \ref KhalimskySpaceND::Cells "Cells": a sequence of unsigned cells
+- \ref KhalimskySpaceND::SCells "SCells": a sequence of signed cells
+- \ref KhalimskySpaceND::CellSet "CellSet": a set container that stores unsigned cells (efficient for queries like \c find, model of boost::UniqueAssociativeContainer and boost::SimpleAssociativeContainer).
+- \ref KhalimskySpaceND::SCellSet "SCellSet": a set container that stores signed cells (efficient for queries like \c find, model of boost::UniqueAssociativeContainer and boost::SimpleAssociativeContainer).
+- \ref KhalimskySpaceND::SurfelSet "SurfetSet": a set container that stores surfels, i.e. signed n-1-cells (efficient for queries like \c find, model of boost::UniqueAssociativeContainer and boost::SimpleAssociativeContainer).
+- \ref KhalimskySpaceND::CellMap "CellMap<Value>": an associative container Cell->Value rebinder type (efficient for key queries). Use as \c typename X::template CellMap<Value>::Type, which is a model of boost::UniqueAssociativeContainer and boost::PairAssociativeContainer.
+- \ref KhalimskySpaceND::SCellMap "SCellMap<Value>": an associative container SCell->Value rebinder type (efficient for key queries). Use as \c typename X::template SCellMap<Value>::Type, which is a model of boost::UniqueAssociativeContainer and boost::PairAssociativeContainer.
+- \ref KhalimskySpaceND::SurfelMap "SurfelMap<Value>": an associative container Surfel->Value rebinder type (efficient for key queries). Use as \c typename X::template SurfelMap<Value>::Type, which is a model of boost::UniqueAssociativeContainer and boost::PairAssociativeContainer.
 
 Methods include:
 - Cell creation services
@@ -150,7 +150,7 @@ Methods include:
 - Incidence services
 - Interface
 
-An comprehensive description is given in concepts::CCellularGridSpaceND.
+An comprehensive description is given in \ref concepts::CCellularGridSpaceND "CCellularGridSpaceND".
 
 @subsection dgtal_ctopo_sec4  Creating a cellular grid space
 
@@ -203,7 +203,7 @@ Domain domain( K.lowerBound(), K.upperBound() );
 @endcode
 
 Last but not least, for standard users it is generally enough to
-use the default types provided in "DGtal/helpers/StdDefs.h".
+use the default types provided in DGtal/helpers/StdDefs.h.
 @code
 #include "DGtal/helpers/StdDefs.h"
 ...
@@ -279,13 +279,13 @@ The file ctopo-1-3d.cpp shows another example in 3D:
 @section dgtal_ctopo_sec6  Cells may be unsigned or signed
 
 Up to now, we have only consider unsigned cells (type
-Cell). However it is often convenient to assign a sign (POS or NEG)
+Cell). However it is often convenient to assign a sign (\ref KhalimskySpaceND::POS "POS" or \ref KhalimskySpaceND::NEG "NEG")
 to a cell, a kind of orientation. The sign is especially useful to
 define boundary operators and digital surfaces. It is also used in
 algebraic topological models of cubical complexes, for instance to
 define chains (formal sums of cells).
 
-Signed cells have type SCell. They are created using methods
+Signed cells have type \ref KhalimskySpaceND::SCell "SCell". They are created using methods
 KhalimskySpaceND::sCell for arbitrary cells,
 KhalimskySpaceND::sSpel for n-dimensional cells,
 KhalimskySpaceND::sPointel for 0-dimensional cells. The user gives
@@ -319,8 +319,8 @@ methods concerning signed cells are prefixed by \c s.
 @section dgtal_ctopo_sec7  Accessing and modifying cell coordinates.
 
 Since one does not necessarily know which model of
-CCellularGridSpaceND you may be using, you cannot access the cell
-coordinates directly. Therefore a model of CCellularGridSpaceND
+\ref concepts::CCellularGridSpaceND "CCellularGridSpaceND" you may be using, you cannot access the cell
+coordinates directly. Therefore a model of \ref concepts::CCellularGridSpaceND "CCellularGridSpaceND"
 provides a set of methods to access and modify cell coordinates and
 topology. Here a few of them (with the model example KhalimskySpaceND)
 
@@ -399,8 +399,8 @@ cells:
 KSpace::Cell q;
 
 ...
-for (q = K.uGetMaxT(q, 0); K.uIsInside(q,0); q = K.uGetDecr(q, 0))
-  for ( q = K.uGetMinT(q, 1); K.uIsInside(q,1); q = K.uGetIncr(q, 1))
+for (q = K.uGetMax(q, 0); K.uIsInside(q,0); q = K.uGetDecr(q, 0))
+  for ( q = K.uGetMin(q, 1); K.uIsInside(q,1); q = K.uGetIncr(q, 1))
     {
       // ... whatever [q] is the current cell
     }
@@ -446,10 +446,10 @@ cell topology.
   @code
   KSpace::Cell p;
   ...
-  for ( KnSpace::DirIterator q = ks.uDirs( p ); q != 0; ++q )
+  for ( KSpace::DirIterator q = ks.uDirs( p ); q != 0; ++q )
   {
-  KSpace::Dimension dir = *q;
-	...
+    Dimension dir = *q;
+    ...
   }
   @endcode
 
@@ -536,7 +536,7 @@ boundary.
 
 @section dgtal_ctopo_periodicKSpace       Periodic Khalimsky space and per-dimension closure specification.
 
-In addition to the concepts::CCellularGridSpaceND requirements,
+In addition to the \ref concepts::CCellularGridSpaceND "CCellularGridSpaceND" requirements,
 KhalimskySpaceND allows the use of different closures for each dimension
 and the use of periodic dimension.
 
@@ -576,9 +576,9 @@ If you need to arbitrarily manipulate the cells coordinates without bounds
 checking, or if you simply doesn't need a bounded space, you may consider
 KhalimskyPreSpaceND.
 
-It is a model of concepts::CPreCellularGridSpaceND, that is a base concept
-of concepts::CCellularGridSpaceND. The main difference is that
-concepts::CPreCellularGridSpaceND doesn't require to initialize the space
+It is a model of \ref concepts::CPreCellularGridSpaceND "CPreCellularGridSpaceND", that is a base concept
+of \ref concepts::CCellularGridSpaceND "CCellularGridSpaceND". The main difference is that
+\ref concepts::CPreCellularGridSpaceND "CPreCellularGridSpaceND" doesn't require to initialize the space
 with bounds and some bounds related methods (like KhalimskySpaceND::uGetMin)
 are not available.
 
@@ -610,7 +610,7 @@ The main features are:
   and SignedKhalimskyCell::preCell methods,
   or using the implicit conversion:
   @code
-  using KSpace = DGtal::KhalimksySpaceND<2, int>;
+  using KSpace = DGtal::KhalimskySpaceND<2, int>;
   KSpace K;
   K.init( {-3, -3}, {3, 2}, true );
   KSpace::Cell cell = K.uSpel( {1, 1} );
@@ -629,8 +629,8 @@ The main features are:
 
 - most KhalimskySpaceND methods exist in KhalimskyPreSpaceND
   (take a look to the KhalimskyPreSpaceND documentation or just to
-   the difference between concepts::CCellularGridSpaceND and
-   concepts::CPreCellularGridSpaceND).
+   the difference between \ref concepts::CCellularGridSpaceND "CCellularGridSpaceND" and
+   \ref concepts::CPreCellularGridSpaceND "CPreCellularGridSpaceND").
 
 - Conversion from a pre-cell to a cell needs the associate Khalimsky space
   in order to ensure that the coordinates are valid:
@@ -639,7 +639,7 @@ The main features are:
   KPreSpace::Cell  preA = KPreSpace::uSpel( {1, 1} );
   KPreSpace::SCell preB = KPreSpace::sPointel( {12, 5}, true );
 
-  using KSpace = DGtal::KhalimksySpaceND<2, int>;
+  using KSpace = DGtal::KhalimskySpaceND<2, int>;
   KSpace K;
   K.init( {-3, -3}, {3, 2}, true );
 

--- a/src/DGtal/topology/doc/moduleCubicalComplex.dox
+++ b/src/DGtal/topology/doc/moduleCubicalComplex.dox
@@ -17,8 +17,7 @@ Part of the \ref packageTopology.
 This part of the manual describes how to represent and process
 arbitrary cubical complexes. 
 
-@note Collapse operation is a backport from <a
-href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+@note Collapse operation is a backport from \e ImaGene.
 @cite ImaGene 
 
 [TOC]

--- a/src/DGtal/topology/doc/moduleDigitalSurfaceHelpers.dox
+++ b/src/DGtal/topology/doc/moduleDigitalSurfaceHelpers.dox
@@ -15,8 +15,7 @@ namespace DGtal {
    This part of the manual describes how to use the helper class
    Surfaces to build digital surfaces, closed or open, or contours
    within digital surfaces. A lot of the ideas, concepts, algorithms,
-   documentation and code is a backport from <a
-   href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>.
+   documentation and code is a backport from \e ImaGene.
 
 [TOC]
 

--- a/src/DGtal/topology/doc/moduleDigitalSurfaces.dox
+++ b/src/DGtal/topology/doc/moduleDigitalSurfaces.dox
@@ -14,8 +14,7 @@ Part of the \ref packageTopology.
   
 This part of the manual describes how to define digital surfaces,
 closed or open. A lot of the ideas, concepts, algorithms,
-documentation and code is a backport from
-<a href="https://gforge.liris.cnrs.fr/projects/imagene">ImaGene</a>
+documentation and code is a backport from \e ImaGene
 \cite ImaGene. Digital surfaces can be defined in very different way
 depending on input data, but they can be manipulated uniformly with
 class \ref DigitalSurface, whichever is the dimension. Note that the

--- a/src/DGtal/topology/helpers/Surfaces.h
+++ b/src/DGtal/topology/helpers/Surfaces.h
@@ -72,7 +72,7 @@ namespace DGtal
      function. This is to be more generic than a simple
      DigitalSet. With this approach, shapes can be defined implicitly.
 
-     Essentially a backport from [ImaGene](https://gforge.liris.cnrs.fr/projects/imagene).
+     Essentially a backport from ImaGene.
    */
   template <typename TKSpace>
   class Surfaces


### PR DESCRIPTION
# PR Description

- fix #1454
- fix typo in class and members names
- add refs to concepts without the concepts:: prefix
- add refs to some members without the class name as prefix

# Checklist

- [x] New link for ImaGene? (@JacquesOlivierLachaud)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
