### PR TITLE
Similar typedefs for parametric shape

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -57,7 +57,7 @@
    (Adrien Krähenbühl,
    [#1427](https://github.com/DGtal-team/DGtal/pull/1427))
   - Homogenizes typedefs of all parametric shapes and fixes some bounding box
-    computing (Adrien Krähenbühl,
+    computations (Adrien Krähenbühl,
    [#1462](https://github.com/DGtal-team/DGtal/pull/1462))
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -56,6 +56,9 @@
   - Fix Lemniscate definition following Bernoulli's definition
    (Adrien Krähenbühl,
    [#1427](https://github.com/DGtal-team/DGtal/pull/1427))
+  - Homogenizes typedefs of all parametric shapes and fixes some bounding box
+    computing (Adrien Krähenbühl,
+   [#1462](https://github.com/DGtal-team/DGtal/pull/1462))
 
 
 ## Bug Fixes

--- a/src/DGtal/geometry/curves/estimation/ParametricShapeArcLengthFunctor.h
+++ b/src/DGtal/geometry/curves/estimation/ParametricShapeArcLengthFunctor.h
@@ -72,9 +72,6 @@ namespace DGtal
 
     ///Type of const iterator on points.
     typedef typename TParametricShape::RealPoint RealPoint;
-    typedef typename TParametricShape::Point Point;
-    typedef typename TParametricShape::Point Vector;
-    typedef typename Point::Coordinate Integer;
 
     ///Type of the functor output.
     typedef double Quantity;

--- a/src/DGtal/shapes/parametric/AccFlower2D.h
+++ b/src/DGtal/shapes/parametric/AccFlower2D.h
@@ -133,8 +133,7 @@ namespace DGtal
      */
     RealPoint getLowerBound() const
     {
-      return RealPoint(myCenter[0] - myRadius - myVarRadius,
-                         myCenter[1] - myRadius - myVarRadius);
+      return myCenter - (myRadius + myVarRadius);
     }
 
     /**
@@ -143,8 +142,7 @@ namespace DGtal
      */
     RealPoint getUpperBound() const
     {
-      return RealPoint(myCenter[0] + myRadius + myVarRadius,
-                         myCenter[1] + myRadius + myVarRadius);
+      return myCenter + (myRadius + myVarRadius);
     }
 
     /**

--- a/src/DGtal/shapes/parametric/AccFlower2D.h
+++ b/src/DGtal/shapes/parametric/AccFlower2D.h
@@ -67,14 +67,14 @@ namespace DGtal
   public:
 
     typedef TSpace Space;
-    typedef typename Space::Point Point;
-    typedef typename Space::RealPoint RealPoint2D;
-    typedef typename Space::RealVector RealVector2D;
+    typedef typename Space::RealPoint RealPoint;
+    typedef typename Space::RealVector RealVector;
 
     /**
-     * Destructor.
+     * Constructor.
+     * Forbidden by default.
      */
-    ~AccFlower2D();
+    AccFlower2D() = delete;
 
     /**
      * Constructor.
@@ -89,7 +89,7 @@ namespace DGtal
         const double r,
         const double smallr,
         const unsigned int k,
-        const double phi);
+        const double phi );
 
     /**
      * Constructor.
@@ -99,26 +99,30 @@ namespace DGtal
      * @param k the number of flower extremeties.
      * @param phi the phase of the flower (in radian).
      */
-    AccFlower2D(const RealPoint2D &aPoint,
+    AccFlower2D( const RealPoint& aPoint,
        const double r,
        const double smallr,
        const unsigned int k,
-       const double phi);
+       const double phi );
 
     /**
-     * Constructor.
-     * @param aPoint the flower center.
-     * @param r the radius of the flower.
-     * @param smallr the variable small radius of the flower.
-     * @param k the number of flower extremeties.
-     * @param phi the phase of the flower (in radian).
+     * Copy constructor.
+     * @param other the object to clone.
      */
-    AccFlower2D(const Point &aPoint,
-       const double r,
-       const double smallr,
-       const unsigned int k,
-       const double phi);
+     AccFlower2D( const AccFlower2D& other );
 
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    AccFlower2D& operator= ( const AccFlower2D& other ) = delete;
+
+    /**
+     * Destructor.
+     */
+    ~AccFlower2D() = default;
 
     // ------------- Implementation of 'StarShaped' services ------------------
   public:
@@ -127,9 +131,9 @@ namespace DGtal
      * @return the lower bound of the shape bounding box.
      *
      */
-    RealPoint2D getLowerBound() const
+    RealPoint getLowerBound() const
     {
-      return RealPoint2D(myCenter[0] - myRadius - myVarRadius,
+      return RealPoint(myCenter[0] - myRadius - myVarRadius,
                          myCenter[1] - myRadius - myVarRadius);
     }
 
@@ -137,16 +141,16 @@ namespace DGtal
      * @return the upper bound of the shape bounding box.
      *
      */
-    RealPoint2D getUpperBound() const
+    RealPoint getUpperBound() const
     {
-      return RealPoint2D(myCenter[0] + myRadius + myVarRadius,
+      return RealPoint(myCenter[0] + myRadius + myVarRadius,
                          myCenter[1] + myRadius + myVarRadius);
     }
 
     /**
      * @return the center of the star-shaped object.
      */
-    RealPoint2D center() const
+    RealPoint center() const
     {
       return myCenter;
     }
@@ -156,7 +160,7 @@ namespace DGtal
      * @param newCenter the new center position
      */
     inline
-    void moveTo( const RealPoint2D& newCenter )
+    void moveTo( const RealPoint& newCenter )
     {
       myCenter = newCenter;
     }
@@ -167,7 +171,7 @@ namespace DGtal
      * @return the angle parameter between 0 and 2*Pi corresponding to
      * this point for the shape.
      */
-    double parameter( const RealPoint2D & p ) const;
+    double parameter( const RealPoint & p ) const;
 
 
     /**
@@ -176,7 +180,7 @@ namespace DGtal
      * @return the vector (x(t),y(t)) which is the position on the
      * shape boundary.
      */
-    RealPoint2D x( const double t ) const;
+    RealPoint x( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -184,14 +188,14 @@ namespace DGtal
      * @return the vector (x'(t),y'(t)) which is the tangent to the
      * shape boundary.
      */
-    RealVector2D xp( const double t ) const;
+    RealVector xp( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
      *
      * @return the vector (x''(t),y''(t)).
      */
-    RealVector2D xpp( const double t ) const;
+    RealVector xpp( const double t ) const;
 
 
     // ------------------------- data ----------------------------
@@ -200,7 +204,7 @@ namespace DGtal
     /**
      * Center of the flower.
      */
-    RealPoint2D myCenter;
+    RealPoint myCenter;
 
     /**
      * Radius of the flower.
@@ -241,36 +245,6 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    AccFlower2D();
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    //  AccFlower2D ( const AccFlower2D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    AccFlower2D & operator= ( const AccFlower2D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class AccFlower2D
 

--- a/src/DGtal/shapes/parametric/AccFlower2D.ih
+++ b/src/DGtal/shapes/parametric/AccFlower2D.ih
@@ -40,15 +40,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ------------------------------
 
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::AccFlower2D<T>::~AccFlower2D()
-{
-}
-
 template <typename T>
 inline
 DGtal::AccFlower2D<T>::AccFlower2D(const double x0, const double y0,
@@ -63,7 +54,7 @@ DGtal::AccFlower2D<T>::AccFlower2D(const double x0, const double y0,
 
 template <typename T>
 inline
-DGtal::AccFlower2D<T>::AccFlower2D(const RealPoint2D &aPoint, const double radius,
+DGtal::AccFlower2D<T>::AccFlower2D(const RealPoint &aPoint, const double radius,
            const double smallRadius,
            const unsigned int k, const double phi)
   : myCenter(aPoint), myRadius(radius), myVarRadius(smallRadius), 
@@ -74,14 +65,10 @@ DGtal::AccFlower2D<T>::AccFlower2D(const RealPoint2D &aPoint, const double radiu
 
 template <typename T>
 inline
-DGtal::AccFlower2D<T>::AccFlower2D(const Point &aPoint, const double radius,
-           const double smallRadius,
-           const unsigned int k, const double phi)
-  : myRadius(radius), myVarRadius(smallRadius), myK(k), myPhi(phi)
-{
-  myCenter = aPoint;
-  myKp = 2 * myK/ ( M_PI * M_PI );
-}
+DGtal::AccFlower2D<T>::AccFlower2D(const AccFlower2D& other) 
+  : myCenter(other.myCenter), myRadius(other.myRadius), myVarRadius(other.myVarRadius), 
+    myK(other.myK), myPhi(other.myPhi)
+{}
 
 /////////////////////////////////////////////////////////////////////////////
 // ------------- Implementation of 'StarShaped' services ------------------
@@ -95,9 +82,9 @@ DGtal::AccFlower2D<T>::AccFlower2D(const Point &aPoint, const double radius,
 template <typename T>
 inline
 double
-DGtal::AccFlower2D<T>::parameter( const RealPoint2D & pp ) const
+DGtal::AccFlower2D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint2D p( pp );
+  RealPoint p( pp );
   p -= myCenter;
 
   double angle = atan2( p[1], p[0] );
@@ -114,7 +101,7 @@ DGtal::AccFlower2D<T>::parameter( const RealPoint2D & pp ) const
  */
 template <typename T>
 inline
-typename DGtal::AccFlower2D<T>::RealPoint2D 
+typename DGtal::AccFlower2D<T>::RealPoint 
 DGtal::AccFlower2D<T>::x(const double t ) const
 {
   double tt =t;
@@ -123,7 +110,7 @@ DGtal::AccFlower2D<T>::x(const double t ) const
   
   double ktn = myKp * tt * tt * tt;
   double r = myRadius + myVarRadius * cos( ktn );
-  RealPoint2D c( r * cos( tt ), r * sin( tt ) );
+  RealPoint c( r * cos( tt ), r * sin( tt ) );
   c += myCenter;
   return c;
 }
@@ -137,7 +124,7 @@ DGtal::AccFlower2D<T>::x(const double t ) const
  */
 template <typename T>
 inline
-typename DGtal::AccFlower2D<T>::RealVector2D 
+typename DGtal::AccFlower2D<T>::RealVector 
 DGtal::AccFlower2D<T>::xp( const double tt ) const
 {
   double t= tt;
@@ -149,7 +136,7 @@ DGtal::AccFlower2D<T>::xp( const double tt ) const
 
   double r = myRadius + myVarRadius * cos( ktn );
   double rp = - myVarRadius * sin( ktn ) * ktnp;
-  RealPoint2D c( rp * cos( t ) - r * sin( t ),
+  RealPoint c( rp * cos( t ) - r * sin( t ),
      rp * sin( t ) + r * cos( t ) );
   return c;
 }
@@ -161,7 +148,7 @@ DGtal::AccFlower2D<T>::xp( const double tt ) const
  */
 template <typename T>
 inline
-typename DGtal::AccFlower2D<T>::RealVector2D
+typename DGtal::AccFlower2D<T>::RealVector
 DGtal::AccFlower2D<T>::xpp( const double tt ) const
 {
   double t=tt;
@@ -177,7 +164,7 @@ DGtal::AccFlower2D<T>::xpp( const double tt ) const
   double rpp = - myVarRadius * cos( ktn ) * ktnp * ktnp - 
     myVarRadius * sin( ktn ) * ktnpp;
   
-  RealPoint2D c( rpp * cos( t ) - 2 * rp * sin( t ) - r * cos( t ),
+  RealPoint c( rpp * cos( t ) - 2 * rp * sin( t ) - r * cos( t ),
      rpp * sin( t ) + 2 * rp * cos( t ) - r * sin( t ) );
   return c;
 }

--- a/src/DGtal/shapes/parametric/AccFlower2D.ih
+++ b/src/DGtal/shapes/parametric/AccFlower2D.ih
@@ -33,6 +33,9 @@
 #include <cstdlib>
 //////////////////////////////////////////////////////////////////////////////
 
+#define FLOWER_PI_SQUARE (M_PI * M_PI)
+#define FLOWER_2_PI      (2. * M_PI)
+
 ///////////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION of inline methods.
 ///////////////////////////////////////////////////////////////////////////////
@@ -48,7 +51,7 @@ DGtal::AccFlower2D<T>::AccFlower2D(const double x0, const double y0,
   :  myCenter(x0,y0), myRadius(radius), myVarRadius(smallRadius), 
      myK(k), myPhi(phi)
 {
-  myKp = 2 * myK/ ( M_PI * M_PI );
+  myKp = 2 * myK / FLOWER_PI_SQUARE;
 }
 
 
@@ -60,7 +63,7 @@ DGtal::AccFlower2D<T>::AccFlower2D(const RealPoint &aPoint, const double radius,
   : myCenter(aPoint), myRadius(radius), myVarRadius(smallRadius), 
     myK(k), myPhi(phi)
 {
-  myKp = 2 * myK/ ( M_PI * M_PI );
+  myKp = 2 * myK/ FLOWER_PI_SQUARE;
 }
 
 template <typename T>
@@ -82,15 +85,13 @@ DGtal::AccFlower2D<T>::AccFlower2D(const AccFlower2D& other)
 template <typename T>
 inline
 double
-DGtal::AccFlower2D<T>::parameter( const RealPoint & pp ) const
+DGtal::AccFlower2D<T>::parameter( const RealPoint& pp ) const
 {
-  RealPoint p( pp );
-  p -= myCenter;
+  RealPoint p = pp - myCenter;
 
-  double angle = atan2( p[1], p[0] );
-  angle = ( angle < 0.0 ) ? angle + 2 * M_PI : angle;
+  const double angle = atan2( p[1], p[0] );
 
-  return angle;
+  return ( angle < 0. ) ? angle + FLOWER_2_PI : angle;
 }
 
 /**
@@ -102,17 +103,14 @@ DGtal::AccFlower2D<T>::parameter( const RealPoint & pp ) const
 template <typename T>
 inline
 typename DGtal::AccFlower2D<T>::RealPoint 
-DGtal::AccFlower2D<T>::x(const double t ) const
+DGtal::AccFlower2D<T>::x( const double tt ) const
 {
-  double tt =t;
-  while ( tt >= M_PI ) tt -= 2 * M_PI; 
-  while ( tt < -M_PI ) tt += 2 * M_PI;
-  
-  double ktn = myKp * tt * tt * tt;
-  double r = myRadius + myVarRadius * cos( ktn );
-  RealPoint c( r * cos( tt ), r * sin( tt ) );
-  c += myCenter;
-  return c;
+  double t = tt;
+  while ( t >= M_PI ) t -= FLOWER_2_PI; 
+  while ( t < -M_PI ) t += FLOWER_2_PI;
+
+  const double r = myRadius + myVarRadius * cos( myKp * t * t * t );
+  return RealPoint( r * cos( t ), r * sin( t ) ) + myCenter;
 }
 
 
@@ -127,18 +125,19 @@ inline
 typename DGtal::AccFlower2D<T>::RealVector 
 DGtal::AccFlower2D<T>::xp( const double tt ) const
 {
-  double t= tt;
-  while ( t >= M_PI ) t -= 2 * M_PI; 
-  while ( t < -M_PI ) t += 2 * M_PI;
+  double t = tt;
+  while ( t >= M_PI ) t -= FLOWER_2_PI;
+  while ( t < -M_PI ) t += FLOWER_2_PI;
   
-  double ktn = myKp * t * t * t;
-  double ktnp = 3 * myKp * t * t ;
+  const double ktn = myKp * t * t * t;
+  const double ktnp = 3 * myKp * t * t ;
 
-  double r = myRadius + myVarRadius * cos( ktn );
-  double rp = - myVarRadius * sin( ktn ) * ktnp;
-  RealPoint c( rp * cos( t ) - r * sin( t ),
-     rp * sin( t ) + r * cos( t ) );
-  return c;
+  const double r = myRadius + myVarRadius * cos( ktn );
+  const double rp = - myVarRadius * sin( ktn ) * ktnp;
+  return RealPoint(
+    rp * cos( t ) - r * sin( t ),
+    rp * sin( t ) + r * cos( t )
+  );
 }
 
 /**
@@ -151,22 +150,23 @@ inline
 typename DGtal::AccFlower2D<T>::RealVector
 DGtal::AccFlower2D<T>::xpp( const double tt ) const
 {
-  double t=tt;
-  while ( t >= M_PI ) t -= 2 * M_PI; 
-  while ( t < -M_PI ) t += 2 * M_PI;
+  double t = tt;
+  while ( t >= M_PI ) t -= FLOWER_2_PI;
+  while ( t < -M_PI ) t += FLOWER_2_PI;
   
-  double ktn = myKp * t * t * t;
-  double ktnp = 3 * myKp * t * t;
-  double ktnpp = 6 * myKp * t;
+  const double ktn = myKp * t * t * t;
+  const double ktnp = 3 * myKp * t * t;
+  const double ktnpp = 6 * myKp * t;
   
-  double r = myRadius + myVarRadius * cos( ktn );
-  double rp = - myVarRadius * sin( ktn ) * ktnp;
-  double rpp = - myVarRadius * cos( ktn ) * ktnp * ktnp - 
+  const double r = myRadius + myVarRadius * cos( ktn );
+  const double rp = - myVarRadius * sin( ktn ) * ktnp;
+  const double rpp = - myVarRadius * cos( ktn ) * ktnp * ktnp - 
     myVarRadius * sin( ktn ) * ktnpp;
   
-  RealPoint c( rpp * cos( t ) - 2 * rp * sin( t ) - r * cos( t ),
-     rpp * sin( t ) + 2 * rp * cos( t ) - r * sin( t ) );
-  return c;
+  return RealPoint(
+    rpp * cos( t ) - 2 * rp * sin( t ) - r * cos( t ),
+    rpp * sin( t ) + 2 * rp * cos( t ) - r * sin( t )
+  );
 }
 
 
@@ -182,8 +182,11 @@ inline
 void
 DGtal::AccFlower2D<T>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[AccFlower2D] center= "<<myCenter<<" radius="<<myRadius<<" smallradius="<<myVarRadius
-      <<" myK="<<myK<<" phase-shift="<<myPhi;
+  out << "[AccFlower2D] center= " << myCenter
+      << " radius=" << myRadius
+      << " smallradius=" << myVarRadius
+      <<" myK=" << myK
+      << " phase-shift=" << myPhi;
 }
 
 /**

--- a/src/DGtal/shapes/parametric/Astroid2D.h
+++ b/src/DGtal/shapes/parametric/Astroid2D.h
@@ -61,17 +61,17 @@ namespace DGtal
   class Astroid2D : public StarShaped2D<TSpace>
   {
     // ----------------------- Standard services ------------------------------
-  public:
+    public:
 
     typedef TSpace Space;
-    typedef typename Space::Point Point2D;
-    typedef typename Space::RealPoint RealPoint2D;
-    typedef typename Space::RealVector RealVector2D;
+    typedef typename Space::RealPoint RealPoint;
+    typedef typename Space::RealVector RealVector;
 
     /**
-     * Destructor.
+     * Constructor.
+     * Forbidden by default.
      */
-    ~Astroid2D();
+    Astroid2D() = delete;
 
     /**
      * Constructor.
@@ -81,7 +81,7 @@ namespace DGtal
      * @param a  coefficient along x-axis
      * @param b  coefficient along y-axis
      */
-   Astroid2D( const double x0, const double y0,
+    Astroid2D( const double x0, const double y0,
               const double a, const double b );
 
     /**
@@ -91,43 +91,52 @@ namespace DGtal
      * @param a      coefficient along x-axis
      * @param b      coefficient along y-axis
      */
-    Astroid2D( const RealPoint2D &aPoint, const double a, const double b );
+    Astroid2D( const RealPoint& aPoint, const double a, const double b );
 
-     /**
-      * Constructor.
-     * The absolute value of radii parameters is used.
-      * @param aPoint the astroid center
-      * @param a      coefficient along x-axis
-      * @param b      coefficient along y-axis
-      */
-    Astroid2D( const Point2D &aPoint, const double a, const double b );
+    /**
+     * Copy constructor.
+     * @param other the object to clone.
+     */
+    Astroid2D( const Astroid2D& other );
 
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    Astroid2D& operator= ( const Astroid2D& other ) = delete;
 
-   // ------------- Implementation of 'StarShaped' services -------------------
-    public:
+    /**
+     * Destructor.
+     */
+    ~Astroid2D() = default;
+
+  // ------------- Implementation of 'StarShaped' services -------------------
+  public:
 
     /**
      * @return the lower bound of the shape bounding box.
      *
      */
-    RealPoint2D getLowerBound() const
+    RealPoint getLowerBound() const
     {
-      return RealPoint2D(-myA - myCenter[0] , -myB - myCenter[1] );
+      return RealPoint(-myA - myCenter[0] , -myB - myCenter[1] );
     }
 
     /**
      * @return the upper bound of the shape bounding box.
      *
      */
-    RealPoint2D getUpperBound() const
+    RealPoint getUpperBound() const
     {
-      return RealPoint2D(myA - myCenter[0] , myB - myCenter[1]);
+      return RealPoint(myA - myCenter[0] , myB - myCenter[1]);
     }
 
     /**
      * @return the center of the star-shaped object.
      */
-    RealPoint2D center() const
+    RealPoint center() const
     {
       return myCenter;
     }
@@ -137,7 +146,7 @@ namespace DGtal
      * @param newCenter the new center position
      */
     inline
-    void moveTo( const RealPoint2D& newCenter )
+    void moveTo( const RealPoint& newCenter )
     {
       myCenter = newCenter;
     }
@@ -148,7 +157,7 @@ namespace DGtal
      * @return the angle parameter between 0 and 2*Pi corresponding to
      * this point for the shape.
      */
-    double parameter( const RealPoint2D & p ) const;
+    double parameter( const RealPoint & p ) const;
 
 
     /**
@@ -157,7 +166,7 @@ namespace DGtal
      * @return the vector (x(t),y(t)) which is the position on the
      * shape boundary.
      */
-    RealPoint2D x( const double t ) const;
+    RealPoint x( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -165,23 +174,23 @@ namespace DGtal
      * @return the vector (x'(t),y'(t)) which is the tangent to the
      * shape boundary.
      */
-    RealVector2D xp( const double t ) const;
+    RealVector xp( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
      *
      * @return the vector (x''(t),y''(t)).
      */
-    RealVector2D xpp( const double t ) const;
+    RealVector xpp( const double t ) const;
 
 
-    // ------------------------- data -----------------------------------------
+  // ------------------------- data -----------------------------------------
   private:
 
     /**
      * Center of the circle.
      */
-    RealPoint2D myCenter;
+    RealPoint myCenter;
 
     /**
      * Coefficient along x-axis
@@ -193,7 +202,7 @@ namespace DGtal
      */
     double myB;
 
-    // ----------------------- Interface --------------------------------------
+  // ----------------------- Interface --------------------------------------
   public:
 
     /**
@@ -208,36 +217,6 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    Astroid2D();
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    //  Astroid2D ( const Astroid2D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    Astroid2D & operator= ( const Astroid2D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class Astroid2D
 

--- a/src/DGtal/shapes/parametric/Astroid2D.h
+++ b/src/DGtal/shapes/parametric/Astroid2D.h
@@ -121,7 +121,7 @@ namespace DGtal
      */
     RealPoint getLowerBound() const
     {
-      return RealPoint(-myA - myCenter[0] , -myB - myCenter[1] );
+      return RealPoint( myCenter[0] - myA, myCenter[1] - myB );
     }
 
     /**
@@ -130,7 +130,7 @@ namespace DGtal
      */
     RealPoint getUpperBound() const
     {
-      return RealPoint(myA - myCenter[0] , myB - myCenter[1]);
+      return RealPoint( myCenter[0] + myA, myCenter[1] + myB );
     }
 
     /**
@@ -217,6 +217,19 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
+
+  // ------------------------- Hidden services ------------------------------
+  private:
+
+    /**
+     * Equality test using relative tolerance.
+     */
+    template <typename T>
+    inline
+    bool isAlmostEqual( T x, T y ) const
+    {
+      return std::abs(x - y) <= std::numeric_limits<T>::epsilon();
+    }
 
   }; // end of class Astroid2D
 

--- a/src/DGtal/shapes/parametric/Astroid2D.ih
+++ b/src/DGtal/shapes/parametric/Astroid2D.ih
@@ -44,15 +44,6 @@ bool isAlmostEqual( T x, T y )
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ----------------------------------
 
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::Astroid2D<T>::~Astroid2D()
-{
-}
-
 template <typename T>
 inline
 DGtal::Astroid2D<T>::Astroid2D( const double x0, const double y0,
@@ -61,17 +52,15 @@ DGtal::Astroid2D<T>::Astroid2D( const double x0, const double y0,
 
 template <typename T>
 inline
-DGtal::Astroid2D<T>::Astroid2D( const RealPoint2D &aPoint,
+DGtal::Astroid2D<T>::Astroid2D( const RealPoint &aPoint,
   const double a, const double b ) : myCenter(aPoint), myA(fabs(a)), myB(fabs(b))
 {}
 
 template <typename T>
 inline
-DGtal::Astroid2D<T>::Astroid2D( const Point2D &aPoint,
-  const double a, const double b ) : myA(fabs(a)), myB(fabs(b))
-{
-  myCenter = aPoint;
-}
+DGtal::Astroid2D<T>::Astroid2D( const Astroid2D& other ) :
+  myCenter(other.myCenter), myA(other.myA), myB(other.myB)
+{}
 
 ///////////////////////////////////////////////////////////////////////////////
 // ------------- Implementation of 'StarShaped' services ----------------------
@@ -85,9 +74,9 @@ DGtal::Astroid2D<T>::Astroid2D( const Point2D &aPoint,
 template <typename T>
 inline
 double
-DGtal::Astroid2D<T>::parameter( const RealPoint2D & pp ) const
+DGtal::Astroid2D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint2D p( pp - myCenter );
+  RealPoint p( pp - myCenter );
   double angle = 0.;
 
   if ( isAlmostEqual(p[0],0.) )
@@ -129,10 +118,10 @@ DGtal::Astroid2D<T>::parameter( const RealPoint2D & pp ) const
  */
 template <typename T>
 inline
-typename DGtal::Astroid2D<T>::RealPoint2D
+typename DGtal::Astroid2D<T>::RealPoint
 DGtal::Astroid2D<T>::x( double t ) const
 {
-  RealPoint2D c( myA*pow(cos(t),3), myB*pow(sin(t),3) );
+  RealPoint c( myA*pow(cos(t),3), myB*pow(sin(t),3) );
   c += myCenter;
   return c;
 }
@@ -146,21 +135,21 @@ DGtal::Astroid2D<T>::x( double t ) const
  */
 template <typename T>
 inline
-typename DGtal::Astroid2D<T>::RealVector2D
+typename DGtal::Astroid2D<T>::RealVector
 DGtal::Astroid2D<T>::xp( const double t ) const
 {
 
-  RealVector2D c( myA * 3*(-sin(t))*pow(cos(t),2),
+  RealVector c( myA * 3*(-sin(t))*pow(cos(t),2),
                   myB * 3*cos(t)*pow(sin(t),2) );
   return c;
 }
 
 template <typename T>
 inline
-typename DGtal::Astroid2D<T>::RealVector2D
+typename DGtal::Astroid2D<T>::RealVector
 DGtal::Astroid2D<T>::xpp( const double t ) const
 {
-  RealVector2D c( -myA * 3*pow(cos(t),3)+6*pow(sin(t),2)*cos(t),
+  RealVector c( -myA * 3*pow(cos(t),3)+6*pow(sin(t),2)*cos(t),
                    myB * (6*pow(cos(t),2)*sin(t) - 3*pow(sin(t),3)) );
   return c;
 }

--- a/src/DGtal/shapes/parametric/Astroid2D.ih
+++ b/src/DGtal/shapes/parametric/Astroid2D.ih
@@ -30,16 +30,12 @@
 #include <cstdlib>
 ///////////////////////////////////////////////////////////////////////////////
 
+#define ASTROID_3_PI_2 (3. * M_PI_2)
+#define ASTROID_2_PI   (2. * M_PI)
+
 ///////////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION of inline methods.
 ///////////////////////////////////////////////////////////////////////////////
-
-template <typename T>
-inline
-bool isAlmostEqual( T x, T y )
-{
-  return std::abs(x - y) <= std::numeric_limits<T>::epsilon();
-}
 
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ----------------------------------
@@ -76,33 +72,18 @@ inline
 double
 DGtal::Astroid2D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint p( pp - myCenter );
+  const RealPoint p( pp - myCenter );
   double angle = 0.;
 
   if ( isAlmostEqual(p[0],0.) )
-  {
-    if  (p[1] > 0. )
-      angle = M_PI_2;
-    else
-      angle = 3. * M_PI_2;
-  }
+      angle = p[1] > 0. ? M_PI_2 : ASTROID_3_PI_2;
   else if ( isAlmostEqual(p[1],0.) )
-  {
-    if ( p[0] > 0. )
-      angle = 0.;
-    else
-      angle = M_PI;
-  }
+      angle = p[0] > 0. ? 0. : M_PI;
   else if ( ! isAlmostEqual(myB,0.) )
   {
     if( p[1]/p[0] < 0. )
-    {
-      angle = atan(-pow(-(myA*p[1])/(myB*p[0]) , 1/3.));
-      if ( p[0] > 0. )
-        angle += 2*M_PI;
-      else
-        angle += M_PI;
-    }
+      angle = atan(-pow(-(myA*p[1])/(myB*p[0]) , 1/3.))
+            + (p[0] > 0. ? ASTROID_2_PI : M_PI);
     else
       angle = atan(pow(( myA*p[1])/(myB*p[0]) , 1/3.));
   }
@@ -119,11 +100,9 @@ DGtal::Astroid2D<T>::parameter( const RealPoint & pp ) const
 template <typename T>
 inline
 typename DGtal::Astroid2D<T>::RealPoint
-DGtal::Astroid2D<T>::x( double t ) const
+DGtal::Astroid2D<T>::x( const double t ) const
 {
-  RealPoint c( myA*pow(cos(t),3), myB*pow(sin(t),3) );
-  c += myCenter;
-  return c;
+  return RealPoint( myA*pow(cos(t),3), myB*pow(sin(t),3) ) + myCenter;
 }
 
 
@@ -139,9 +118,8 @@ typename DGtal::Astroid2D<T>::RealVector
 DGtal::Astroid2D<T>::xp( const double t ) const
 {
 
-  RealVector c( myA * 3*(-sin(t))*pow(cos(t),2),
-                  myB * 3*cos(t)*pow(sin(t),2) );
-  return c;
+  return RealVector( myA * 3*(-sin(t))*pow(cos(t),2),
+                     myB * 3*cos(t)*pow(sin(t),2) );
 }
 
 template <typename T>
@@ -149,9 +127,8 @@ inline
 typename DGtal::Astroid2D<T>::RealVector
 DGtal::Astroid2D<T>::xpp( const double t ) const
 {
-  RealVector c( -myA * 3*pow(cos(t),3)+6*pow(sin(t),2)*cos(t),
-                   myB * (6*pow(cos(t),2)*sin(t) - 3*pow(sin(t),3)) );
-  return c;
+  return RealVector( -myA * 3*pow(cos(t),3) + 6*pow(sin(t),2)*cos(t),
+                      myB * (6*pow(cos(t),2)*sin(t) - 3*pow(sin(t),3)) );
 }
 
 
@@ -167,7 +144,9 @@ inline
 void
 DGtal::Astroid2D<T>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[Astroid2D] center= "<<myCenter<<" a="<<myA<<" b="<<myB;
+  out << "[Astroid2D] center= " << myCenter
+      << " a=" << myA
+      << " b=" << myB;
 }
 
 /**

--- a/src/DGtal/shapes/parametric/Ball2D.h
+++ b/src/DGtal/shapes/parametric/Ball2D.h
@@ -115,7 +115,7 @@ namespace DGtal
      */
     RealPoint getLowerBound() const
     {
-      return RealPoint(myCenter[0] - myRadius, myCenter[1] - myRadius);
+      return myCenter - myRadius;
     }
 
     /**
@@ -124,7 +124,7 @@ namespace DGtal
      */
     RealPoint getUpperBound() const
     {
-      return RealPoint(myCenter[0] + myRadius, myCenter[1] + myRadius);
+      return myCenter + myRadius;
     }
 
     /**

--- a/src/DGtal/shapes/parametric/Ball2D.h
+++ b/src/DGtal/shapes/parametric/Ball2D.h
@@ -63,14 +63,14 @@ namespace DGtal
   public:
 
     typedef TSpace Space;
-    typedef typename Space::Point Point;
-    typedef typename Space::RealPoint RealPoint2D;
-    typedef typename Space::RealVector RealVector2D;
+    typedef typename Space::RealPoint RealPoint;
+    typedef typename Space::RealVector RealVector;
 
     /**
-     * Destructor.
+     * Constructor.
+     * Forbidden by default.
      */
-    ~Ball2D();
+    Ball2D() = delete;
 
     /**
      * Constructor.
@@ -85,15 +85,26 @@ namespace DGtal
      * @param aPoint the circle center.
      * @param r the radius of the circle.
      */
-    Ball2D(const RealPoint2D &aPoint, const double r);
+    Ball2D( const RealPoint &aPoint, const double r );
 
     /**
-     * Constructor.
-     * @param aPoint the circle center.
-     * @param r the radius of the circle.
+     * Copy constructor.
+     * @param other the object to clone.
      */
-    Ball2D(const Point &aPoint, const double r);
+    Ball2D( const Ball2D & other );
 
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    Ball2D& operator=( const Ball2D& other ) = delete;
+
+    /**
+     * Destructor.
+     */
+    ~Ball2D() = default;
 
   // ------------- Implementation of 'StarShaped' services ------------------
   public:
@@ -102,24 +113,24 @@ namespace DGtal
      * @return the lower bound of the shape bounding box.
      *
      */
-    RealPoint2D getLowerBound() const
+    RealPoint getLowerBound() const
     {
-      return RealPoint2D(myCenter[0] - myRadius, myCenter[1] - myRadius);
+      return RealPoint(myCenter[0] - myRadius, myCenter[1] - myRadius);
     }
 
     /**
      * @return the upper bound of the shape bounding box.
      *
      */
-    RealPoint2D getUpperBound() const
+    RealPoint getUpperBound() const
     {
-      return RealPoint2D(myCenter[0] + myRadius, myCenter[1] + myRadius);
+      return RealPoint(myCenter[0] + myRadius, myCenter[1] + myRadius);
     }
 
     /**
      * @return the center of the star-shaped object.
      */
-    RealPoint2D center() const
+    RealPoint center() const
     {
       return myCenter;
     }
@@ -129,7 +140,7 @@ namespace DGtal
      * @param newCenter the new center position
      */
     inline
-    void moveTo( const RealPoint2D& newCenter )
+    void moveTo( const RealPoint& newCenter )
     {
       myCenter = newCenter;
     }
@@ -140,7 +151,7 @@ namespace DGtal
      * @return the angle parameter between 0 and 2*Pi corresponding to
      * this point for the shape.
      */
-    double parameter( const RealPoint2D & p ) const;
+    double parameter( const RealPoint & p ) const;
 
 
     /**
@@ -149,7 +160,7 @@ namespace DGtal
      * @return the vector (x(t),y(t)) which is the position on the
      * shape boundary.
      */
-    RealPoint2D x( const double t ) const;
+    RealPoint x( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -157,14 +168,14 @@ namespace DGtal
      * @return the vector (x'(t),y'(t)) which is the tangent to the
      * shape boundary.
      */
-    RealVector2D xp( const double t ) const;
+    RealVector xp( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
      *
      * @return the vector (x''(t),y''(t)).
      */
-    RealVector2D xpp( const double t ) const;
+    RealVector xpp( const double t ) const;
 
 
     // ------------------------- data ----------------------------
@@ -178,7 +189,7 @@ namespace DGtal
     /**
      * Center of the circle.
      */
-    RealPoint2D myCenter;
+    RealPoint myCenter;
 
 
     // ----------------------- Interface --------------------------------------
@@ -195,36 +206,6 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    Ball2D();
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    //  Ball2D ( const Ball2D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    Ball2D & operator= ( const Ball2D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class Ball2D
 

--- a/src/DGtal/shapes/parametric/Ball2D.ih
+++ b/src/DGtal/shapes/parametric/Ball2D.ih
@@ -38,15 +38,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ------------------------------
 
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::Ball2D<T>::~Ball2D()
-{
-}
-
 template <typename T>
 inline
 DGtal::Ball2D<T>::Ball2D(const double x0, const double y0, const double radius):
@@ -56,17 +47,15 @@ DGtal::Ball2D<T>::Ball2D(const double x0, const double y0, const double radius):
 
 template <typename T>
 inline
-DGtal::Ball2D<T>::Ball2D(const RealPoint2D &aPoint, const double radius):
+DGtal::Ball2D<T>::Ball2D(const RealPoint &aPoint, const double radius):
   myRadius(radius), myCenter(aPoint) 
 {}
 
 template <typename T>
 inline
-DGtal::Ball2D<T>::Ball2D(const Point &aPoint, const double radius):
-  myRadius(radius)
-{
-  myCenter = aPoint;
-}
+DGtal::Ball2D<T>::Ball2D(const Ball2D &other):
+  myCenter(other.myCenter), myRadius(other.myRadius)
+{}
 
 /////////////////////////////////////////////////////////////////////////////
 // ------------- Implementation of 'StarShaped' services ------------------
@@ -80,9 +69,9 @@ DGtal::Ball2D<T>::Ball2D(const Point &aPoint, const double radius):
 template <typename T>
 inline
 double
-DGtal::Ball2D<T>::parameter( const RealPoint2D & pp ) const
+DGtal::Ball2D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint2D p( pp );
+  RealPoint p( pp );
   p -= myCenter;
 
   double angle = atan2( p[1], p[0] );
@@ -99,10 +88,10 @@ DGtal::Ball2D<T>::parameter( const RealPoint2D & pp ) const
  */
 template <typename T>
 inline
-typename DGtal::Ball2D<T>::RealPoint2D 
+typename DGtal::Ball2D<T>::RealPoint 
 DGtal::Ball2D<T>::x( double t ) const
 {
-  RealPoint2D c( myRadius*cos(t), myRadius*sin(t) );
+  RealPoint c( myRadius*cos(t), myRadius*sin(t) );
   c += myCenter;
   return c;
 }
@@ -116,10 +105,10 @@ DGtal::Ball2D<T>::x( double t ) const
  */
 template <typename T>
 inline
-typename DGtal::Ball2D<T>::RealVector2D 
+typename DGtal::Ball2D<T>::RealVector 
 DGtal::Ball2D<T>::xp( const double t ) const
 {
-  RealVector2D c( -myRadius*sin(t), myRadius*cos(t) );
+  RealVector c( -myRadius*sin(t), myRadius*cos(t) );
   return c;
 }
 
@@ -130,10 +119,10 @@ DGtal::Ball2D<T>::xp( const double t ) const
  */
 template <typename T>
 inline
-typename DGtal::Ball2D<T>::RealVector2D
+typename DGtal::Ball2D<T>::RealVector
 DGtal::Ball2D<T>::xpp( const double t ) const
 {
-  RealVector2D c( -myRadius*cos(t), -myRadius*sin(t) );
+  RealVector c( -myRadius*cos(t), -myRadius*sin(t) );
   return c;
 }
 

--- a/src/DGtal/shapes/parametric/Ball2D.ih
+++ b/src/DGtal/shapes/parametric/Ball2D.ih
@@ -31,6 +31,8 @@
 #include <cstdlib>
 //////////////////////////////////////////////////////////////////////////////
 
+#define BALL2D_2_PI (2. * M_PI)
+
 ///////////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION of inline methods.
 ///////////////////////////////////////////////////////////////////////////////
@@ -69,15 +71,10 @@ DGtal::Ball2D<T>::Ball2D(const Ball2D &other):
 template <typename T>
 inline
 double
-DGtal::Ball2D<T>::parameter( const RealPoint & pp ) const
+DGtal::Ball2D<T>::parameter( const RealPoint & p ) const
 {
-  RealPoint p( pp );
-  p -= myCenter;
-
-  double angle = atan2( p[1], p[0] );
-  angle = ( angle < 0.0 ) ? angle + 2*M_PI : angle;
-
-  return angle;
+  const double angle = atan2(p[1]-myCenter[1], p[0]-myCenter[0]);
+  return angle < 0. ? angle + BALL2D_2_PI : angle;
 }
 
 /**
@@ -89,11 +86,9 @@ DGtal::Ball2D<T>::parameter( const RealPoint & pp ) const
 template <typename T>
 inline
 typename DGtal::Ball2D<T>::RealPoint 
-DGtal::Ball2D<T>::x( double t ) const
+DGtal::Ball2D<T>::x( const double t ) const
 {
-  RealPoint c( myRadius*cos(t), myRadius*sin(t) );
-  c += myCenter;
-  return c;
+  return RealPoint( myRadius*cos(t)+myCenter[0], myRadius*sin(t)+myCenter[1] );
 }
 
 
@@ -108,8 +103,7 @@ inline
 typename DGtal::Ball2D<T>::RealVector 
 DGtal::Ball2D<T>::xp( const double t ) const
 {
-  RealVector c( -myRadius*sin(t), myRadius*cos(t) );
-  return c;
+  return RealVector( -myRadius*sin(t), myRadius*cos(t) );
 }
 
 /**
@@ -122,8 +116,7 @@ inline
 typename DGtal::Ball2D<T>::RealVector
 DGtal::Ball2D<T>::xpp( const double t ) const
 {
-  RealVector c( -myRadius*cos(t), -myRadius*sin(t) );
-  return c;
+  return RealVector( -myRadius*cos(t), -myRadius*sin(t) );
 }
 
 
@@ -139,7 +132,8 @@ inline
 void
 DGtal::Ball2D<T>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[Ball2D] center= "<<myCenter<<" radius="<<myRadius;
+  out << "[Ball2D] center= " << myCenter
+      << " radius=" << myRadius;
 }
 
 /**

--- a/src/DGtal/shapes/parametric/Ball3D.h
+++ b/src/DGtal/shapes/parametric/Ball3D.h
@@ -117,9 +117,7 @@ namespace DGtal
     RealPoint getLowerBound() const
     {
 
-      return RealPoint(myCenter[0] - myRadius,
-                       myCenter[1] - myRadius ,
-                       myCenter[2] - myRadius );
+      return myCenter - myRadius;
     }
 
     /**
@@ -128,9 +126,7 @@ namespace DGtal
      */
     RealPoint getUpperBound() const
     {
-      return RealPoint(myCenter[0] + myRadius ,
-                       myCenter[1] + myRadius,
-                       myCenter[2] + myRadius);
+      return myCenter + myRadius;
     }
 
     /**
@@ -166,49 +162,49 @@ namespace DGtal
      * @return the vector (x(t),y(t),z(t)) which is the position on the
      * shape boundary.
      */
-    RealPoint x( const AngularCoordinates t ) const;
+    RealPoint x( const AngularCoordinates& t ) const;
 
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
      * @return the vector (gradf(M)).
      */
-    virtual RealPoint gradient( const AngularCoordinates t) const ;
+    virtual RealPoint gradient( const AngularCoordinates& t) const ;
 
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
      * @return the vector (rt(M)) wich is the partial derivative with respect to Teta.
      */
-    virtual RealPoint rt( const AngularCoordinates t) const ;
+    virtual RealPoint rt( const AngularCoordinates& t) const ;
 
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
      * @return the vector (rp(M)) wich is the partial derivative with respect to Phi.
      */
-    virtual RealPoint rp( const AngularCoordinates t) const ;
+    virtual RealPoint rp( const AngularCoordinates& t) const ;
 
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
      * @return the vector (rtt(M)) wich is second the partial derivative with respect to Teta (twice).
      */
-    virtual RealPoint rtt( const AngularCoordinates t) const ;
+    virtual RealPoint rtt( const AngularCoordinates& t) const ;
 
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
      * @return the vector (rpp(M)) wich is second the partial derivatif with respect to Phi (twice).
      */
-    virtual RealPoint rpp( const AngularCoordinates t) const ;
+    virtual RealPoint rpp( const AngularCoordinates& t) const ;
 
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
      * @return the vector (rpp(M)) wich is second the partial derivative with respect to Teta then Phi.
      */
-    virtual RealPoint rtp( const AngularCoordinates t) const ;
+    virtual RealPoint rtp( const AngularCoordinates& t) const ;
 
 
     // ------------------------- data ----------------------------

--- a/src/DGtal/shapes/parametric/Ball3D.h
+++ b/src/DGtal/shapes/parametric/Ball3D.h
@@ -67,9 +67,10 @@ namespace DGtal
     typedef std::pair<double,double> AngularCoordinates;
 
     /**
-     * Destructor.
+     * Constructor.
+     * Forbidden by default.
      */
-    ~Ball3D();
+    Ball3D() = delete;
 
     /**
      * Constructor.
@@ -85,17 +86,26 @@ namespace DGtal
      * @param aPoint the sphere center.
      * @param r the radius of the sphere.
      */
-    Ball3D(const RealPoint &aPoint, const double r);
+    Ball3D( const RealPoint& aPoint, const double r );
 
-
-    /*
-     * Constructor.
-     * @param aPoint the sphere center.
-     * @param r the radius of the sphere.
+    /**
+     * Copy constructor.
+     * @param other the object to clone.
      */
-    /*
-      Ball3D(const Point &aPoint, const double r);
-    */
+    Ball3D( const Ball3D& other );
+
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    Ball3D& operator=( const Ball3D& other ) = delete;
+
+    /**
+     * Destructor.
+     */
+    ~Ball3D() = default;
 
     // ------------- Implementation of 'StarShaped' services ------------------
   public:
@@ -150,8 +160,6 @@ namespace DGtal
      */
     AngularCoordinates parameter( const RealPoint & p ) const;
 
-
-
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
@@ -160,17 +168,12 @@ namespace DGtal
      */
     RealPoint x( const AngularCoordinates t ) const;
 
-
-
-
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
      * @return the vector (gradf(M)).
      */
     virtual RealPoint gradient( const AngularCoordinates t) const ;
-
-
 
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
@@ -179,15 +182,12 @@ namespace DGtal
      */
     virtual RealPoint rt( const AngularCoordinates t) const ;
 
-
-
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
      * @return the vector (rp(M)) wich is the partial derivative with respect to Phi.
      */
     virtual RealPoint rp( const AngularCoordinates t) const ;
-
 
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
@@ -196,8 +196,6 @@ namespace DGtal
      */
     virtual RealPoint rtt( const AngularCoordinates t) const ;
 
-
-
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
@@ -205,15 +203,12 @@ namespace DGtal
      */
     virtual RealPoint rpp( const AngularCoordinates t) const ;
 
-
     /**
      * @param t is a couple of Teta && Phi wich are respectivly between [-Pi/2,Pi/2) and [-Pi,Pi].
      *
      * @return the vector (rpp(M)) wich is second the partial derivative with respect to Teta then Phi.
      */
     virtual RealPoint rtp( const AngularCoordinates t) const ;
-
-
 
 
     // ------------------------- data ----------------------------
@@ -229,7 +224,6 @@ namespace DGtal
      */
     RealPoint myCenter;
 
-
     // ----------------------- Interface --------------------------------------
   public:
 
@@ -244,36 +238,6 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    Ball3D();
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    // Ball3D ( const Ball3D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    Ball3D & operator= ( const Ball3D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class Ball3D
 

--- a/src/DGtal/shapes/parametric/Ball3D.ih
+++ b/src/DGtal/shapes/parametric/Ball3D.ih
@@ -42,15 +42,6 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ------------------------------
-typedef std::pair<double,double> AngularCoordinates;
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::Ball3D<T>::~Ball3D()
-{
-}
 
 template <typename T>
 inline
@@ -65,6 +56,11 @@ DGtal::Ball3D<T>::Ball3D(const RealPoint &aPoint, const double radius):
   myRadius(radius), myCenter(aPoint)
 {}
 
+template <typename T>
+inline
+DGtal::Ball3D<T>::Ball3D(const Ball3D& other):
+  myCenter(other.myCenter), myRadius(other.myRadius)
+{}
 
 /////////////////////////////////////////////////////////////////////////////
 // ------------- Implementation of 'StarShaped' services ------------------

--- a/src/DGtal/shapes/parametric/Ball3D.ih
+++ b/src/DGtal/shapes/parametric/Ball3D.ih
@@ -36,6 +36,8 @@
 
 //////////////////////////////////////////////////////////////////////////////
 
+#define BALL3D_2_PI (2. * M_PI)
+
 ///////////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION of inline methods.
 ///////////////////////////////////////////////////////////////////////////////
@@ -76,17 +78,16 @@ inline
 AngularCoordinates
 DGtal::Ball3D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint p( pp );
-  p -= myCenter;
+  const RealPoint p( pp - myCenter );
   AngularCoordinates angle;
   
   angle.first = atan2( p[1], p[0] );
-  double tmp = std::min ( std::abs( p[2] ), 1.0 );
-  double pn = p.norm();
-  angle.second = pn > 0.0 ? acos( tmp / pn ) : 0.0;
+  const double tmp = std::min( std::abs(p[2]), 1. );
+  const double pn = p.norm();
+  angle.second = pn > 0. ? acos(tmp/pn) : 0.;
 
-  angle.first = ( angle.first < 0.0 ) ? angle.first + 2*M_PI : angle.first;
-  angle.second = ( angle.second < 0.0 ) ? angle.second + M_PI : angle.second;
+  angle.first = ( angle.first < 0. ) ? angle.first + BALL3D_2_PI : angle.first;
+  angle.second = ( angle.second < 0. ) ? angle.second + M_PI : angle.second;
   
   return angle;
 }
@@ -100,11 +101,13 @@ DGtal::Ball3D<T>::parameter( const RealPoint & pp ) const
 template <typename T>
 inline
 typename DGtal::Ball3D<T>::RealPoint
-DGtal::Ball3D<T>::x( AngularCoordinates t ) const
+DGtal::Ball3D<T>::x( const AngularCoordinates& t ) const
 {
-  RealPoint c( myRadius*cos(t.first)*sin(t.second), myRadius*sin(t.first)*sin(t.second) , myRadius*cos(t.second));
-  c += myCenter;
-  return c;
+  return RealPoint(
+    myRadius * cos(t.first) * sin(t.second) + myCenter[0],
+    myRadius * sin(t.first) * sin(t.second) + myCenter[1],
+    myRadius * cos(t.second) + myCenter[2]
+  );
 }
 
 
@@ -117,13 +120,9 @@ DGtal::Ball3D<T>::x( AngularCoordinates t ) const
 template <typename T>
 inline
 typename DGtal::Ball3D<T>::RealPoint
-DGtal::Ball3D<T>::gradient( const AngularCoordinates t) const
+DGtal::Ball3D<T>::gradient( const AngularCoordinates& t ) const
 {
-  RealPoint p= x(t);
-  double xx=2*(p[0]-myCenter[0]);
-  double yy =2*(p[1]-myCenter[1]);
-  double zz=2*(p[2]-myCenter[2]);
-  return RealPoint(xx,yy,zz);
+  return 2 * (x(t) - myCenter);
 }
 
 /**
@@ -134,9 +133,13 @@ DGtal::Ball3D<T>::gradient( const AngularCoordinates t) const
 template <typename T>
 inline
 typename DGtal::Ball3D<T>::RealPoint
-DGtal::Ball3D<T>::rt( const AngularCoordinates t) const
+DGtal::Ball3D<T>::rt( const AngularCoordinates& t ) const
 {
-  return RealPoint(-myRadius*sin(t.first)*sin(t.second),myRadius*cos(t.first)*sin(t.second),0);
+  return RealPoint(
+    -myRadius * sin(t.first) * sin(t.second),
+     myRadius * cos(t.first) * sin(t.second),
+     0
+  );
 }
 
 
@@ -149,9 +152,13 @@ DGtal::Ball3D<T>::rt( const AngularCoordinates t) const
 template <typename T>
 inline
 typename DGtal::Ball3D<T>::RealPoint
-DGtal::Ball3D<T>::rp( const AngularCoordinates t) const
+DGtal::Ball3D<T>::rp( const AngularCoordinates& t ) const
 {
-  return RealPoint(myRadius*cos(t.first)*cos(t.second),myRadius*sin(t.first)*cos(t.second),-myRadius*sin(t.second));
+  return RealPoint(
+     myRadius * cos(t.first) * cos(t.second),
+     myRadius * sin(t.first) * cos(t.second),
+    -myRadius * sin(t.second)
+  );
 }
 
 
@@ -163,9 +170,13 @@ DGtal::Ball3D<T>::rp( const AngularCoordinates t) const
 template <typename T>
 inline
 typename DGtal::Ball3D<T>::RealPoint
-DGtal::Ball3D<T>::rtt( const AngularCoordinates t) const
+DGtal::Ball3D<T>::rtt( const AngularCoordinates& t ) const
 {
-  return RealPoint(-myRadius*cos(t.first)*sin(t.second),-myRadius*sin(t.first)*sin(t.second),0);
+  return RealPoint(
+    -myRadius * cos(t.first) * sin(t.second),
+    -myRadius * sin(t.first) * sin(t.second),
+     0.
+  );
 }
 
 
@@ -178,11 +189,15 @@ DGtal::Ball3D<T>::rtt( const AngularCoordinates t) const
 template <typename T>
 inline
 typename DGtal::Ball3D<T>::RealPoint
-DGtal::Ball3D<T>::rpp( const AngularCoordinates t) const
+DGtal::Ball3D<T>::rpp( const AngularCoordinates& t ) const
 {
-  return RealPoint(-myRadius*cos(t.first)*sin(t.second),-myRadius*sin(t.first)*sin(t.second),-myRadius*cos(t.second));
+  return RealPoint(
+    -myRadius * cos(t.first) * sin(t.second),
+    -myRadius * sin(t.first) * sin(t.second),
+    -myRadius * cos(t.second)
+  );
 }
-    
+
 /**
  * @param t is a couple of Teta && Phi wich are angles respectivly betweend [0,2PI] and [0,Pi]
  *
@@ -191,14 +206,18 @@ DGtal::Ball3D<T>::rpp( const AngularCoordinates t) const
 template <typename T>
 inline
 typename DGtal::Ball3D<T>::RealPoint
-DGtal::Ball3D<T>::rtp( const AngularCoordinates t) const
+DGtal::Ball3D<T>::rtp( const AngularCoordinates& t ) const
 {
-  return RealPoint(-myRadius*sin(t.first)*cos(t.second),myRadius*cos(t.first)*cos(t.second),0);
+  return RealPoint(
+    -myRadius * sin(t.first) * cos(t.second),
+     myRadius * cos(t.first) * cos(t.second),
+     0.
+  );
 }
-    
 
-    
-    
+
+
+
 ///////////////////////////////////////////////////////////////////////////////
 // Interface - public :
 
@@ -211,7 +230,8 @@ inline
 void
 DGtal::Ball3D<T>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[Ball3D] center= "<<myCenter<<" radius="<<myRadius;
+  out << "[Ball3D] center= " << myCenter
+      << " radius=" << myRadius;
 }
 
 /**

--- a/src/DGtal/shapes/parametric/Ellipse2D.h
+++ b/src/DGtal/shapes/parametric/Ellipse2D.h
@@ -63,7 +63,7 @@ namespace DGtal
   template <typename TSpace>
   class Ellipse2D final:  public StarShaped2D<TSpace>
   {
-    // ----------------------- Standard services ------------------------------
+  // ----------------------- Standard services ------------------------------
   public:
 
     typedef TSpace Space;
@@ -125,7 +125,7 @@ namespace DGtal
      */
     RealPoint getLowerBound() const
     {
-      return RealPoint(myCenter[0] - myAxis1, myCenter[1] - myAxis1);
+      return myCenter - myAxis1;
     }
 
     /**
@@ -134,7 +134,7 @@ namespace DGtal
      */
     RealPoint getUpperBound() const
     {
-      return RealPoint(myCenter[0] + myAxis1, myCenter[1] + myAxis1);
+      return myCenter + myAxis1;
     }
 
     /**
@@ -188,7 +188,7 @@ namespace DGtal
     RealVector xpp( const double t ) const;
 
 
-    // ------------------------- data ----------------------------
+  // ------------------------- data ----------------------------
   private:
 
     /**
@@ -212,7 +212,7 @@ namespace DGtal
      */
     double myTheta;
 
-    // ----------------------- Interface --------------------------------------
+  // ----------------------- Interface --------------------------------------
   public:
 
     /**
@@ -226,6 +226,19 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
+
+  // ------------------------- Hidden services ------------------------------
+  private:
+
+    /**
+     * Equality test using relative tolerance.
+     */
+    template <typename T>
+    inline
+    bool isAlmostEqual( T x, T y ) const
+    {
+      return std::abs(x - y) <= std::numeric_limits<T>::epsilon();
+    }
 
   }; // end of class Ellipse2D
 

--- a/src/DGtal/shapes/parametric/Ellipse2D.h
+++ b/src/DGtal/shapes/parametric/Ellipse2D.h
@@ -67,14 +67,14 @@ namespace DGtal
   public:
 
     typedef TSpace Space;
-    typedef typename Space::Point Point;
-    typedef typename Space::RealPoint RealPoint2D;
-    typedef typename Space::RealVector RealVector2D;
+    typedef typename Space::RealPoint RealPoint;
+    typedef typename Space::RealVector RealVector;
 
     /**
-     * Destructor.
+     * Constructor.
+     * Forbidden by default.
      */
-    ~Ellipse2D();
+    Ellipse2D() = delete;
 
     /**
      * Constructor.
@@ -85,7 +85,7 @@ namespace DGtal
      * @param theta the orientation of the ellipse.
      */
     Ellipse2D( const double x0, const double y0,
-         const double a0, const double a1, const double theta);
+         const double a0, const double a1, const double theta );
 
     /**
      * Constructor.
@@ -94,19 +94,27 @@ namespace DGtal
      * @param a1 the half small axis of the ellipse.
      * @param theta the orientation of the ellipse.
      */
-    Ellipse2D(const RealPoint2D &aPoint,
-        const double a0, const double a1, const double theta);
+    Ellipse2D( const RealPoint& aPoint,
+        const double a0, const double a1, const double theta );
 
     /**
-     * Constructor.
-     * @param aPoint the circle center.
-     * @param a0 the half big axis of the ellipse.
-     * @param a1 the half small axis of the ellipse.
-     * @param theta the orientation of the ellipse.
+     * Copy constructor.
+     * @param other the object to clone.
      */
-    Ellipse2D(const Point &aPoint,
-        const double a0, const double a1, const double theta);
+     Ellipse2D( const Ellipse2D& other );
 
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    Ellipse2D& operator=( const Ellipse2D& other ) = delete;
+
+    /**
+     * Destructor.
+     */
+    ~Ellipse2D() = default;
 
   // ------------- Implementation of 'StarShaped' services ------------------
   public:
@@ -115,24 +123,24 @@ namespace DGtal
      * @return the lower bound of the shape bounding box.
      *
      */
-    RealPoint2D getLowerBound() const
+    RealPoint getLowerBound() const
     {
-      return RealPoint2D(myCenter[0] - myAxis1, myCenter[1] - myAxis1);
+      return RealPoint(myCenter[0] - myAxis1, myCenter[1] - myAxis1);
     }
 
     /**
      * @return the upper bound of the shape bounding box.
      *
      */
-    RealPoint2D getUpperBound() const
+    RealPoint getUpperBound() const
     {
-      return RealPoint2D(myCenter[0] + myAxis1, myCenter[1] + myAxis1);
+      return RealPoint(myCenter[0] + myAxis1, myCenter[1] + myAxis1);
     }
 
     /**
      * @return the center of the star-shaped object.
      */
-    RealPoint2D center() const
+    RealPoint center() const
     {
       return myCenter;
     }
@@ -142,7 +150,7 @@ namespace DGtal
      * @param newCenter the new center position
      */
     inline
-    void moveTo( const RealPoint2D& newCenter )
+    void moveTo( const RealPoint& newCenter )
     {
       myCenter = newCenter;
     }
@@ -153,7 +161,7 @@ namespace DGtal
      * @return the angle parameter between 0 and 2*Pi corresponding to
      * this point for the shape.
      */
-    double parameter( const RealPoint2D & p ) const;
+    double parameter( const RealPoint & p ) const;
 
 
     /**
@@ -162,7 +170,7 @@ namespace DGtal
      * @return the vector (x(t),y(t)) which is the position on the
      * shape boundary.
      */
-    RealPoint2D x( const double t ) const;
+    RealPoint x( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -170,14 +178,14 @@ namespace DGtal
      * @return the vector (x'(t),y'(t)) which is the tangent to the
      * shape boundary.
      */
-    RealVector2D xp( const double t ) const;
+    RealVector xp( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
      *
      * @return the vector (x''(t),y''(t)).
      */
-    RealVector2D xpp( const double t ) const;
+    RealVector xpp( const double t ) const;
 
 
     // ------------------------- data ----------------------------
@@ -186,7 +194,7 @@ namespace DGtal
     /**
      * Center of the circle.
      */
-    RealPoint2D myCenter;
+    RealPoint myCenter;
 
     /**
      * First axis.
@@ -218,36 +226,6 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    Ellipse2D();
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    //  Ellipse2D ( const Ellipse2D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    Ellipse2D & operator= ( const Ellipse2D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class Ellipse2D
 

--- a/src/DGtal/shapes/parametric/Ellipse2D.ih
+++ b/src/DGtal/shapes/parametric/Ellipse2D.ih
@@ -37,6 +37,9 @@
 // IMPLEMENTATION of inline methods.
 ///////////////////////////////////////////////////////////////////////////////
 
+#define ELLIPSE2D_3_PI_2 (1.5*M_PI)
+#define ELLIPSE2D_2_PI   (2.*M_PI)
+
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ------------------------------
 
@@ -75,25 +78,15 @@ inline
 double
 DGtal::Ellipse2D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint v2d( pp );
-  v2d -= myCenter;
+  RealPoint v2d( pp - myCenter );
   
   double angle; 
 
-  if ( v2d[0] == 0.0 ) 
-    {
-      if ( v2d[1] >0 )
-        angle = M_PI/2.0; 
-      else 
-        angle = 1.5*M_PI; 
-    }
-  else if (  ( v2d[0] > 0.0 ) && (   v2d[1] >= 0.0 ) )
-    angle = atan(v2d[1]/v2d[0]);
-  else if (  ( v2d[0] > 0.0 ) && (   v2d[1] <= 0.0 ) )
-    angle = 2*M_PI + atan(v2d[1]/v2d[0]);
-  else if (  ( v2d[0] < 0.0 ) && (   v2d[1] >= 0.0 ) )
-    angle = atan(v2d[1]/v2d[0]) + M_PI;
-  else // (  ( v2d[0] < 0.0 ) && (   v2d[1] <= 0.0 ) )
+  if ( isAlmostEqual(v2d[0],0.) ) 
+    angle = v2d[1] > 0. ? M_PI_2 : ELLIPSE2D_3_PI_2;
+  else if ( v2d[0] > 0. )
+    angle = atan(v2d[1]/v2d[0]) + (v2d[1] < 0. ? ELLIPSE2D_2_PI : 0.);
+  else
     angle = atan(v2d[1]/v2d[0]) + M_PI;
 
    return angle;
@@ -108,20 +101,16 @@ DGtal::Ellipse2D<T>::parameter( const RealPoint & pp ) const
 template <typename T>
 inline
 typename DGtal::Ellipse2D<T>::RealPoint 
-DGtal::Ellipse2D<T>::x( double t ) const
+DGtal::Ellipse2D<T>::x( const double t ) const
 {
-  double a2 = myAxis1*myAxis1;
-  double b2 = myAxis2*myAxis2;
-  double costth = cos( t - myTheta );
-  //  double sintth = sin( t - myTheta );
-  double cost = cos( t );
-  double sint = sin( t );
-  double rho = myAxis2 / sqrt( 1.0 - ((a2-b2)/a2)*costth*costth);
-    //myAxis2*myAxis1 / sqrt( a2 - (a2-b2)*costth*costth);
-  RealPoint v( rho*cost, 
-     rho*sint );
-  v += myCenter;
-  return v;
+  const double a2 = myAxis1*myAxis1;
+  const double b2 = myAxis2*myAxis2;
+  const double costth = cos(t - myTheta);
+  const double rho = myAxis2 / sqrt(1. - (a2-b2) / a2 * costth * costth);
+
+  return RealPoint(
+    rho * cos(t) + myCenter[0],
+    rho * sin(t) + myCenter[1] );
 }
 
 
@@ -136,20 +125,20 @@ inline
 typename DGtal::Ellipse2D<T>::RealVector 
 DGtal::Ellipse2D<T>::xp( const double t ) const
 {
-  double a2 = myAxis1*myAxis1;
-  double b2 = myAxis2*myAxis2;
-  double costth = cos( t - myTheta );
-  double sintth = sin( t - myTheta );
-  double cost = cos( t );
-  double sint = sin( t );
-  double rho = myAxis2 / sqrt( 1.0 - ((a2-b2)/a2)*costth*costth);
-  double a = myAxis1; 
-  double b = myAxis2;
-  double rhod= a*b*(b2-a2)*sintth*costth
-    / std::pow( a2*sintth*sintth + b2*costth*costth, 1.5 );
-  RealPoint v( rhod*cost - rho*sint, rhod*sint + rho*cost );
+  const double a2 = myAxis1 * myAxis1;
+  const double b2 = myAxis2 * myAxis2;
+  const double costth = cos(t - myTheta);
+  const double sintth = sin(t - myTheta);
+  const double cost = cos(t);
+  const double sint = sin(t);
+  const double rho = myAxis2 / sqrt(1. - (a2-b2) / a2 * costth * costth);
+  const double rhod = myAxis1 * myAxis2 * (b2-a2) * sintth * costth
+    / std::pow(a2 * sintth * sintth + b2 * costth * costth, 1.5);
   
-  return v;
+  return RealPoint(
+    rhod*cost - rho*sint,
+    rhod*sint + rho*cost
+  );
 }
 
 /**
@@ -162,26 +151,25 @@ inline
 typename DGtal::Ellipse2D<T>::RealVector
 DGtal::Ellipse2D<T>::xpp( const double t ) const
 {
-  double a2 = myAxis1*myAxis1;
-  double b2 = myAxis2*myAxis2;
-  double costth = cos( t - myTheta );
-  double sintth = sin( t - myTheta );
-  double cost = cos( t );
-  double sint = sin( t );
-  double rho = myAxis2 / sqrt( 1.0 - ((a2-b2)/a2)*costth*costth);
+  const double a2 = myAxis1 * myAxis1;
+  const double b2 = myAxis2 * myAxis2;
+  const double costth = cos(t - myTheta);
+  const double sintth = sin(t - myTheta);
+  const double cost = cos(t);
+  const double sint = sin(t);
+  const double rho = myAxis2 / sqrt( 1. - (a2-b2)/a2*costth*costth);
 
-  double a = myAxis1; 
-  double b = myAxis2;
-  double rhod = a*b*(b2-a2)*sintth*costth
+  const double rhod = myAxis1 * myAxis2 * (b2-a2) * sintth * costth
     / std::pow( a2*sintth*sintth + b2*costth*costth, 1.5 );
-  double rhodd = a*b*(b2-a2)
+  const double rhodd = myAxis1 * myAxis2 * (b2-a2)
     / std::pow( a2*sintth*sintth + b2*costth*costth, 2.5 )
     * ( (costth*costth - sintth*sintth) * (a2*sintth*sintth + b2*costth*costth)
-  + 3.0*(b2-a2)*sintth*sintth*costth*costth );
+        + 3.*(b2-a2)*sintth*sintth*costth*costth );
   
-  RealPoint v( rhodd*cost - 2.0*rhod*sint - rho*cost, 
-     rhodd*sint + 2.0*rhod*cost - rho*sint );
-  return v;
+  return RealPoint(
+    rhodd*cost - 2.*rhod*sint - rho*cost,
+    rhodd*sint + 2.*rhod*cost - rho*sint
+  );
 }
 
 
@@ -197,8 +185,10 @@ inline
 void
 DGtal::Ellipse2D<T>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[Ellipse2D] center= "<<myCenter<<" big axis="<<myAxis1
-      <<" small axis="<<myAxis2<<" phase="<<myTheta;
+  out << "[Ellipse2D] center= " << myCenter
+      << " big axis=" << myAxis1
+      << " small axis=" << myAxis2
+      << " phase=" << myTheta;
 }
 
 /**

--- a/src/DGtal/shapes/parametric/Ellipse2D.ih
+++ b/src/DGtal/shapes/parametric/Ellipse2D.ih
@@ -40,38 +40,26 @@
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ------------------------------
 
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::Ellipse2D<T>::~Ellipse2D()
-{
-}
-
 template <typename T>
 inline
 DGtal::Ellipse2D<T>::Ellipse2D(const double x0, const double y0,
              const double a0, const double a1, const double theta)
-  : myCenter(x0,y0), myAxis1(a0),myAxis2(a1),myTheta(theta)
+  : myCenter(x0,y0), myAxis1(a0), myAxis2(a1), myTheta(theta)
 {}
-
 
 template <typename T>
 inline
-DGtal::Ellipse2D<T>::Ellipse2D(const RealPoint2D &aPoint,
+DGtal::Ellipse2D<T>::Ellipse2D(const RealPoint &aPoint,
              const double a0, const double a1, const double theta)
-  : myCenter(aPoint), myAxis1(a0),myAxis2(a1),myTheta(theta)
+  : myCenter(aPoint), myAxis1(a0), myAxis2(a1), myTheta(theta)
 {}
 
 template <typename T>
 inline
-DGtal::Ellipse2D<T>::Ellipse2D(const Point &aPoint,
-             const double a0, const double a1, const double theta) 
-  : myAxis1(a0),myAxis2(a1),myTheta(theta)
-{
-  myCenter = aPoint;
-}
+DGtal::Ellipse2D<T>::Ellipse2D(const Ellipse2D& other)
+  : myCenter(other.myCenter), myAxis1(other.myAxis1),
+    myAxis2(other.myAxis2), myTheta(other.myTheta)
+{}
 
 /////////////////////////////////////////////////////////////////////////////
 // ------------- Implementation of 'StarShaped' services ------------------
@@ -85,9 +73,9 @@ DGtal::Ellipse2D<T>::Ellipse2D(const Point &aPoint,
 template <typename T>
 inline
 double
-DGtal::Ellipse2D<T>::parameter( const RealPoint2D & pp ) const
+DGtal::Ellipse2D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint2D v2d( pp );
+  RealPoint v2d( pp );
   v2d -= myCenter;
   
   double angle; 
@@ -119,7 +107,7 @@ DGtal::Ellipse2D<T>::parameter( const RealPoint2D & pp ) const
  */
 template <typename T>
 inline
-typename DGtal::Ellipse2D<T>::RealPoint2D 
+typename DGtal::Ellipse2D<T>::RealPoint 
 DGtal::Ellipse2D<T>::x( double t ) const
 {
   double a2 = myAxis1*myAxis1;
@@ -130,7 +118,7 @@ DGtal::Ellipse2D<T>::x( double t ) const
   double sint = sin( t );
   double rho = myAxis2 / sqrt( 1.0 - ((a2-b2)/a2)*costth*costth);
     //myAxis2*myAxis1 / sqrt( a2 - (a2-b2)*costth*costth);
-  RealPoint2D v( rho*cost, 
+  RealPoint v( rho*cost, 
      rho*sint );
   v += myCenter;
   return v;
@@ -145,7 +133,7 @@ DGtal::Ellipse2D<T>::x( double t ) const
  */
 template <typename T>
 inline
-typename DGtal::Ellipse2D<T>::RealVector2D 
+typename DGtal::Ellipse2D<T>::RealVector 
 DGtal::Ellipse2D<T>::xp( const double t ) const
 {
   double a2 = myAxis1*myAxis1;
@@ -159,7 +147,7 @@ DGtal::Ellipse2D<T>::xp( const double t ) const
   double b = myAxis2;
   double rhod= a*b*(b2-a2)*sintth*costth
     / std::pow( a2*sintth*sintth + b2*costth*costth, 1.5 );
-  RealPoint2D v( rhod*cost - rho*sint, rhod*sint + rho*cost );
+  RealPoint v( rhod*cost - rho*sint, rhod*sint + rho*cost );
   
   return v;
 }
@@ -171,7 +159,7 @@ DGtal::Ellipse2D<T>::xp( const double t ) const
  */
 template <typename T>
 inline
-typename DGtal::Ellipse2D<T>::RealVector2D
+typename DGtal::Ellipse2D<T>::RealVector
 DGtal::Ellipse2D<T>::xpp( const double t ) const
 {
   double a2 = myAxis1*myAxis1;
@@ -191,7 +179,7 @@ DGtal::Ellipse2D<T>::xpp( const double t ) const
     * ( (costth*costth - sintth*sintth) * (a2*sintth*sintth + b2*costth*costth)
   + 3.0*(b2-a2)*sintth*sintth*costth*costth );
   
-  RealPoint2D v( rhodd*cost - 2.0*rhod*sint - rho*cost, 
+  RealPoint v( rhodd*cost - 2.0*rhod*sint - rho*cost, 
      rhodd*sint + 2.0*rhod*cost - rho*sint );
   return v;
 }

--- a/src/DGtal/shapes/parametric/Flower2D.h
+++ b/src/DGtal/shapes/parametric/Flower2D.h
@@ -67,13 +67,14 @@ namespace DGtal
   public:
 
     typedef TSpace Space;
-    typedef typename Space::Point Point;
-    typedef typename Space::RealPoint RealPoint2D;
-    typedef typename Space::RealVector RealVector2D;
+    typedef typename Space::RealPoint RealPoint;
+    typedef typename Space::RealVector RealVector;
+
     /**
-     * Destructor.
+     * Constructor.
+     * Forbidden by default.
      */
-    ~Flower2D();
+    Flower2D() = delete;
 
     /**
      * Constructor.
@@ -88,7 +89,7 @@ namespace DGtal
         const double r,
         const double smallr,
         const unsigned int k,
-        const double phi);
+        const double phi );
 
     /**
      * Constructor.
@@ -98,25 +99,30 @@ namespace DGtal
      * @param k the number of flower extremeties.
      * @param phi the phase of the flower (in radian).
      */
-    Flower2D(const RealPoint2D &aPoint,
+    Flower2D( const RealPoint& aPoint,
        const double r,
        const double smallr,
        const unsigned int k,
-       const double phi);
+       const double phi );
 
     /**
-     * Constructor.
-     * @param aPoint the flower center.
-     * @param r the radius of the flower.
-     * @param smallr the variable small radius of the flower.
-     * @param k the number of flower extremeties.
-     * @param phi the phase of the flower (in radian).
+     * Copy constructor.
+     * @param other the object to clone.
      */
-    Flower2D(const Point &aPoint,
-       const double r,
-       const double smallr,
-       const unsigned int k,
-       const double phi);
+    Flower2D( const Flower2D& other );
+
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    Flower2D& operator=( const Flower2D& other ) = delete;
+
+    /**
+     * Destructor.
+     */
+    ~Flower2D() = default;
 
 
     // ------------- Implementation of 'StarShaped' services ------------------
@@ -126,24 +132,24 @@ namespace DGtal
      * @return the lower bound of the shape bounding box.
      *
      */
-    RealPoint2D getLowerBound() const
+    RealPoint getLowerBound() const
     {
-      return RealPoint2D(myCenter[0] - myRadius - myVarRadius, myCenter[1] - myRadius - myVarRadius);
+      return RealPoint(myCenter[0] - myRadius - myVarRadius, myCenter[1] - myRadius - myVarRadius);
     }
 
     /**
      * @return the upper bound of the shape bounding box.
      *
      */
-    RealPoint2D getUpperBound() const
+    RealPoint getUpperBound() const
     {
-      return RealPoint2D(myCenter[0] + myRadius + myVarRadius, myCenter[1] + myRadius + myVarRadius);
+      return RealPoint(myCenter[0] + myRadius + myVarRadius, myCenter[1] + myRadius + myVarRadius);
     }
 
     /**
      * @return the center of the star-shaped object.
      */
-    RealPoint2D center() const
+    RealPoint center() const
     {
       return myCenter;
     }
@@ -153,7 +159,7 @@ namespace DGtal
      * @param newCenter the new center position
      */
     inline
-    void moveTo( const RealPoint2D& newCenter )
+    void moveTo( const RealPoint& newCenter )
     {
       myCenter = newCenter;
     }
@@ -164,7 +170,7 @@ namespace DGtal
      * @return the angle parameter between 0 and 2*Pi corresponding to
      * this point for the shape.
      */
-    double parameter( const RealPoint2D & p ) const;
+    double parameter( const RealPoint & p ) const;
 
 
     /**
@@ -173,7 +179,7 @@ namespace DGtal
      * @return the vector (x(t),y(t)) which is the position on the
      * shape boundary.
      */
-    RealPoint2D x( const double t ) const;
+    RealPoint x( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -181,14 +187,14 @@ namespace DGtal
      * @return the vector (x'(t),y'(t)) which is the tangent to the
      * shape boundary.
      */
-    RealVector2D xp( const double t ) const;
+    RealVector xp( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
      *
      * @return the vector (x''(t),y''(t)).
      */
-    RealVector2D xpp( const double t ) const;
+    RealVector xpp( const double t ) const;
 
 
     // ------------------------- data ----------------------------
@@ -197,7 +203,7 @@ namespace DGtal
     /**
      * Center of the flower.
      */
-    RealPoint2D myCenter;
+    RealPoint myCenter;
 
     /**
      * Radius of the flower.
@@ -233,36 +239,6 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    Flower2D();
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    //  Flower2D ( const Flower2D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    Flower2D & operator= ( const Flower2D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class Flower2D
 

--- a/src/DGtal/shapes/parametric/Flower2D.h
+++ b/src/DGtal/shapes/parametric/Flower2D.h
@@ -134,7 +134,7 @@ namespace DGtal
      */
     RealPoint getLowerBound() const
     {
-      return RealPoint(myCenter[0] - myRadius - myVarRadius, myCenter[1] - myRadius - myVarRadius);
+      return myCenter - (myRadius + myVarRadius);
     }
 
     /**
@@ -143,7 +143,7 @@ namespace DGtal
      */
     RealPoint getUpperBound() const
     {
-      return RealPoint(myCenter[0] + myRadius + myVarRadius, myCenter[1] + myRadius + myVarRadius);
+      return myCenter + (myRadius + myVarRadius);
     }
 
     /**

--- a/src/DGtal/shapes/parametric/Flower2D.ih
+++ b/src/DGtal/shapes/parametric/Flower2D.ih
@@ -40,15 +40,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ------------------------------
 
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::Flower2D<T>::~Flower2D()
-{
-}
-
 template <typename T>
 inline
 DGtal::Flower2D<T>::Flower2D(const double x0, const double y0,
@@ -60,7 +51,7 @@ DGtal::Flower2D<T>::Flower2D(const double x0, const double y0,
 
 template <typename T>
 inline
-DGtal::Flower2D<T>::Flower2D(const RealPoint2D &aPoint, const double radius,
+DGtal::Flower2D<T>::Flower2D(const RealPoint &aPoint, const double radius,
            const double varRadius,
            const unsigned int k, const double phi)
   : myCenter(aPoint), myRadius(radius), myVarRadius(varRadius), 
@@ -69,13 +60,10 @@ DGtal::Flower2D<T>::Flower2D(const RealPoint2D &aPoint, const double radius,
 
 template <typename T>
 inline
-DGtal::Flower2D<T>::Flower2D(const Point &aPoint, const double radius,
-           const double varRadius,
-           const unsigned int k, const double phi)
-  : myRadius(radius),myVarRadius(varRadius),myK(k),myPhi(phi)
-{
-  myCenter = aPoint;
-}
+DGtal::Flower2D<T>::Flower2D(const Flower2D& other)
+  : myCenter(other.myCenter), myRadius(other.myRadius),
+    myVarRadius(other.myVarRadius), myK(other.myK), myPhi(other.myPhi)
+{}
 
 /////////////////////////////////////////////////////////////////////////////
 // ------------- Implementation of 'StarShaped' services ------------------
@@ -89,9 +77,9 @@ DGtal::Flower2D<T>::Flower2D(const Point &aPoint, const double radius,
 template <typename T>
 inline
 double
-DGtal::Flower2D<T>::parameter( const RealPoint2D & pp ) const
+DGtal::Flower2D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint2D p( pp );
+  RealPoint p( pp );
   p -= myCenter;
 
   double angle = atan2( p[1], p[0] );
@@ -108,11 +96,11 @@ DGtal::Flower2D<T>::parameter( const RealPoint2D & pp ) const
  */
 template <typename T>
 inline
-typename DGtal::Flower2D<T>::RealPoint2D 
+typename DGtal::Flower2D<T>::RealPoint 
 DGtal::Flower2D<T>::x( double t ) const
 {
   double r= myRadius+ myVarRadius*cos(myK*t + myPhi);
-  RealPoint2D c( r*cos(t), r*sin(t) );
+  RealPoint c( r*cos(t), r*sin(t) );
   c += myCenter;
   return c;
 }
@@ -126,12 +114,12 @@ DGtal::Flower2D<T>::x( double t ) const
  */
 template <typename T>
 inline
-typename DGtal::Flower2D<T>::RealVector2D 
+typename DGtal::Flower2D<T>::RealVector 
 DGtal::Flower2D<T>::xp( const double t ) const
 {
   double r= myRadius+ myVarRadius*cos(myK*t + myPhi);
   double rp = - myVarRadius * sin( myK * t + myPhi ) * myK;
-  RealVector2D c( rp*cos(t) - r*sin(t),rp*sin(t) + r*cos(t) );
+  RealVector c( rp*cos(t) - r*sin(t),rp*sin(t) + r*cos(t) );
   return c;
 }
 
@@ -142,13 +130,13 @@ DGtal::Flower2D<T>::xp( const double t ) const
  */
 template <typename T>
 inline
-typename DGtal::Flower2D<T>::RealVector2D
+typename DGtal::Flower2D<T>::RealVector
 DGtal::Flower2D<T>::xpp( const double t ) const
 {
   double r= myRadius+ myVarRadius*cos(myK*t + myPhi);
   double rp = - myVarRadius * sin( myK * t + myPhi ) * myK;
   double rpp = - myVarRadius * cos( myK * t + myPhi ) * myK * myK;
-  RealVector2D c(rpp * cos( t ) - 2 * rp * sin( t ) - r * cos( t ),
+  RealVector c(rpp * cos( t ) - 2 * rp * sin( t ) - r * cos( t ),
      rpp * sin( t ) + 2 * rp * cos( t ) - r * sin( t ) );
   return c;
 }

--- a/src/DGtal/shapes/parametric/Flower2D.ih
+++ b/src/DGtal/shapes/parametric/Flower2D.ih
@@ -33,6 +33,8 @@
 #include <cstdlib>
 //////////////////////////////////////////////////////////////////////////////
 
+#define FLOWER2D_2_PI   (2. * M_PI)
+
 ///////////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION of inline methods.
 ///////////////////////////////////////////////////////////////////////////////
@@ -77,15 +79,10 @@ DGtal::Flower2D<T>::Flower2D(const Flower2D& other)
 template <typename T>
 inline
 double
-DGtal::Flower2D<T>::parameter( const RealPoint & pp ) const
+DGtal::Flower2D<T>::parameter( const RealPoint & p ) const
 {
-  RealPoint p( pp );
-  p -= myCenter;
-
-  double angle = atan2( p[1], p[0] );
-  angle = ( angle < 0.0 ) ? angle + 2*M_PI : angle;
-
-  return angle;
+  const double angle = atan2( p[1]-myCenter[1], p[0]-myCenter[0] );
+  return angle < 0.0 ? angle + FLOWER2D_2_PI : angle;
 }
 
 /**
@@ -97,12 +94,13 @@ DGtal::Flower2D<T>::parameter( const RealPoint & pp ) const
 template <typename T>
 inline
 typename DGtal::Flower2D<T>::RealPoint 
-DGtal::Flower2D<T>::x( double t ) const
+DGtal::Flower2D<T>::x( const double t ) const
 {
-  double r= myRadius+ myVarRadius*cos(myK*t + myPhi);
-  RealPoint c( r*cos(t), r*sin(t) );
-  c += myCenter;
-  return c;
+  const double r = myRadius + myVarRadius * cos(myK*t + myPhi);
+  return RealPoint(
+    r*cos(t) + myCenter[0],
+    r*sin(t) + myCenter[1]
+  );
 }
 
 
@@ -117,10 +115,12 @@ inline
 typename DGtal::Flower2D<T>::RealVector 
 DGtal::Flower2D<T>::xp( const double t ) const
 {
-  double r= myRadius+ myVarRadius*cos(myK*t + myPhi);
-  double rp = - myVarRadius * sin( myK * t + myPhi ) * myK;
-  RealVector c( rp*cos(t) - r*sin(t),rp*sin(t) + r*cos(t) );
-  return c;
+  const double r = myRadius + myVarRadius * cos(myK*t + myPhi);
+  const double rp = -myVarRadius * sin(myK*t + myPhi) * myK;
+  return RealVector(
+    rp*cos(t) - r*sin(t),
+    rp*sin(t) + r*cos(t)
+  );
 }
 
 /**
@@ -133,12 +133,13 @@ inline
 typename DGtal::Flower2D<T>::RealVector
 DGtal::Flower2D<T>::xpp( const double t ) const
 {
-  double r= myRadius+ myVarRadius*cos(myK*t + myPhi);
-  double rp = - myVarRadius * sin( myK * t + myPhi ) * myK;
-  double rpp = - myVarRadius * cos( myK * t + myPhi ) * myK * myK;
-  RealVector c(rpp * cos( t ) - 2 * rp * sin( t ) - r * cos( t ),
-     rpp * sin( t ) + 2 * rp * cos( t ) - r * sin( t ) );
-  return c;
+  const double r   =  myRadius + myVarRadius * cos(myK*t + myPhi);
+  const double rp  = -myVarRadius * sin(myK*t + myPhi) * myK;
+  const double rpp = -myVarRadius * cos(myK*t + myPhi) * myK * myK;
+  return RealVector(
+    rpp*cos(t) - 2*rp*sin(t) - r*cos(t),
+    rpp*sin(t) + 2*rp*cos(t) - r*sin(t)
+  );
 }
 
 
@@ -154,8 +155,11 @@ inline
 void
 DGtal::Flower2D<T>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[Flower2D] center= "<<myCenter<<" radius="<<myRadius<<" varRadius="<<myVarRadius
-      <<" myK="<<myK<<" phase-shift="<<myPhi;
+  out << "[Flower2D] center= " << myCenter
+      << " radius=" << myRadius
+      << " varRadius=" << myVarRadius
+      << " myK=" << myK
+      << " phase-shift=" << myPhi;
 }
 
 /**

--- a/src/DGtal/shapes/parametric/Lemniscate2D.h
+++ b/src/DGtal/shapes/parametric/Lemniscate2D.h
@@ -64,14 +64,14 @@ namespace DGtal
   public:
 
     typedef TSpace Space;
-    typedef typename Space::Point Point2D;
-    typedef typename Space::RealPoint RealPoint2D;
-    typedef typename Space::RealVector RealVector2D;
+    typedef typename Space::RealPoint RealPoint;
+    typedef typename Space::RealVector RealVector;
 
     /**
-     * Destructor.
+     * Constructor.
+     * Forbidden by default.
      */
-    ~Lemniscate2D();
+    Lemniscate2D() = delete;
 
     /**
      * Constructor.
@@ -90,15 +90,27 @@ namespace DGtal
       * @param aPoint the lemniscate center
       * @param a      semi-axis length along x-axis
       */
-    Lemniscate2D( const RealPoint2D &aPoint, const double a );
+    Lemniscate2D( const RealPoint& aPoint, const double a );
 
-     /**
-      * Constructor.
-     * The absolute value of parameter `a` is used.
-      * @param aPoint the lemniscate center
-      * @param a      semi-axis length along x-axis
-      */
-    Lemniscate2D( const Point2D &aPoint, const double a );
+    /**
+     * Copy constructor.
+     * @param other the object to clone.
+     */
+     Lemniscate2D( const Lemniscate2D& other );
+
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    Lemniscate2D& operator=( const Lemniscate2D& other ) = delete;
+
+    /**
+     * Destructor.
+     */
+    ~Lemniscate2D() = default;
+
 
 
    // ------------- Implementation of 'StarShaped' services ------------------
@@ -108,24 +120,24 @@ namespace DGtal
      * @return the lower bound of the shape bounding box.
      *
      */
-    RealPoint2D getLowerBound() const
+    RealPoint getLowerBound() const
     {
-      return RealPoint2D(-myA - myCenter[0] , -myA * .5 - myCenter[1] );
+      return RealPoint(-myA - myCenter[0] , -myA * .5 - myCenter[1] );
     }
 
     /**
      * @return the upper bound of the shape bounding box.
      *
      */
-    RealPoint2D getUpperBound() const
+    RealPoint getUpperBound() const
     {
-      return RealPoint2D( myA - myCenter[0] , myA * .5 - myCenter[1]);
+      return RealPoint( myA - myCenter[0] , myA * .5 - myCenter[1]);
     }
 
     /**
      * @return the center of the star-shaped object.
      */
-    RealPoint2D center() const
+    RealPoint center() const
     {
       return myCenter;
     }
@@ -135,7 +147,7 @@ namespace DGtal
      * @param newCenter the new center position
      */
     inline
-    void moveTo( const RealPoint2D& newCenter )
+    void moveTo( const RealPoint& newCenter )
     {
       myCenter = newCenter;
     }
@@ -146,7 +158,7 @@ namespace DGtal
      * @return the angle parameter between 0 and 2*Pi corresponding to
      * this point for the shape.
      */
-    double parameter( const RealPoint2D & p ) const;
+    double parameter( const RealPoint & p ) const;
 
 
     /**
@@ -155,7 +167,7 @@ namespace DGtal
      * @return the vector (x(t),y(t)) which is the position on the
      * shape boundary.
      */
-    RealPoint2D x( const double t ) const;
+    RealPoint x( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -163,14 +175,14 @@ namespace DGtal
      * @return the vector (x'(t),y'(t)) which is the tangent to the
      * shape boundary.
      */
-    RealVector2D xp( const double t ) const;
+    RealVector xp( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
      *
      * @return the vector (x''(t),y''(t)).
      */
-    RealVector2D xpp( const double t ) const;
+    RealVector xpp( const double t ) const;
 
 
     // ------------------------- data -----------------------------------------
@@ -179,7 +191,7 @@ namespace DGtal
     /**
      * Center of the circle.
      */
-    RealPoint2D myCenter;
+    RealPoint myCenter;
 
     /**
      * Semi-axis length along x-axis
@@ -201,36 +213,6 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    Lemniscate2D();
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    //  Lemniscate2D ( const Lemniscate2D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    Lemniscate2D & operator= ( const Lemniscate2D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class Lemniscate2D
 

--- a/src/DGtal/shapes/parametric/Lemniscate2D.h
+++ b/src/DGtal/shapes/parametric/Lemniscate2D.h
@@ -60,7 +60,7 @@ namespace DGtal
   template <typename TSpace>
   class Lemniscate2D : public DGtal::StarShaped2D<TSpace>
   {
-    // ----------------------- Standard services ------------------------------
+  // ----------------------- Standard services ------------------------------
   public:
 
     typedef TSpace Space;
@@ -80,7 +80,7 @@ namespace DGtal
      * @param y0 the y-coordinate of the lemniscate center.
      * @param a  semi-axis length along x-axis
      */
-   Lemniscate2D( const double x0, const double y0,
+    Lemniscate2D( const double x0, const double y0,
                  const double a );
 
      /**
@@ -111,10 +111,8 @@ namespace DGtal
      */
     ~Lemniscate2D() = default;
 
-
-
-   // ------------- Implementation of 'StarShaped' services ------------------
-    public:
+  // ------------- Implementation of 'StarShaped' services ------------------
+  public:
 
     /**
      * @return the lower bound of the shape bounding box.
@@ -122,7 +120,7 @@ namespace DGtal
      */
     RealPoint getLowerBound() const
     {
-      return RealPoint(-myA - myCenter[0] , -myA * .5 - myCenter[1] );
+      return RealPoint( myCenter[0] - myA, myCenter[1] - myA * 0.5 );
     }
 
     /**
@@ -131,7 +129,7 @@ namespace DGtal
      */
     RealPoint getUpperBound() const
     {
-      return RealPoint( myA - myCenter[0] , myA * .5 - myCenter[1]);
+      return RealPoint( myCenter[0] + myA, myCenter[1] + myA * 0.5 );
     }
 
     /**
@@ -159,7 +157,6 @@ namespace DGtal
      * this point for the shape.
      */
     double parameter( const RealPoint & p ) const;
-
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -198,7 +195,7 @@ namespace DGtal
      */
     double myA;
 
-    // ----------------------- Interface --------------------------------------
+  // ----------------------- Interface --------------------------------------
   public:
 
     /**
@@ -213,6 +210,19 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
+  
+  // ------------------------- Hidden services ------------------------------
+  private:
+
+    /**
+     * Equality test using relative tolerance.
+     */
+    template <typename T>
+    inline
+    bool isAlmostEqual( T x, T y ) const
+    {
+      return std::abs(x - y) <= std::numeric_limits<T>::epsilon();
+    }
 
   }; // end of class Lemniscate2D
 

--- a/src/DGtal/shapes/parametric/Lemniscate2D.ih
+++ b/src/DGtal/shapes/parametric/Lemniscate2D.ih
@@ -37,15 +37,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ----------------------------------
 
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::Lemniscate2D<T>::~Lemniscate2D()
-{
-}
-
 template <typename T>
 inline
 DGtal::Lemniscate2D<T>::Lemniscate2D( const double x0, const double y0,
@@ -54,17 +45,15 @@ DGtal::Lemniscate2D<T>::Lemniscate2D( const double x0, const double y0,
 
 template <typename T>
 inline
-DGtal::Lemniscate2D<T>::Lemniscate2D( const RealPoint2D &aPoint,
+DGtal::Lemniscate2D<T>::Lemniscate2D( const RealPoint &aPoint,
   const double a ) : myCenter(aPoint), myA(fabs(a))
 {}
 
 template <typename T>
 inline
-DGtal::Lemniscate2D<T>::Lemniscate2D( const Point2D &aPoint,
-  const double a ) : myA(fabs(a))
-{
-  myCenter = aPoint;
-}
+DGtal::Lemniscate2D<T>::Lemniscate2D(const Lemniscate2D& other ) :
+  myCenter(other.myCenter), myA(other.myA)
+{}
 
 ///////////////////////////////////////////////////////////////////////////////
 // ------------- Implementation of 'StarShaped' services ----------------------
@@ -78,9 +67,9 @@ DGtal::Lemniscate2D<T>::Lemniscate2D( const Point2D &aPoint,
 template <typename T>
 inline
 double
-DGtal::Lemniscate2D<T>::parameter( const RealPoint2D & pp ) const
+DGtal::Lemniscate2D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint2D p( pp-myCenter );
+  RealPoint p( pp-myCenter );
   double angle;
 
   if ( fabs(p[0]) < fabs(p[1]) )
@@ -107,13 +96,13 @@ DGtal::Lemniscate2D<T>::parameter( const RealPoint2D & pp ) const
  */
 template <typename T>
 inline
-typename DGtal::Lemniscate2D<T>::RealPoint2D
+typename DGtal::Lemniscate2D<T>::RealPoint
 DGtal::Lemniscate2D<T>::x( double t ) const
 {
   const double cost = cos(t);
   const double sint = sin(t);
   const double cos2t = pow(cost,2);
-  RealPoint2D c( myA * sint / (1. + cos2t),
+  RealPoint c( myA * sint / (1. + cos2t),
                  myA * sint * cost / (1. + cos2t) );
   c += myCenter;
   return c;
@@ -128,14 +117,14 @@ DGtal::Lemniscate2D<T>::x( double t ) const
  */
 template <typename T>
 inline
-typename DGtal::Lemniscate2D<T>::RealVector2D
+typename DGtal::Lemniscate2D<T>::RealVector
 DGtal::Lemniscate2D<T>::xp( const double t ) const
 {
   const double cost = cos(t);
   const double cos2t = pow(cost,2);
   const double sin2t = pow(sin(t),2);
 
-  RealVector2D c(
+  RealVector c(
     myA * (cost + 2*sin2t*cost+pow(cost,3)) / pow(1+cos2t,2),
     myA * (pow(cost,4) + cos2t - sin2t +
                          sin2t * cos2t)  / pow(1+cos2t,2) );
@@ -144,7 +133,7 @@ DGtal::Lemniscate2D<T>::xp( const double t ) const
 
 template <typename T>
 inline
-typename DGtal::Lemniscate2D<T>::RealVector2D
+typename DGtal::Lemniscate2D<T>::RealVector
 DGtal::Lemniscate2D<T>::xpp( const double t ) const
 {
   const double cost = cos(t);
@@ -152,7 +141,7 @@ DGtal::Lemniscate2D<T>::xpp( const double t ) const
   const double sint = sin(t);
   const double sin3t = pow(sint,3);
 
-  RealVector2D c(
+  RealVector c(
     myA * ( 4 * sin3t * cos2t +
             6 * sin3t * pow(cost,4) +
             3 * sint * cos2t -

--- a/src/DGtal/shapes/parametric/Lemniscate2D.ih
+++ b/src/DGtal/shapes/parametric/Lemniscate2D.ih
@@ -30,6 +30,8 @@
 #include <cstdlib>
 ///////////////////////////////////////////////////////////////////////////////
 
+#define LEMNISCATE2D_3_PI_2   (3. * M_PI / 2.)
+
 ///////////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION of inline methods.
 ///////////////////////////////////////////////////////////////////////////////
@@ -67,21 +69,17 @@ DGtal::Lemniscate2D<T>::Lemniscate2D(const Lemniscate2D& other ) :
 template <typename T>
 inline
 double
-DGtal::Lemniscate2D<T>::parameter( const RealPoint & pp ) const
+DGtal::Lemniscate2D<T>::parameter( const RealPoint& pp ) const
 {
-  RealPoint p( pp-myCenter );
+  const RealPoint p( pp-myCenter );
   double angle;
 
   if ( fabs(p[0]) < fabs(p[1]) )
-    return 0.;
-  if ( p[0] == 0. )
     angle = 0.;
-  else if ( p[0] == 0. && p[1] < 0. )
-    angle = M_PI;
-  else if ( p[1] == 0. && p[0] > 0. )
-    angle = M_PI_2;
-  else if ( p[1] == 0. && p[0] < 0. )
-    angle = 3. * M_PI_2;
+  else if ( isAlmostEqual(p[0],0.) )
+    angle = p[1] < 0. ? M_PI : 0.;
+  else if ( isAlmostEqual(p[1],0.) )
+    angle = p[0] > 0. ? M_PI_2 : LEMNISCATE2D_3_PI_2;
   else
     angle = acos(p[1]/p[0]);
 
@@ -97,15 +95,15 @@ DGtal::Lemniscate2D<T>::parameter( const RealPoint & pp ) const
 template <typename T>
 inline
 typename DGtal::Lemniscate2D<T>::RealPoint
-DGtal::Lemniscate2D<T>::x( double t ) const
+DGtal::Lemniscate2D<T>::x( const double t ) const
 {
   const double cost = cos(t);
   const double sint = sin(t);
   const double cos2t = pow(cost,2);
-  RealPoint c( myA * sint / (1. + cos2t),
-                 myA * sint * cost / (1. + cos2t) );
-  c += myCenter;
-  return c;
+  return RealPoint(
+    myA * sint / (1. + cos2t) + myCenter[0],
+    myA * sint * cost / (1. + cos2t) + myCenter[1]
+  );
 }
 
 
@@ -120,15 +118,14 @@ inline
 typename DGtal::Lemniscate2D<T>::RealVector
 DGtal::Lemniscate2D<T>::xp( const double t ) const
 {
-  const double cost = cos(t);
+  const double cost  = cos(t);
   const double cos2t = pow(cost,2);
   const double sin2t = pow(sin(t),2);
 
-  RealVector c(
+  return RealVector(
     myA * (cost + 2*sin2t*cost+pow(cost,3)) / pow(1+cos2t,2),
-    myA * (pow(cost,4) + cos2t - sin2t +
-                         sin2t * cos2t)  / pow(1+cos2t,2) );
-  return c;
+    myA * (pow(cost,4) + cos2t - sin2t + sin2t * cos2t)
+        / pow(1+cos2t,2) );
 }
 
 template <typename T>
@@ -141,7 +138,7 @@ DGtal::Lemniscate2D<T>::xpp( const double t ) const
   const double sint = sin(t);
   const double sin3t = pow(sint,3);
 
-  RealVector c(
+ return RealVector(
     myA * ( 4 * sin3t * cos2t +
             6 * sin3t * pow(cost,4) +
             3 * sint * cos2t -
@@ -159,7 +156,6 @@ DGtal::Lemniscate2D<T>::xpp( const double t ) const
             2 * sint * pow(cost,7) )
         / pow(1+cos2t,4)
   );
-  return c;
 }
 
 
@@ -175,7 +171,8 @@ inline
 void
 DGtal::Lemniscate2D<T>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[Lemniscate2D] center= " << myCenter << " a=" << myA;
+  out << "[Lemniscate2D] center= " << myCenter
+      << " a=" << myA;
 }
 
 /**

--- a/src/DGtal/shapes/parametric/NGon2D.h
+++ b/src/DGtal/shapes/parametric/NGon2D.h
@@ -125,7 +125,7 @@ namespace DGtal
      */
     RealPoint getLowerBound() const
     {
-      return RealPoint(myCenter[0] - myRadius, myCenter[1] - myRadius);
+      return myCenter - myRadius;
     }
 
     /**
@@ -134,7 +134,7 @@ namespace DGtal
      */
     RealPoint getUpperBound() const
     {
-      return RealPoint(myCenter[0] + myRadius, myCenter[1] + myRadius);
+      return myCenter + myRadius;
     }
 
     /**

--- a/src/DGtal/shapes/parametric/NGon2D.h
+++ b/src/DGtal/shapes/parametric/NGon2D.h
@@ -66,14 +66,14 @@ namespace DGtal
   public:
 
     typedef TSpace Space;
-    typedef typename Space::Point Point;
-    typedef typename Space::RealPoint RealPoint2D;
-    typedef typename Space::RealVector RealVector2D;
+    typedef typename Space::RealPoint RealPoint;
+    typedef typename Space::RealVector RealVector;
 
     /**
-     * Destructor.
+     * Constructor.
+     * Forbidden by default.
      */
-    ~NGon2D();
+    NGon2D() = delete;
 
     /**
      * Constructor.
@@ -93,18 +93,27 @@ namespace DGtal
      * @param k the number of faces of the k-gon.
      * @param phi the phase of the ngon (radian).
      */
-    NGon2D(const RealPoint2D &aPoint, const double r,
-     const   unsigned int k, const double phi);
+    NGon2D( const RealPoint& aPoint, const double r,
+     const   unsigned int k, const double phi );
 
     /**
-     * Constructor.
-     * @param aPoint the circle center.
-     * @param r the radius of the circle.
-     * @param k the number of faces of the k-gon.
-     * @param phi the phase of the ngon (radian).
+     * Copy constructor.
+     * @param other the object to clone.
      */
-    NGon2D(const Point &aPoint, const double r,
-     const  unsigned int k, const double phi);
+    NGon2D( const NGon2D& other );
+
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    NGon2D& operator= ( const NGon2D& other ) = delete;
+
+    /**
+     * Destructor.
+     */
+    ~NGon2D() = default;
 
 
   // ------------- Implementation of 'StarShaped' services ------------------
@@ -114,24 +123,24 @@ namespace DGtal
      * @return the lower bound of the shape bounding box.
      *
      */
-    RealPoint2D getLowerBound() const
+    RealPoint getLowerBound() const
     {
-      return RealPoint2D(myCenter[0] - myRadius, myCenter[1] - myRadius);
+      return RealPoint(myCenter[0] - myRadius, myCenter[1] - myRadius);
     }
 
     /**
      * @return the upper bound of the shape bounding box.
      *
      */
-    RealPoint2D getUpperBound() const
+    RealPoint getUpperBound() const
     {
-      return RealPoint2D(myCenter[0] + myRadius, myCenter[1] + myRadius);
+      return RealPoint(myCenter[0] + myRadius, myCenter[1] + myRadius);
     }
 
     /**
      * @return the center of the star-shaped object.
      */
-    RealPoint2D center() const
+    RealPoint center() const
     {
       return myCenter;
     }
@@ -141,7 +150,7 @@ namespace DGtal
      * @param newCenter the new center position
      */
     inline
-    void moveTo( const RealPoint2D& newCenter )
+    void moveTo( const RealPoint& newCenter )
     {
       myCenter = newCenter;
     }
@@ -152,7 +161,7 @@ namespace DGtal
      * @return the angle parameter between 0 and 2*Pi corresponding to
      * this point for the shape.
      */
-    double parameter( const RealPoint2D & p ) const;
+    double parameter( const RealPoint & p ) const;
 
 
     /**
@@ -161,7 +170,7 @@ namespace DGtal
      * @return the vector (x(t),y(t)) which is the position on the
      * shape boundary.
      */
-    RealPoint2D x( const double t ) const;
+    RealPoint x( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -169,14 +178,14 @@ namespace DGtal
      * @return the vector (x'(t),y'(t)) which is the tangent to the
      * shape boundary.
      */
-    RealVector2D xp( const double t ) const;
+    RealVector xp( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
      *
      * @return the vector (x''(t),y''(t)).
      */
-    RealVector2D xpp( const double t ) const;
+    RealVector xpp( const double t ) const;
 
 
     // ------------------------- data ----------------------------
@@ -185,7 +194,7 @@ namespace DGtal
     /**
      * Center of the circle.
      */
-    RealPoint2D myCenter;
+    RealPoint myCenter;
 
     /**
      * Radius of the circle.
@@ -218,36 +227,6 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    NGon2D();
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    //  NGon2D ( const NGon2D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    NGon2D & operator= ( const NGon2D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class NGon2D
 

--- a/src/DGtal/shapes/parametric/NGon2D.ih
+++ b/src/DGtal/shapes/parametric/NGon2D.ih
@@ -33,6 +33,8 @@
 #include <cstdlib>
 //////////////////////////////////////////////////////////////////////////////
 
+#define NGON2D_2_PI (2. * M_PI)
+
 ///////////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION of inline methods.
 ///////////////////////////////////////////////////////////////////////////////
@@ -76,15 +78,10 @@ DGtal::NGon2D<T>::NGon2D(const NGon2D& other):
 template <typename T>
 inline
 double
-DGtal::NGon2D<T>::parameter( const RealPoint & pp ) const
+DGtal::NGon2D<T>::parameter( const RealPoint & p ) const
 {
-  RealPoint p( pp );
-  p -= myCenter;
-
-  double angle = atan2( p[1], p[0] );
-  angle = ( angle < 0.0 ) ? angle + 2 * M_PI : angle;
-
-  return angle;
+  const double angle = atan2( p[1]-myCenter[1], p[0]-myCenter[0] );
+  return angle < 0. ? angle + NGON2D_2_PI : angle;
 }
 
 /**
@@ -96,34 +93,27 @@ DGtal::NGon2D<T>::parameter( const RealPoint & pp ) const
 template <typename T>
 inline
 typename DGtal::NGon2D<T>::RealPoint 
-DGtal::NGon2D<T>::x( double t ) const
+DGtal::NGon2D<T>::x( const double t ) const
 {
-  double angle = t - myPhi;
-  angle = (angle < 0.0) ? angle + 2 * M_PI : angle;
+  const double angle = t - myPhi + (angle < 0.0 ? NGON2D_2_PI : 0.);
 
   // seek the vertices between the point, then compute the vector from one vertex to the next one.
 
-  unsigned int intervale_lower = static_cast<unsigned int>( floor( ( angle ) * myK / (2.0 * M_PI ) ) );
-  unsigned int intervale_upper = intervale_lower == ( myK - 1 ) ? 0 : intervale_lower + 1;
-  double dist = myRadius * cos( M_PI / myK );
-  RealPoint s1 ( myRadius * cos( myPhi + intervale_lower * 2.0 * M_PI / myK ),
-                   myRadius * sin( myPhi + intervale_lower * 2.0 * M_PI / myK ));
-  RealPoint s2 ( myRadius * cos( myPhi + intervale_upper * 2.0 * M_PI / myK ),
-                   myRadius * sin( myPhi + intervale_upper * 2.0 * M_PI / myK ));
-  RealPoint s3 ( s2[0] - s1[0],
-                   s2[1] - s1[1]);
+  const unsigned int intervale_lower = static_cast<unsigned int>( floor( angle * myK / NGON2D_2_PI ) );
+  const unsigned int intervale_upper = intervale_lower == ( myK - 1 ) ? 0 : intervale_lower + 1;
+  const RealPoint s1 ( myRadius * cos( myPhi + intervale_lower * NGON2D_2_PI / myK ),
+                       myRadius * sin( myPhi + intervale_lower * NGON2D_2_PI / myK ));
+  const RealPoint s2 ( myRadius * cos( myPhi + intervale_upper * NGON2D_2_PI / myK ),
+                       myRadius * sin( myPhi + intervale_upper * NGON2D_2_PI / myK ));
 
-  //double line_angle = atan2f( (float)s3[ 1 ], (float)s3[ 0 ]);
-  double line_angle = atan2( s3[1], s3[0] );
+  const double line_angle = atan2( s2[1]-s1[1], s2[0]-s1[0] );
   //line_angle = (line_angle < 0.0) ? angle + 2 * M_PI : line_angle;
+  const double rho = myRadius * cos(M_PI / myK) / cos(t - line_angle - M_PI_2);
 
-  double rho = dist / ( cos(t - line_angle - 0.5 * M_PI) );
-
-  RealPoint c( - rho*cos(t), - rho*sin(t) );
-
-  c += myCenter;
-
-  return c;
+  return RealPoint(
+    -rho * cos(t) + myCenter[0],
+    -rho * sin(t) + myCenter[1]
+  );
 }
 
 
@@ -142,23 +132,20 @@ DGtal::NGon2D<T>::xp( const double t ) const
   // TODO check if angle equals that of a vertex ?
   double angle = t - myPhi; 
   while ( angle < 0.0 )
-    angle += 2.0*M_PI;
+    angle += NGON2D_2_PI;
   
-  unsigned int intervalle_lower = static_cast<unsigned int>( floor( angle * myK / (2.0 * M_PI ) ) );
+  unsigned int intervalle_lower = static_cast<unsigned int>( floor( angle * myK / (NGON2D_2_PI ) ) );
   unsigned int intervalle_upper = intervalle_lower == ( myK -1 ) ? 0 : intervalle_lower+1;
-  //float dist = myRadius*sin ( M_PI / myK );
-  RealPoint s1 ( myRadius*cos(myPhi + intervalle_lower*2.0*M_PI/myK),
-       myRadius*sin(myPhi + intervalle_lower*2.0*M_PI/myK) );
-  RealPoint s2 ( myRadius*cos(myPhi + intervalle_upper*2.0*M_PI/myK),
-       myRadius*sin(myPhi + intervalle_upper*2.0*M_PI/myK) );
-  s2 -= s1;
+
+  const RealPoint s(
+        myRadius*cos(myPhi + intervalle_upper*NGON2D_2_PI/myK)
+      - myRadius*cos(myPhi + intervalle_lower*NGON2D_2_PI/myK),
+        myRadius*sin(myPhi + intervalle_upper*NGON2D_2_PI/myK)
+      - myRadius*sin(myPhi + intervalle_lower*NGON2D_2_PI/myK)
+  );
   
   //normalize
-  double norm = s2.norm();
-  s2[0] /= norm;
-  s2[1] /= norm;
- 
-  return s2;
+  return s / s.norm();
 }
 
 /**
@@ -171,8 +158,7 @@ inline
 typename DGtal::NGon2D<T>::RealVector
 DGtal::NGon2D<T>::xpp( const double /*t*/ ) const
 {
-  RealVector c(0,0);
-  return c;
+  return RealVector(0.,0.);
 }
 
 
@@ -188,8 +174,10 @@ inline
 void
 DGtal::NGon2D<T>::selfDisplay ( std::ostream & out ) const
 {
-  out << "[NGon2D] center= "<<myCenter<<" radius="<<myRadius<<" number of sides="<<myK
-      << " phase-shift="<<myPhi;
+  out << "[NGon2D] center= " << myCenter
+      << " radius=" << myRadius
+      << " number of sides=" << myK
+      << " phase-shift=" << myPhi;
 }
 
 /**

--- a/src/DGtal/shapes/parametric/NGon2D.ih
+++ b/src/DGtal/shapes/parametric/NGon2D.ih
@@ -40,15 +40,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // ----------------------- Standard services ------------------------------
 
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::NGon2D<T>::~NGon2D()
-{
-}
-
 template <typename T>
 inline
 DGtal::NGon2D<T>::NGon2D(const double x0, const double y0, 
@@ -60,7 +51,7 @@ DGtal::NGon2D<T>::NGon2D(const double x0, const double y0,
 
 template <typename T>
 inline
-DGtal::NGon2D<T>::NGon2D(const RealPoint2D &aPoint,
+DGtal::NGon2D<T>::NGon2D(const RealPoint &aPoint,
        const double radius, const unsigned int k,
        const double phi):
   myCenter(aPoint), myRadius(radius) , myK(k), myPhi(phi)
@@ -68,13 +59,10 @@ DGtal::NGon2D<T>::NGon2D(const RealPoint2D &aPoint,
 
 template <typename T>
 inline
-DGtal::NGon2D<T>::NGon2D(const Point &aPoint, 
-       const double radius, const unsigned int k,
-       const double phi):
-  myRadius(radius), myK(k), myPhi(phi)
-{
-  myCenter = aPoint;
-}
+DGtal::NGon2D<T>::NGon2D(const NGon2D& other):
+  myCenter(other.myCenter), myRadius(other.myRadius),
+  myK(other.myK), myPhi(other.myPhi)
+{}
 
 /////////////////////////////////////////////////////////////////////////////
 // ------------- Implementation of 'StarShaped' services ------------------
@@ -88,9 +76,9 @@ DGtal::NGon2D<T>::NGon2D(const Point &aPoint,
 template <typename T>
 inline
 double
-DGtal::NGon2D<T>::parameter( const RealPoint2D & pp ) const
+DGtal::NGon2D<T>::parameter( const RealPoint & pp ) const
 {
-  RealPoint2D p( pp );
+  RealPoint p( pp );
   p -= myCenter;
 
   double angle = atan2( p[1], p[0] );
@@ -107,7 +95,7 @@ DGtal::NGon2D<T>::parameter( const RealPoint2D & pp ) const
  */
 template <typename T>
 inline
-typename DGtal::NGon2D<T>::RealPoint2D 
+typename DGtal::NGon2D<T>::RealPoint 
 DGtal::NGon2D<T>::x( double t ) const
 {
   double angle = t - myPhi;
@@ -118,11 +106,11 @@ DGtal::NGon2D<T>::x( double t ) const
   unsigned int intervale_lower = static_cast<unsigned int>( floor( ( angle ) * myK / (2.0 * M_PI ) ) );
   unsigned int intervale_upper = intervale_lower == ( myK - 1 ) ? 0 : intervale_lower + 1;
   double dist = myRadius * cos( M_PI / myK );
-  RealPoint2D s1 ( myRadius * cos( myPhi + intervale_lower * 2.0 * M_PI / myK ),
+  RealPoint s1 ( myRadius * cos( myPhi + intervale_lower * 2.0 * M_PI / myK ),
                    myRadius * sin( myPhi + intervale_lower * 2.0 * M_PI / myK ));
-  RealPoint2D s2 ( myRadius * cos( myPhi + intervale_upper * 2.0 * M_PI / myK ),
+  RealPoint s2 ( myRadius * cos( myPhi + intervale_upper * 2.0 * M_PI / myK ),
                    myRadius * sin( myPhi + intervale_upper * 2.0 * M_PI / myK ));
-  RealPoint2D s3 ( s2[0] - s1[0],
+  RealPoint s3 ( s2[0] - s1[0],
                    s2[1] - s1[1]);
 
   //double line_angle = atan2f( (float)s3[ 1 ], (float)s3[ 0 ]);
@@ -131,7 +119,7 @@ DGtal::NGon2D<T>::x( double t ) const
 
   double rho = dist / ( cos(t - line_angle - 0.5 * M_PI) );
 
-  RealPoint2D c( - rho*cos(t), - rho*sin(t) );
+  RealPoint c( - rho*cos(t), - rho*sin(t) );
 
   c += myCenter;
 
@@ -147,7 +135,7 @@ DGtal::NGon2D<T>::x( double t ) const
  */
 template <typename T>
 inline
-typename DGtal::NGon2D<T>::RealVector2D 
+typename DGtal::NGon2D<T>::RealVector 
 DGtal::NGon2D<T>::xp( const double t ) const
 {
   // seek the vertices between the point, then compute the vector from one vertex to the next one.
@@ -159,9 +147,9 @@ DGtal::NGon2D<T>::xp( const double t ) const
   unsigned int intervalle_lower = static_cast<unsigned int>( floor( angle * myK / (2.0 * M_PI ) ) );
   unsigned int intervalle_upper = intervalle_lower == ( myK -1 ) ? 0 : intervalle_lower+1;
   //float dist = myRadius*sin ( M_PI / myK );
-  RealPoint2D s1 ( myRadius*cos(myPhi + intervalle_lower*2.0*M_PI/myK),
+  RealPoint s1 ( myRadius*cos(myPhi + intervalle_lower*2.0*M_PI/myK),
        myRadius*sin(myPhi + intervalle_lower*2.0*M_PI/myK) );
-  RealPoint2D s2 ( myRadius*cos(myPhi + intervalle_upper*2.0*M_PI/myK),
+  RealPoint s2 ( myRadius*cos(myPhi + intervalle_upper*2.0*M_PI/myK),
        myRadius*sin(myPhi + intervalle_upper*2.0*M_PI/myK) );
   s2 -= s1;
   
@@ -180,10 +168,10 @@ DGtal::NGon2D<T>::xp( const double t ) const
  */
 template <typename T>
 inline
-typename DGtal::NGon2D<T>::RealVector2D
+typename DGtal::NGon2D<T>::RealVector
 DGtal::NGon2D<T>::xpp( const double /*t*/ ) const
 {
-  RealVector2D c(0,0);
+  RealVector c(0,0);
   return c;
 }
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -103,7 +103,7 @@ namespace DGtal
      */
     virtual ~StarShaped2D() = default;
 
-    // ------------------------- Implemented services -------------------------
+  // ------------------------- Implemented services -------------------------
   public:
     /**
      * @return a point p such that 'isInside(p)' returns 'true'.
@@ -113,7 +113,7 @@ namespace DGtal
       return center();
     }
 
-    // ------------------------- Abstract services ----------------------------
+  // ------------------------- Abstract services ----------------------------
   public:
 
     /**
@@ -172,7 +172,7 @@ namespace DGtal
     virtual RealPoint xpp( const double t ) const = 0;
 
 
-    // ------------------------- star-shaped services -------------------------
+  // ------------------------- star-shaped services -------------------------
   public:
 
     /**
@@ -190,7 +190,7 @@ namespace DGtal
      * @return the vector (x'(t),y'(t)) made unitary which is the unit
      * tangent to the shape boundary.
      */
-    RealPoint tangent( double t ) const;
+    RealPoint tangent( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -198,7 +198,7 @@ namespace DGtal
      * @return the vector (x''(t),y''(t)) made unitary which is the unit
      * normal to the shape boundary looking inside the shape.
      */
-    RealPoint normal( double t ) const;
+    RealPoint normal( const double t ) const;
 
     /**
      * @param t any angle between 0 and 2*Pi.
@@ -207,7 +207,7 @@ namespace DGtal
      * is convex, negative is concave when shape is to the left and
      * the shape boundary is followed counterclockwise.
      */
-    double curvature( double t ) const;
+    double curvature( const double t ) const;
 
     /**
      * @param t1 any angle between 0 and 2*Pi.
@@ -216,7 +216,7 @@ namespace DGtal
      *
      * @return the estimated arclength.
      */
-    double arclength( double t1, double t2, unsigned int nb ) const;
+    double arclength( const double t1, double t2, const unsigned int nb ) const;
 
     /**
      * Return a point on the segment [inner;outer] that is at most \f$\epsilon\f$ from the shape in \f$L_2\f$ norm.
@@ -241,7 +241,7 @@ namespace DGtal
      * */
     RealPoint closestPointWithWitnesses( const RealPoint& p, const RealPoint& left, const RealPoint& right, const int step) const;
 
-    // ----------------------- Interface --------------------------------------
+  // ----------------------- Interface --------------------------------------
   public:
 
     /**
@@ -255,6 +255,19 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
+
+  // ------------------------- Hidden services ------------------------------
+  private:
+
+    /**
+     * Equality test using relative tolerance.
+     */
+    template <typename T>
+    inline
+    bool isAlmostEqual( T x, T y ) const
+    {
+      return std::abs(x - y) <= std::numeric_limits<T>::epsilon();
+    }
 
   }; // end of class StarShaped2D
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.h
+++ b/src/DGtal/shapes/parametric/StarShaped2D.h
@@ -76,19 +76,32 @@ namespace DGtal
 
   public:
     typedef TSpace Space;
-    typedef typename Space::Point Point;
     typedef typename Space::RealPoint RealPoint;
 
    /**
      * Constructor.
      */
-    StarShaped2D()
-    {}
+    StarShaped2D() = default;
+
+    /**
+     * Copy constructor.
+     * @param other the object to clone.
+     * Forbidden by default.
+     */
+    StarShaped2D ( const StarShaped2D & other ) = delete;
+
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    StarShaped2D & operator= ( const StarShaped2D & other ) = delete;
 
     /**
      * Destructor.
      */
-    ~StarShaped2D();
+    virtual ~StarShaped2D() = default;
 
     // ------------------------- Implemented services -------------------------
   public:
@@ -242,40 +255,6 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-    // ------------------------- Protected Datas ------------------------------
-  private:
-    // ------------------------- Private Datas --------------------------------
-  private:
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    //StarShaped2D();
-
-  private:
-
-    /**
-     * Copy constructor.
-     * @param other the object to clone.
-     * Forbidden by default.
-     */
-    //StarShaped2D ( const StarShaped2D & other );
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    StarShaped2D & operator= ( const StarShaped2D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class StarShaped2D
 

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -51,23 +51,14 @@
 template<typename TSpace>
 inline
 DGtal::Orientation
-DGtal::StarShaped2D<TSpace>::orientation( const RealPoint & p ) const
+DGtal::StarShaped2D<TSpace>::orientation( const RealPoint& p ) const
 {
-  RealPoint x_rel = x( parameter( p ));
-  x_rel -= center();
-  RealPoint p_rel( p );
-  p_rel -= center();
+  RealPoint x_rel( x(parameter(p)) - center() );
+  RealPoint p_rel( p - center() );
 
-  double d_x = x_rel.norm();
-  double d_p = p_rel.norm();
-  double diff = d_p - d_x;
+  const double diff = p_rel.norm() - x_rel.norm();
 
-  if ( diff > 0.0 )
-      return OUTSIDE;
-  else if ( diff < 0.0 )
-      return INSIDE;
-  else
-      return ON;
+  return isAlmostEqual(diff,0.) ? ON : (diff > 0. ? OUTSIDE : INSIDE);
 }
 
 
@@ -80,12 +71,10 @@ DGtal::StarShaped2D<TSpace>::orientation( const RealPoint & p ) const
 template<typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::tangent( double t ) const
+DGtal::StarShaped2D<TSpace>::tangent( const double t ) const
 {
-  RealPoint tgt( xp( t ) );
-  double norm = tgt.norm();
-  tgt /= norm;
-  return tgt;
+  const RealPoint tgt( xp(t) );
+  return tgt / tgt.norm();
 }
 
 
@@ -98,10 +87,10 @@ b */
 template<typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::normal( double t ) const
+DGtal::StarShaped2D<TSpace>::normal( const double t ) const
 {
-  RealPoint tgt( tangent( t ) );
-  return RealPoint( -tgt[1], tgt[0]);
+  RealPoint tgt( tangent(t) );
+  return RealPoint( -tgt[1], tgt[0] );
 }
 
 
@@ -115,13 +104,12 @@ DGtal::StarShaped2D<TSpace>::normal( double t ) const
 template<typename TSpace>
 inline
 double 
-DGtal::StarShaped2D<TSpace>::curvature( double t ) const
+DGtal::StarShaped2D<TSpace>::curvature( const double t ) const
 {
-  RealPoint tgt( xp( t ) );
-  RealPoint dt( xpp( t ) );
-  double norm = tgt.norm();
-  double curv = ( dt[0] * tgt[1] - dt[1] * tgt[0] ) / ( norm * norm * norm );
-  return - curv;
+  RealPoint tgt( xp(t) );
+  RealPoint dt( xpp(t) );
+  const double norm = tgt.norm();
+  return - ( dt[0] * tgt[1] - dt[1] * tgt[0] ) / ( norm * norm * norm );
 }
   
 
@@ -134,21 +122,23 @@ DGtal::StarShaped2D<TSpace>::curvature( double t ) const
 template<typename TSpace>
 inline
 double
-DGtal::StarShaped2D<TSpace>::arclength( double t1, double t2, unsigned int nb ) const
+DGtal::StarShaped2D<TSpace>::arclength( const double t1, double t2, const unsigned int nb ) const
 {
   while ( t2 < t1 ) t2 += 2.0*M_PI;
 
-  RealPoint x0( x( t1 ) );
-  double l = 0.0;
+  RealPoint x0( x(t1) );
+  double l = 0.;
   // JOL 2008/08/28
   for ( unsigned int i = 1; i <= nb; ++i )
-    {
-      double t = ( ( t2 - t1 ) * i ) / nb;
-      RealPoint x1( x( t1 + t ) );
-      l += sqrt( ( x1[0] - x0[0] )*( x1[0] - x0[0] )
-         + ( x1[1] - x0[1] )*( x1[1] - x0[1] ) );
-      x0 = x1;
-    }
+  {
+    const double t = ((t2 - t1) * i) / nb;
+    const RealPoint x1( x(t1 + t) );
+    l += sqrt(
+        (x1[0] - x0[0]) * (x1[0] - x0[0])
+      + (x1[1] - x0[1]) * (x1[1] - x0[1])
+    );
+    x0 = x1;
+  }
   return l;
 }
 
@@ -164,16 +154,24 @@ DGtal::StarShaped2D<TSpace>::arclength( double t1, double t2, unsigned int nb ) 
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::findIntersection( const typename DGtal::StarShaped2D<TSpace>::RealPoint& inner, 
-                                               const typename DGtal::StarShaped2D<TSpace>::RealPoint& outer, 
-                                               double epsilon ) const
+DGtal::StarShaped2D<TSpace>::findIntersection( const RealPoint& inner, 
+                                               const RealPoint& outer, 
+                                               const double epsilon ) const
 {
-  typename DGtal::StarShaped2D<TSpace>::RealPoint mid = RealPoint(0.5 * (inner + outer));
+  const typename DGtal::StarShaped2D<TSpace>::RealPoint mid = RealPoint(0.5 * (inner + outer));
 
-  if((inner - outer).norm() < epsilon) return mid; // We found a point that is at distance epsilon from the shape
-  else if(orientation(mid) == Orientation::INSIDE)  return findIntersection( mid, outer, epsilon ); // The point lies inside the shape
-  else if(orientation(mid) == Orientation::ON)      return mid; // The point is right onto the shape
-  else if(orientation(mid) == Orientation::OUTSIDE) return findIntersection( inner, mid, epsilon ); // The point lies outside the shape
+  // We found a point that is at distance epsilon from the shape
+  if((inner - outer).norm() < epsilon)
+    return mid;
+  // The point lies inside the shape
+  else if(orientation(mid) == Orientation::INSIDE)
+    return findIntersection( mid, outer, epsilon );
+  // The point is right onto the shape
+  else if(orientation(mid) == Orientation::ON)
+    return mid;
+  // The point lies outside the shape
+  else if(orientation(mid) == Orientation::OUTSIDE)
+    return findIntersection( inner, mid, epsilon );
 
   ASSERT( false ); //this should not be reached
   return RealPoint(0., 0.);
@@ -192,31 +190,32 @@ DGtal::StarShaped2D<TSpace>::findIntersection( const typename DGtal::StarShaped2
 template <typename TSpace>
 inline
 typename DGtal::StarShaped2D<TSpace>::RealPoint
-DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::StarShaped2D<TSpace>::RealPoint& p, const typename DGtal::StarShaped2D<TSpace>::RealPoint& left, 
-    const typename DGtal::StarShaped2D<TSpace>::RealPoint& right, const int step) const
+DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const RealPoint& p,
+    const RealPoint& left, const RealPoint& right, const int step ) const
 {
-  double left_angl = parameter(left);
-  double right_angl = parameter(right);
+  if ( step == 0 )
+    return RealPoint(0., 0.);
 
-  std::vector<typename DGtal::StarShaped2D<TSpace>::RealPoint> points;
+  const double left_angl = parameter(left);
+  const double right_angl = parameter(right);
 
-  for(int i = 0; i < step; i++)
+  std::vector<RealPoint> points;
+
+  for( int i = 0; i < step; i++ )
   {
     double arc = fabs(right_angl - left_angl);
     if(arc > M_PI) arc = 2 * M_PI - arc;
     const double current_angl = fmod(left_angl + arc / step * i, 2 * M_PI);
-
-    RealPoint temp = x(current_angl);
-    points.push_back(temp);
+    points.push_back(x(current_angl));
   }
 
-  double p_norm = 1e15;
-  RealPoint p_return(0., 0.);
+  RealPoint p_return(points[0]);
+  double p_norm = (p_return - p).norm();
 
-  for(unsigned int i = 0; i < points.size(); i++)
+  for( unsigned int i = 1; i < points.size(); i++ )
   {
     const double p_norm_current = (points[i] - p).norm();
-    if(p_norm_current < p_norm)
+    if ( p_norm_current < p_norm )
     {
       p_return = points[i];
       p_norm = p_norm_current;

--- a/src/DGtal/shapes/parametric/StarShaped2D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped2D.ih
@@ -53,21 +53,21 @@ inline
 DGtal::Orientation
 DGtal::StarShaped2D<TSpace>::orientation( const RealPoint & p ) const
 {
-    RealPoint x_rel = x( parameter( p ));
-    x_rel -= center();
-    RealPoint p_rel( p );
-    p_rel -= center();
+  RealPoint x_rel = x( parameter( p ));
+  x_rel -= center();
+  RealPoint p_rel( p );
+  p_rel -= center();
 
-    double d_x = x_rel.norm();
-    double d_p = p_rel.norm();
-    double diff = d_p - d_x;
+  double d_x = x_rel.norm();
+  double d_p = p_rel.norm();
+  double diff = d_p - d_x;
 
-    if ( diff > 0.0 )
-        return OUTSIDE;
-    else if ( diff < 0.0 )
-        return INSIDE;
-    else
-        return ON;
+  if ( diff > 0.0 )
+      return OUTSIDE;
+  else if ( diff < 0.0 )
+      return INSIDE;
+  else
+      return ON;
 }
 
 
@@ -211,7 +211,7 @@ DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::St
   }
 
   double p_norm = 1e15;
-  RealPoint p_return = Point(0., 0.);
+  RealPoint p_return(0., 0.);
 
   for(unsigned int i = 0; i < points.size(); i++)
   {
@@ -224,15 +224,6 @@ DGtal::StarShaped2D<TSpace>::closestPointWithWitnesses( const typename DGtal::St
   }
 
   return p_return;
-}
-
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::StarShaped2D<T>::~StarShaped2D()
-{
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/DGtal/shapes/parametric/StarShaped3D.h
+++ b/src/DGtal/shapes/parametric/StarShaped3D.h
@@ -79,13 +79,20 @@ namespace DGtal
     /**
      * Constructor.
      */
-    StarShaped3D()
-    {}
+    StarShaped3D() = default;
+
+    /**
+     * Assignment.
+     * @param other the object to copy.
+     * @return a reference on 'this'.
+     * Forbidden by default.
+     */
+    StarShaped3D & operator= ( const StarShaped3D & other ) = delete;
 
     /**
      * Destructor.
      */
-    ~StarShaped3D();
+    virtual ~StarShaped3D() = default;
 
     // ------------------------- Implemented services -------------------------
   public:
@@ -146,7 +153,7 @@ namespace DGtal
      *
      * @return the vector (gradf(M).
      */
-    virtual RealPoint gradient( const AngularCoordinates t) const = 0;
+    virtual RealPoint gradient( const AngularCoordinates t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -154,9 +161,7 @@ namespace DGtal
      *
      * @return the vector (rt(M)) wich is the partial derivative with respect to Teta.
      */
-    virtual RealPoint rt( const AngularCoordinates t) const = 0;
-
-
+    virtual RealPoint rt( const AngularCoordinates t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -164,8 +169,7 @@ namespace DGtal
      *
      * @return the vector (rp(M)) wich is the first partial derivative with respect to Phi.
      */
-    virtual RealPoint rp( const AngularCoordinates t) const = 0;
-
+    virtual RealPoint rp( const AngularCoordinates t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -174,9 +178,7 @@ namespace DGtal
      * @return the vector (rtt(M)) wich is second the partial
      * derivative with respect to Teta(twice).
      */
-    virtual RealPoint rtt( const AngularCoordinates t) const = 0;
-
-
+    virtual RealPoint rtt( const AngularCoordinates t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -185,7 +187,7 @@ namespace DGtal
      * @return the vector (rpp(M)) wich is second the partial
      * derivative with respect to Phi.
      */
-    virtual RealPoint rpp( const AngularCoordinates t) const = 0;
+    virtual RealPoint rpp( const AngularCoordinates t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -194,10 +196,7 @@ namespace DGtal
      * @return the vector (rpp(M)) wich is second the partial
      * derivative with respect to Teta then Phi.
      */
-    virtual RealPoint rtp( const AngularCoordinates t) const = 0;
-
-
-
+    virtual RealPoint rtp( const AngularCoordinates t ) const = 0;
 
     // ------------------------- star-shaped services -------------------------
   public:
@@ -209,8 +208,7 @@ namespace DGtal
      *
      * @return the orientation of the point (<0 means inside, ...)
      */
-    virtual Orientation orientation( const RealPoint &p) const;
-
+    virtual Orientation orientation( const RealPoint &p ) const;
 
     /*
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -222,9 +220,6 @@ namespace DGtal
     /*
       virtual RealPoint tangent( AngularCoordinates t ) const;
     */
-
-
-
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -243,7 +238,7 @@ namespace DGtal
      * is convex, negative is concave when shape is to the left and
      * the shape boundary is followed counterclockwise.
      */
-    virtual double gaussianCurvature( AngularCoordinates t) const;
+    virtual double gaussianCurvature( AngularCoordinates t ) const;
 
 
     /**
@@ -254,7 +249,7 @@ namespace DGtal
      * is convex, negative is concave when shape is to the left and
      * the shape boundary is followed counterclockwise.
      */
-    virtual double meanCurvature( AngularCoordinates t) const;
+    virtual double meanCurvature( AngularCoordinates t ) const;
 
 
     /**
@@ -295,40 +290,13 @@ namespace DGtal
      * Writes/Displays the object on an output stream.
      * @param out the output stream where the object is written.
      */
-    void selfDisplay ( std::ostream & out ) const;
+    void selfDisplay( std::ostream & out ) const;
 
     /**
      * Checks the validity/consistency of the object.
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
-
-    // ------------------------- Protected Datas ------------------------------
-  private:
-    // ------------------------- Private Datas --------------------------------
-  private:
-
-    // ------------------------- Hidden services ------------------------------
-  protected:
-
-    /**
-     * Constructor.
-     * Forbidden by default (protected to avoid g++ warnings).
-     */
-    //StarShaped3D();
-
-  private:
-
-    /**
-     * Assignment.
-     * @param other the object to copy.
-     * @return a reference on 'this'.
-     * Forbidden by default.
-     */
-    StarShaped3D & operator= ( const StarShaped3D & other );
-
-    // ------------------------- Internals ------------------------------------
-  private:
 
   }; // end of class StarShaped3D
 

--- a/src/DGtal/shapes/parametric/StarShaped3D.h
+++ b/src/DGtal/shapes/parametric/StarShaped3D.h
@@ -94,7 +94,7 @@ namespace DGtal
      */
     virtual ~StarShaped3D() = default;
 
-    // ------------------------- Implemented services -------------------------
+  // ------------------------- Implemented services -------------------------
   public:
     /**
      * @return a point p such that 'isInside(p)' returns 'true'.
@@ -104,7 +104,7 @@ namespace DGtal
       return center();
     }
 
-    // ------------------------- Abstract services ----------------------------
+  // ------------------------- Abstract services ----------------------------
   public:
 
     /**
@@ -136,7 +136,7 @@ namespace DGtal
      * @return the angles parameters (Teta, Phi) corresponding to
      * this point for the shape.
      */
-    virtual AngularCoordinates parameter( const RealPoint & p ) const = 0;
+    virtual AngularCoordinates parameter( const RealPoint& p ) const = 0;
 
     /**
      * @param t is a couple of Theta && Phi wich are 2 angles
@@ -145,7 +145,7 @@ namespace DGtal
      * @return the vector (x(t),y(t),z(t)) which is the position on the
      * shape boundary.
      */
-    virtual RealPoint x( const AngularCoordinates t ) const = 0;
+    virtual RealPoint x( const AngularCoordinates& t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -153,7 +153,7 @@ namespace DGtal
      *
      * @return the vector (gradf(M).
      */
-    virtual RealPoint gradient( const AngularCoordinates t ) const = 0;
+    virtual RealPoint gradient( const AngularCoordinates& t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -161,7 +161,7 @@ namespace DGtal
      *
      * @return the vector (rt(M)) wich is the partial derivative with respect to Teta.
      */
-    virtual RealPoint rt( const AngularCoordinates t ) const = 0;
+    virtual RealPoint rt( const AngularCoordinates& t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -169,7 +169,7 @@ namespace DGtal
      *
      * @return the vector (rp(M)) wich is the first partial derivative with respect to Phi.
      */
-    virtual RealPoint rp( const AngularCoordinates t ) const = 0;
+    virtual RealPoint rp( const AngularCoordinates& t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -178,7 +178,7 @@ namespace DGtal
      * @return the vector (rtt(M)) wich is second the partial
      * derivative with respect to Teta(twice).
      */
-    virtual RealPoint rtt( const AngularCoordinates t ) const = 0;
+    virtual RealPoint rtt( const AngularCoordinates& t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -187,7 +187,7 @@ namespace DGtal
      * @return the vector (rpp(M)) wich is second the partial
      * derivative with respect to Phi.
      */
-    virtual RealPoint rpp( const AngularCoordinates t ) const = 0;
+    virtual RealPoint rpp( const AngularCoordinates& t ) const = 0;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -196,9 +196,9 @@ namespace DGtal
      * @return the vector (rpp(M)) wich is second the partial
      * derivative with respect to Teta then Phi.
      */
-    virtual RealPoint rtp( const AngularCoordinates t ) const = 0;
+    virtual RealPoint rtp( const AngularCoordinates& t ) const = 0;
 
-    // ------------------------- star-shaped services -------------------------
+  // ------------------------- star-shaped services -------------------------
   public:
 
     /**
@@ -208,7 +208,7 @@ namespace DGtal
      *
      * @return the orientation of the point (<0 means inside, ...)
      */
-    virtual Orientation orientation( const RealPoint &p ) const;
+    virtual Orientation orientation( const RealPoint& p ) const;
 
     /*
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -228,7 +228,7 @@ namespace DGtal
      * @return the vector normal made unitary which is the unit
      * normal to the shape boundary looking inside the shape.
      */
-    virtual RealPoint normal( AngularCoordinates t ) const;
+    virtual RealPoint normal( const AngularCoordinates& t ) const;
 
     /**
      * @param t is a couple of Teta && Phi wich are 2 angles
@@ -238,7 +238,7 @@ namespace DGtal
      * is convex, negative is concave when shape is to the left and
      * the shape boundary is followed counterclockwise.
      */
-    virtual double gaussianCurvature( AngularCoordinates t ) const;
+    virtual double gaussianCurvature( const AngularCoordinates& t ) const;
 
 
     /**
@@ -249,7 +249,7 @@ namespace DGtal
      * is convex, negative is concave when shape is to the left and
      * the shape boundary is followed counterclockwise.
      */
-    virtual double meanCurvature( AngularCoordinates t ) const;
+    virtual double meanCurvature( const AngularCoordinates& t ) const;
 
 
     /**
@@ -262,7 +262,7 @@ namespace DGtal
      * between x(Teta1,Phi1) and x(Teta2,Phi2).
      * @return the estimated arclength.
      */
-    virtual double arclength( AngularCoordinates t1,
+    virtual double arclength( const AngularCoordinates& t1,
                               AngularCoordinates t2,
                               unsigned int nb ) const;
 
@@ -277,13 +277,13 @@ namespace DGtal
      * between x(Teta1,Phi1) and x(Teta2,Phi2).
      * @return the estimated surfacelength.
      */
-    virtual double surfacelength( AngularCoordinates t1,
+    virtual double surfacelength( const AngularCoordinates& t1,
                                   AngularCoordinates t2,
                                   unsigned int nb ) const;
 
 
 
-    // ----------------------- Interface --------------------------------------
+  // ----------------------- Interface --------------------------------------
   public:
 
     /**
@@ -297,6 +297,19 @@ namespace DGtal
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
+
+  // ------------------------- Hidden services ------------------------------
+  private:
+
+    /**
+     * Equality test using relative tolerance.
+     */
+    template <typename T>
+    inline
+    bool isAlmostEqual( T x, T y ) const
+    {
+      return std::abs(x - y) <= std::numeric_limits<T>::epsilon();
+    }
 
   }; // end of class StarShaped3D
 

--- a/src/DGtal/shapes/parametric/StarShaped3D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped3D.ih
@@ -53,23 +53,13 @@ typedef std::pair<double,double> AngularCoordinates;
 template<typename TSpace>
 inline
 DGtal::Orientation
-DGtal::StarShaped3D<TSpace>::orientation( const RealPoint & p ) const
+DGtal::StarShaped3D<TSpace>::orientation( const RealPoint& p ) const
 {
-    RealPoint x_rel = x( parameter( p ));
-    x_rel -= center();
-    RealPoint p_rel( p );
-    p_rel -= center();
+  const RealPoint x_rel( x(parameter(p)) - center() );
+  const RealPoint p_rel( p - center() );
+  const double diff = p_rel.norm() - x_rel.norm();
 
-    double d_x = x_rel.norm();
-    double d_p = p_rel.norm();
-    double diff = d_p - d_x;
-
-    if ( diff > 0.0 )
-        return OUTSIDE;
-    else if ( diff < 0.0 )
-        return INSIDE;
-    else
-        return ON;
+  return isAlmostEqual(diff,0.) ? ON : (diff > 0. ? OUTSIDE : INSIDE);
 }
 
 
@@ -82,11 +72,10 @@ DGtal::StarShaped3D<TSpace>::orientation( const RealPoint & p ) const
 template<typename TSpace>
 inline
 typename DGtal::StarShaped3D<TSpace>::RealPoint
-DGtal::StarShaped3D<TSpace>::normal( AngularCoordinates t ) const
+DGtal::StarShaped3D<TSpace>::normal( const AngularCoordinates& t ) const
 {
-  RealPoint aNormal( gradient(t));
-  double norm = sqrt(aNormal[0]*aNormal[0] + aNormal[1]*aNormal[1] +aNormal[2]*aNormal[2]);
-  return (RealPoint(aNormal[0]/norm,aNormal[1]/norm,aNormal[2]/norm));
+  const RealPoint aNormal( gradient(t) );
+  return aNormal / aNormal.norm();
 }
 
 
@@ -100,29 +89,29 @@ DGtal::StarShaped3D<TSpace>::normal( AngularCoordinates t ) const
 template<typename TSpace>
 inline
 double
-DGtal::StarShaped3D<TSpace>::meanCurvature( AngularCoordinates t) const
+DGtal::StarShaped3D<TSpace>::meanCurvature( const AngularCoordinates& t ) const
 {
-  RealPoint art = rt(t);
-  RealPoint arp = rp(t);
-  RealPoint artt = rtt(t);
-  RealPoint arpp = rpp(t);
-  RealPoint artp = rtp(t);
+  const RealPoint art = rt(t);
+  const RealPoint arp = rp(t);
+  const RealPoint artt = rtt(t);
+  const RealPoint arpp = rpp(t);
+  const RealPoint artp = rtp(t);
 
-  RealPoint n(art[1]*arp[2]-art[2]*arp[1],art[2]*arp[0]-art[0]*arp[2],art[0]*arp[1]-art[1]*arp[0]);
-  double norme= sqrt(n[0]*n[0]+n[1]*n[1]+n[2]*n[2]);
-  n[0]=n[0]/norme;
-  n[1]=n[1]/norme;
-  n[2]=n[2]/norme;
-  double E = art[0] * art[0]+ art[1] * art[1]+ art[2] * art[2];
-  double F= art[0] * arp[0]+ art[1] * arp[1]+ art[2] * arp[2];
-  double G = arp[0] * arp[0]+ arp[1] * arp[1]+ arp[2] * arp[2];
-  double L = artt[0] * n[0]+ artt[1] * n[1]+ artt[2] * n[2];
-  double M = artp[0] * n[0]+ artp[1] * n[1]+ artp[2] * n[2];
-  double N = arpp[0] * n[0]+ arpp[1] * n[1]+ arpp[2] * n[2];
-  double H = (E*N-2.0f*F*M+G*L)/(2.0f*(E*G-F*F));
-    
+  RealPoint n(
+    art[1] * arp[2] - art[2] * arp[1],
+    art[2] * arp[0] - art[0] * arp[2],
+    art[0] * arp[1] - art[1] * arp[0]
+  );
+  n /= n.norm();
 
-  return H;
+  const double E = art[0] * art[0]+ art[1] * art[1]+ art[2] * art[2];
+  const double F = art[0] * arp[0]+ art[1] * arp[1]+ art[2] * arp[2];
+  const double G = arp[0] * arp[0]+ arp[1] * arp[1]+ arp[2] * arp[2];
+  const double L = artt[0] * n[0]+ artt[1] * n[1]+ artt[2] * n[2];
+  const double M = artp[0] * n[0]+ artp[1] * n[1]+ artp[2] * n[2];
+  const double N = arpp[0] * n[0]+ arpp[1] * n[1]+ arpp[2] * n[2];
+
+  return ( E*N - 2.*F*M + G*L ) / ( 2.* (E*G - F*F) );
 }
   
 
@@ -138,30 +127,30 @@ DGtal::StarShaped3D<TSpace>::meanCurvature( AngularCoordinates t) const
 template<typename TSpace>
 inline
 double
-DGtal::StarShaped3D<TSpace>::gaussianCurvature( AngularCoordinates t ) const
+DGtal::StarShaped3D<TSpace>::gaussianCurvature( const AngularCoordinates& t ) const
 {
-  RealPoint art = rt(t);
-  RealPoint arp = rp(t);
-  RealPoint artt = rtt(t);
-  RealPoint arpp = rpp(t);
-  RealPoint artp = rtp(t);
+  const RealPoint art = rt(t);
+  const RealPoint arp = rp(t);
+  const RealPoint artt = rtt(t);
+  const RealPoint arpp = rpp(t);
+  const RealPoint artp = rtp(t);
 
 
-  RealPoint n(art[1]*arp[2]-art[2]*arp[1],art[2]*arp[0]-art[0]*arp[2],art[0]*arp[1]-art[1]*arp[0]);
-  double norme= sqrt(n[0]*n[0]+n[1]*n[1]+n[2]*n[2]);
-  n[0]=n[0]/norme;
-  n[1]=n[1]/norme;
-  n[2]=n[2]/norme;
-  double E = art[0] * art[0]+ art[1] * art[1]+ art[2] * art[2];
-  double F= art[0] * arp[0]+ art[1] * arp[1]+ art[2] * arp[2];
-  double G = arp[0] * arp[0]+ arp[1] * arp[1]+ arp[2] * arp[2];
-  double L = artt[0] * n[0]+ artt[1] * n[1]+ artt[2] * n[2];
-  double M = artp[0] * n[0]+ artp[1] * n[1]+ artp[2] * n[2];
-  double N = arpp[0] * n[0]+ arpp[1] * n[1]+ arpp[2] * n[2];
+  RealPoint n(
+    art[1] * arp[2] - art[2] * arp[1],
+    art[2] * arp[0] - art[0] * arp[2],
+    art[0] * arp[1] - art[1] * arp[0]
+  );
+  n /= n.norm();
 
-  double K = (L*N-M*M)/(E*G-F*F);
+  const double E = art[0] * art[0]+ art[1] * art[1]+ art[2] * art[2];
+  const double F= art[0] * arp[0]+ art[1] * arp[1]+ art[2] * arp[2];
+  const double G = arp[0] * arp[0]+ arp[1] * arp[1]+ arp[2] * arp[2];
+  const double L = artt[0] * n[0]+ artt[1] * n[1]+ artt[2] * n[2];
+  const double M = artp[0] * n[0]+ artp[1] * n[1]+ artp[2] * n[2];
+  const double N = arpp[0] * n[0]+ arpp[1] * n[1]+ arpp[2] * n[2];
 
-  return K;
+  return ( L*N - M*M ) / ( E*G - F*F );
 }
   
 
@@ -175,26 +164,26 @@ DGtal::StarShaped3D<TSpace>::gaussianCurvature( AngularCoordinates t ) const
 template<typename TSpace>
 inline
 double
-DGtal::StarShaped3D<TSpace>::arclength( AngularCoordinates t1, AngularCoordinates t2, unsigned int nb ) const
+DGtal::StarShaped3D<TSpace>::arclength( const AngularCoordinates& t1, AngularCoordinates t2, unsigned int nb ) const
 {
   while ( t2.first < t1.first ) t2.first += 2.0*M_PI;
   while ( t2.second < t1.second ) t2.second += 2.0*M_PI;
 
-  RealPoint x0( x( t1 ) );
-  double l = 0.0;
+  RealPoint x0( x(t1) );
+  double l = 0.;
+
   for ( unsigned int i = 1; i <= nb; ++i )
-    {
-      AngularCoordinates t;
-      t.first = ( ( t2.first - t1.first ) * i ) / nb;
-      t.second = ( ( t2.second - t1.second ) * i ) / nb;
-      AngularCoordinates h;
-      h.first=t1.first + t.first;
-      h.second=t1.second + t.second;
-      RealPoint x1( x( h ) );
-      l += sqrt( ( x1[0] - x0[0] )*( x1[0] - x0[0] )
-                 + ( x1[1] - x0[1] )*( x1[1] - x0[1] ) + ( x1[2] - x0[2] )*( x1[2] - x0[2] ) );
-      x0 = x1;
-    }
+  {
+    const AngularCoordinates h(
+      t1.first + ((t2.first  - t1.first)  * i) / nb,
+      t1.second + ((t2.second - t1.second) * i) / nb
+    );
+    const RealPoint x1( x(h) );
+    l += sqrt( (x1[0] - x0[0]) * (x1[0] - x0[0])
+             + (x1[1] - x0[1]) * (x1[1] - x0[1])
+             + (x1[2] - x0[2]) * (x1[2] - x0[2]) );
+    x0 = x1;
+  }
   return l;
 }
 
@@ -208,36 +197,34 @@ DGtal::StarShaped3D<TSpace>::arclength( AngularCoordinates t1, AngularCoordinate
 template<typename TSpace>
 inline
 double
-DGtal::StarShaped3D<TSpace>::surfacelength( AngularCoordinates t1, AngularCoordinates t2, unsigned int nb ) const
+DGtal::StarShaped3D<TSpace>::surfacelength( const AngularCoordinates& t1, AngularCoordinates t2, unsigned int nb ) const
 {
   while ( t2.first < t1.first ) t2.first += 2.0*M_PI;
   while ( t2.second < t1.second ) t2.second += 2.0*M_PI;
 
-  double step1 = ( t2.first - t1.first )  / nb;
-  double step2 = ( t2.second - t1.second )  / nb;
-  AngularCoordinates t( std::make_pair(0.0,0.0));
+  const double step1 = ( t2.first - t1.first )  / nb;
+  const double step2 = ( t2.second - t1.second )  / nb;
+
   double l = 0.0;
+
   for ( unsigned int i = 0; i < nb; ++i )
+  {
+    const double tFirst = step1 * i;
+    for ( unsigned int j = 0; j < nb; ++j )
     {
-      t.first = step1 *i;
-      for ( unsigned int j = 0; j < nb; ++j )
-        {
+      const double tSecond = step2 * j;
+      const RealPoint xtp (  x( std::make_pair( t1.first + tFirst - step1 ,t1.second + tSecond - step2 )));
+      const RealPoint xt1p1( x( std::make_pair( t1.first + tFirst,         t1.second + tSecond ))); 
+      const RealPoint xt1p(  x( std::make_pair( t1.first + tFirst,         t1.second + tSecond - step2 ))); 
 
-          t.second = step2 * j;
-          RealPoint xtp (x( std::make_pair( t1.first + t.first - step1 ,t1.second + t.second - step2 ) ));
-          RealPoint xt1p1( x( std::make_pair(t1.first + t.first,t1.second + t.second) ) ); 
-          RealPoint xt1p( x( std::make_pair(t1.first + t.first,t1.second + t.second- step2 ) ) ); 
-          double D = sqrt( ( xt1p[0] - xtp[0] )*( xt1p[0] - xtp[0] ) + 
-			   ( xt1p[1] - xtp[1] )*( xt1p[1] - xtp[1] ) + 
-			   ( xt1p[2] - xtp[2] )*( xt1p[2] - xtp[2] ));
-	  double d = sqrt( ( xt1p1[0] - xt1p[0] )*( xt1p1[0] - xt1p[0] ) + 
-			   ( xt1p1[1] - xt1p[1] )*( xt1p1[1] - xt1p[1] ) + 
-			   ( xt1p1[2] - xt1p[2] )*( xt1p1[2] - xt1p[2] ));
-
-
-          l += (d*D);
-        }
-    }
+      l += sqrt( (xt1p[0] - xtp[0]) * (xt1p[0] - xtp[0]) +
+                 (xt1p[1] - xtp[1]) * (xt1p[1] - xtp[1]) +
+                 (xt1p[2] - xtp[2]) * (xt1p[2] - xtp[2]) )
+         * sqrt( (xt1p1[0] - xt1p[0]) * (xt1p1[0] - xt1p[0]) +
+                 (xt1p1[1] - xt1p[1]) * (xt1p1[1] - xt1p[1]) +
+                 (xt1p1[2] - xt1p[2]) * (xt1p1[2] - xt1p[2]) );
+      }
+  }
   return l;
 }
 

--- a/src/DGtal/shapes/parametric/StarShaped3D.ih
+++ b/src/DGtal/shapes/parametric/StarShaped3D.ih
@@ -241,17 +241,6 @@ DGtal::StarShaped3D<TSpace>::surfacelength( AngularCoordinates t1, AngularCoordi
   return l;
 }
 
-
-
-/**
- * Destructor.
- */
-template <typename T>
-inline
-DGtal::StarShaped3D<T>::~StarShaped3D()
-{
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // Interface - public :
 

--- a/tests/shapes/testDigitalShapesDecorator.cpp
+++ b/tests/shapes/testDigitalShapesDecorator.cpp
@@ -59,10 +59,11 @@ bool testDigitalShapesDecorator()
 
   trace.beginBlock ( "Testing Unary operation on digital shapes ..." );
 
-  typedef Ball2D< Z2i::Space > ShapeA;
-  typedef GaussDigitizer< Z2i::Space, ShapeA > MyGaussDigitizerA;
+  typedef Z2i::Space Space;
+  typedef Ball2D< Space > ShapeA;
+  typedef GaussDigitizer< Space, ShapeA > MyGaussDigitizerA;
 
-  typedef ShapeA::Point Point;
+  typedef Space::Point Point;
 
   double h = 0.5;
 

--- a/tests/shapes/testGaussDigitizer.cpp
+++ b/tests/shapes/testGaussDigitizer.cpp
@@ -35,8 +35,11 @@
 #include "DGtal/kernel/sets/DigitalSetSelector.h"
 #include "DGtal/shapes/GaussDigitizer.h"
 #include "DGtal/helpers/StdDefs.h"
+#include "DGtal/shapes/parametric/Ball2D.h"
+#include "DGtal/shapes/parametric/Astroid2D.h"
 #include "DGtal/shapes/parametric/Ellipse2D.h"
 #include "DGtal/shapes/parametric/Flower2D.h"
+#include "DGtal/shapes/parametric/Lemniscate2D.h"
 #include "DGtal/shapes/Shapes.h"
 #include "DGtal/topology/helpers/Surfaces.h"
 #include "DGtal/geometry/curves/GridCurve.h"
@@ -84,7 +87,7 @@ testDigitization( const Shape & aShape, double h,
   RealPoint xUp( 7.4, 4.7 );
   GaussDigitizer<Space,Shape> dig;  
   dig.attach( aShape ); // attaches the shape.
-  dig.init( xLow, xUp, h ); 
+  dig.init( aShape.getLowerBound(), aShape.getUpperBound(), h );
   
   // The domain size is given by the digitizer according to the window
   // and the step.
@@ -123,11 +126,6 @@ testDigitization( const Shape & aShape, double h,
 
   board << SetMode( gridcurve.className(), "Edges" )
   << CustomStyle( bel.className(), 
-      new CustomColors( DGtal::Color( 0, 0, 0 ),
-            DGtal::Color( 0, 192, 0 ) ) )
-  << gridcurve;
-  board << SetMode( gridcurve.className(), "Points" )
-  << CustomStyle( bel.className(), 
       new CustomColors( DGtal::Color( 255, 0, 0 ),
             DGtal::Color( 200, 0, 0 ) ) )
   << gridcurve;
@@ -148,6 +146,30 @@ bool testGaussDigitizer()
   unsigned int nb = 0;
   
   trace.beginBlock ( "Testing GaussDigitizer as a Digital Shape functor." );
+
+  typedef Astroid2D< Z2i::Space > MyAstroid;
+  MyAstroid astroid( 6.2, -2.1, 7.3, 4.9 );
+  nbok += testDigitization<Z2i::Space,MyAstroid>
+    ( astroid, 1.0, "gauss-astroid-1" ) ? 1 : 0; 
+  nb++;
+  nbok += testDigitization<Z2i::Space,MyAstroid>
+    ( astroid, 0.5, "gauss-astroid-0_5" ) ? 1 : 0; 
+  nb++;
+  nbok += testDigitization<Z2i::Space,MyAstroid>
+    ( astroid, 0.25, "gauss-astroid-0_25" ) ? 1 : 0; 
+  nb++;
+
+  typedef Ball2D< Z2i::Space > MyBall;
+  MyBall ball( 6.2, -2.1, 7.3 );
+  nbok += testDigitization<Z2i::Space,MyBall>
+    ( ball, 1.0, "gauss-ball-1" ) ? 1 : 0; 
+  nb++;
+  nbok += testDigitization<Z2i::Space,MyBall>
+    ( ball, 0.5, "gauss-ball-0_5" ) ? 1 : 0; 
+  nb++;
+  nbok += testDigitization<Z2i::Space,MyBall>
+    ( ball, 0.25, "gauss-ball-0_25" ) ? 1 : 0; 
+  nb++;
 
   typedef Ellipse2D< Z2i::Space > MyEllipse;
   MyEllipse ellipse( 1.2, 0.1, 4.0, 3.0, 0.3 );
@@ -171,6 +193,18 @@ bool testGaussDigitizer()
   nb++;
   nbok += testDigitization<Z2i::Space,MyFlower>
     ( flower, 0.25, "gauss-flower-0_25" ) ? 1 : 0; 
+  nb++;
+
+  typedef Lemniscate2D< Z2i::Space > MyLemniscate;
+  MyLemniscate lemniscate( 0.5, -2.3, 5.0 );
+  nbok += testDigitization<Z2i::Space,MyLemniscate>
+    ( lemniscate, 1.0, "gauss-lemniscate-1" ) ? 1 : 0; 
+  nb++;
+  nbok += testDigitization<Z2i::Space,MyLemniscate>
+    ( lemniscate, 0.5, "gauss-lemniscate-0_5" ) ? 1 : 0; 
+  nb++;
+  nbok += testDigitization<Z2i::Space,MyLemniscate>
+    ( lemniscate, 0.25, "gauss-lemniscate-0_25" ) ? 1 : 0; 
   nb++;
 
   trace.info() << "(" << nbok << "/" << nb << ") "


### PR DESCRIPTION
# PR Description

This PR:
- homogenizes typdefs of parametric shapes that could be Points/Points2D and Vector/Vector2D
- modify constructors/destructors by using delete/default directives
- adds copy constructors that were strangely forbidden

This PR also:
- fixes computation of bounding boxes for some shapes
- removes some useless temporary variables
- improves comparisons to 0 by using isAlmostEqual method
- adds const directives to several method parameters

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
