### PR TITLE
Adding suggested `skip_cleanup: true` in deployment conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,3 +78,4 @@ jobs:
        verbose: true
        local_dir: "$TRAVIS_BUILD_DIR/build/html"
        strategy: api
+       skip_cleanup: true


### PR DESCRIPTION
To avoid stashing just generated documentation files

It was previously removed because of a warning that is was deprecated,
we will see...
