### PR TITLE
Itk image origin fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -110,6 +110,11 @@
   - Removing a `using namespace std;` in the Viewer3D hearder file. (David
     Coeurjolly [#1413](https://github.com/DGtal-team/DGtal/pull/1413))
 
+- *images*
+  - Fix origin image that was not taken into account in class
+    ImageContainerByITKImage. (Bertrand Kerautret
+    [#1482](https://github.com/DGtal-team/DGtal/pull/1482))
+
 - *Shapes package*
   - Fix bug in Astroid parameter() method : orientation correction
    (Adrien Krähenbühl,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -106,14 +106,15 @@
     CCW ordering by default (in 3D).
     (Jacques-Olivier Lachaud,[#1421](https://github.com/DGtal-team/DGtal/pull/1445))
 
+- *images*
+  - Fix origin image that was not taken into account in class
+    ImageContainerByITKImage. (Bertrand Kerautret
+    [#1484](https://github.com/DGtal-team/DGtal/pull/1484))
+    
 - *IO*
   - Removing a `using namespace std;` in the Viewer3D hearder file. (David
     Coeurjolly [#1413](https://github.com/DGtal-team/DGtal/pull/1413))
 
-- *images*
-  - Fix origin image that was not taken into account in class
-    ImageContainerByITKImage. (Bertrand Kerautret
-    [#1482](https://github.com/DGtal-team/DGtal/pull/1482))
 
 - *Shapes package*
   - Fix bug in Astroid parameter() method : orientation correction

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -107,7 +107,7 @@
     (Jacques-Olivier Lachaud,[#1421](https://github.com/DGtal-team/DGtal/pull/1445))
 
 - *images*
-  - Fix origin image that was not taken into account in class
+  - Fix the image origin that was not taken into account in class
     ImageContainerByITKImage. (Bertrand Kerautret
     [#1484](https://github.com/DGtal-team/DGtal/pull/1484))
     

--- a/src/DGtal/images/ImageContainerByITKImage.ih
+++ b/src/DGtal/images/ImageContainerByITKImage.ih
@@ -95,13 +95,15 @@ namespace DGtal
         const typename ITKImage::RegionType region = myITKImagePointer->GetLargestPossibleRegion();
         const typename ITKImage::IndexType start = region.GetIndex();
         const typename ITKImage::SizeType size = region.GetSize();
+        const typename ITKImage::PointType origin = myITKImagePointer->GetOrigin();
+
 
         Point lowerBound;
         Point upperBound;
         for (Dimension k = 0; k < dimension; k++)
         {
-            lowerBound[k] = start[k];
-            upperBound[k] = start[k]+size[k]-1;
+            lowerBound[k] = start[k]+origin[k];
+            upperBound[k] = start[k]+size[k]+origin[k]-1;
         }
 
         myDomain = TDomain(lowerBound, upperBound);
@@ -120,7 +122,7 @@ namespace DGtal
     {
       typename ITKImage::IndexType p;
       for (Dimension k = 0; k < dimension; k++)
-        p[k] = aPoint[k];
+        p[k] = aPoint[k]-myITKImagePointer->GetOrigin()[k];
       return myITKImagePointer->GetPixel(p);
     }
 
@@ -173,7 +175,7 @@ namespace DGtal
     {
       typename ITKImage::IndexType p;
       for (Dimension k = 0; k < dimension; k++)
-        p[k] = aPoint[k];
+        p[k] = aPoint[k]-myITKImagePointer->GetOrigin()[k];
       myITKImagePointer->SetPixel(p, V);
     }
 


### PR DESCRIPTION
# PR Description

Fix origin image that was not taken into account in class ImageContainerByITKImage.
(all ITK images were always shifted with origin (0,0,0))

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
