### PR TITLE
process ITK in GenericWriter

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,7 +33,7 @@
 
 - *io*
   - The GenericWriter can now export in 3D ITK format (nii, mha,  mhd,  tiff).  
-    (Bertrand Kerautret [#1485](https://github.com/DGtal-team/DGtal/pull/1421))
+    (Bertrand Kerautret [#1485](https://github.com/DGtal-team/DGtal/pull/1485))
 
 - *Kernel package*
   - Add .data() function to PointVector to expose internal array data.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,10 @@
   - Add principal directions of curvature functions for implicit polynomial 3D shapes.
     (Jacques-Olivier Lachaud,[#1470](https://github.com/DGtal-team/DGtal/pull/1470))
 
+- *io*
+  - The GenericWriter can now export in 3D ITK format (nii, mha,  mhd,  tiff).  
+    (Bertrand Kerautret [#1485](https://github.com/DGtal-team/DGtal/pull/1421))
+
 - *Kernel package*
   - Add .data() function to PointVector to expose internal array data.
     (Pablo Hernandez-Cerdan, [#1452](https://github.com/DGtal-team/DGtal/pull/1452))

--- a/src/DGtal/io/writers/GenericWriter.ih
+++ b/src/DGtal/io/writers/GenericWriter.ih
@@ -39,7 +39,9 @@
 #ifdef WITH_MAGICK
 #include "DGtal/io/writers/MagickWriter.h"
 #endif
-
+#ifdef WITH_ITK
+#include "DGtal/io/writers/ITKWriter.h"
+#endif
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -104,6 +106,14 @@ exportFile( const std::string & filename,
     {
       return RawWriter<TContainer>::template exportRaw<TValue>( filename, anImage, aFunctor  );
     }
+  #ifdef WITH_ITK
+  else if ( extension == "nii" || extension == "mha" ||
+            extension == "mhd" || extension == "tiff" ||
+            extension == "tif" )
+          {
+            return ITKWriter<TContainer, TFunctor>::exportITK( filename, anImage, aFunctor );
+          }
+#endif
   else
     {
       trace.error() << "Extension " << extension << " in 3D, not yet implemented in DGtal GenericWriter." << std::endl;


### PR DESCRIPTION
# PR Description

The GenericWriter can now export in 3D ITK format (nii, mha,  mhd,  tiff).

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
