### PR TITLE
Avoid setting globally feenableexcept in Linux when in Debug mode

### DIFF
--- a/.travis/build_all.sh
+++ b/.travis/build_all.sh
@@ -9,6 +9,7 @@ BTYPE="$BTYPE -DBUILD_EXAMPLES=false -DBUILD_TESTING=true"
 BTYPE="$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
               -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug \
               -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DWITH_EIGEN=true\
+              -DDGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS=true \
               -DWARNING_AS_ERROR=OFF -DCMAKE_INSTALL_PREFIX='$DEPS_DIR'"
 
 # OSX dependencies and build customization (hence the source)

--- a/.travis/build_dgtal.sh
+++ b/.travis/build_dgtal.sh
@@ -9,6 +9,7 @@ BTYPE="$BTYPE -DBUILD_EXAMPLES=true -DBUILD_TESTING=false"
 BTYPE="$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
               -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug \
               -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DWITH_EIGEN=true\
+              -DDGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS=true \
               -DWARNING_AS_ERROR=OFF -DCMAKE_INSTALL_PREFIX='$DEPS_DIR'"
 
 # OSX dependencies and build customization (hence the source)

--- a/.travis/build_dgtal_doc.sh
+++ b/.travis/build_dgtal_doc.sh
@@ -8,6 +8,7 @@ BTYPE="$BTYPE -DBUILD_EXAMPLES=true -DBUILD_TESTING=false"
 BTYPE="$BTYPE -DCMAKE_BUILD_TYPE=Debug -DWITH_MAGICK=true -DWITH_GMP=true\
                      -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug \
                      -DWITH_HDF5=true -DWITH_CAIRO=true -DWITH_QGLVIEWER=true -DWITH_EIGEN=true\
+                     -DDGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS=true \
                      -DWARNING_AS_ERROR=OFF"
 
 #############################

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,9 @@
   Coeurjolly [#1444](https://github.com/DGtal-team/DGtal/pull/1444))
   - Add .gitattributes file for github to recognize ih files as c++
     (Pablo Hernandez-Cerdan [#1457](https://github.com/DGtal-team/DGtal/pull/1457))
+  - Add CMake option `DGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS` to control enabling
+    `feenableexcept` (only applies in Linux when in Debug mode).
+    (Pablo Hernandez-Cerdan, [#1489](https://github.com/DGtal-team/DGtal/pull/1489))
 
 - *Geometry*
   - New Integral Invariant functor to retrieve the curvature tensor (principal curvature

--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -78,6 +78,16 @@ OPTION(VERBOSE "Verbose messages." OFF)
 OPTION(COLOR_WITH_ALPHA_ARITH "Consider alpha channel in color arithmetical operations." OFF)
 OPTION(DGTAL_NO_ESCAPED_CHAR_IN_TRACE "Avoid printing special color and font weight terminal escaped char in program output." OFF)
 
+# Enable floating point exception when DGtal library is loaded. Only works for gcc.
+IF (UNIX AND NOT APPLE)
+  # Only used in Common.cpp
+  OPTION(DGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS "Enable feenableexcept when DGtal library is loaded." OFF)
+  mark_as_advanced(DGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS)
+  if(DGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS)
+    add_definitions(-DDGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS)
+  endif()
+ENDIF()
+
 SET(VERBOSE_DGTAL 0)
 SET(DEBUG_VERBOSE_DGTAL 0)
 SET(COLOR_WITH_ALPHA_ARITH_DGTAL 0)

--- a/src/DGtal/base/Common.cpp
+++ b/src/DGtal/base/Common.cpp
@@ -47,11 +47,13 @@ namespace DGtal
 
 #ifndef NDEBUG
 #ifdef __linux__
+#ifdef DGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS
   void beforeMain (void) __attribute__((constructor));
   void beforeMain (void)
   {
       feenableexcept ( FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW );
   }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Discovered while using DGtal in a third party project, along other
libraries.
When DGtal library is loaded imposes `feenableexcept`.

`Common.cpp`:

```cpp
void beforeMain (void) __attribute__((constructor));
void beforeMain (void)
{
  feenableexcept ( FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW );
}
```

There are other libraries that relies on feenableexcept not enabled.
For example ITK reading .nrrd files.

Add an option `DGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS`, OFF by default,
to control this behavior at compile time.

# PR Description

*your description here*

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
