### PR TITLE
fix bug in BasicDomainSubSampler

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@
   - Making `HyperRectDomain_(sub)Iterator` random-access iterators
     (allowing parallel scans of the domain, Roland Denis,
     [#1416](https://github.com/DGtal-team/DGtal/pull/1416))
+  - Fix bug in BasicDomainSubSampler with negative coordinates of 
+    domain lower bound. (Bertrand Kerautret
+    [#1504](https://github.com/DGtal-team/DGtal/pull/1504))
+    
 
 - *DEC*
   - Add discrete calculus model of Ambrosio-Tortorelli functional in

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
   - Making `HyperRectDomain_(sub)Iterator` random-access iterators
     (allowing parallel scans of the domain, Roland Denis,
     [#1416](https://github.com/DGtal-team/DGtal/pull/1416))
-  - Fix bug in BasicDomainSubSampler for negative coordinates of 
+  - Fix bug in BasicDomainSubSampler for negative coordinates of the
     domain lower bound. (Bertrand Kerautret
     [#1504](https://github.com/DGtal-team/DGtal/pull/1504))
     

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
   - Making `HyperRectDomain_(sub)Iterator` random-access iterators
     (allowing parallel scans of the domain, Roland Denis,
     [#1416](https://github.com/DGtal-team/DGtal/pull/1416))
-  - Fix bug in BasicDomainSubSampler with negative coordinates of 
+  - Fix bug in BasicDomainSubSampler for negative coordinates of 
     domain lower bound. (Bertrand Kerautret
     [#1504](https://github.com/DGtal-team/DGtal/pull/1504))
     

--- a/src/DGtal/kernel/BasicPointFunctors.h
+++ b/src/DGtal/kernel/BasicPointFunctors.h
@@ -592,6 +592,7 @@ namespace functors
   public:
     typedef typename TDomain::Space  Space;
     typedef typename TDomain::Size Size;
+    typedef typename TDomain::Integer IntergerDom;
     typedef typename Space::Dimension Dimension;
     typedef typename Space::Point Point;
 
@@ -615,8 +616,10 @@ namespace functors
       Point domainLowerBound=aSourceDomain.lowerBound();
 
       for (Dimension dim=0; dim< Space::dimension; dim++){
-        domainLowerBound[dim] /= NumberTraits<TInteger>::castToDouble( aGridSize[dim] );
-        domainUpperBound[dim] /= NumberTraits<TInteger>::castToDouble( aGridSize[dim] );
+        domainLowerBound[dim] = static_cast<IntergerDom>(floor(NumberTraits<IntergerDom>::castToDouble(domainLowerBound[dim]) /
+                                                               NumberTraits<TValue>::castToDouble( aGridSize[dim] )));        
+        domainUpperBound[dim] = static_cast<IntergerDom>(floor(NumberTraits<IntergerDom>::castToDouble(domainUpperBound[dim]) /
+                                                               NumberTraits<TValue>::castToDouble( aGridSize[dim] )));
       }
       myNewDomain = TDomain(domainLowerBound,
                             domainUpperBound);

--- a/src/DGtal/kernel/BasicPointFunctors.h
+++ b/src/DGtal/kernel/BasicPointFunctors.h
@@ -615,8 +615,8 @@ namespace functors
       Point domainLowerBound=aSourceDomain.lowerBound();
 
       for (Dimension dim=0; dim< Space::dimension; dim++){
-        domainLowerBound[dim] /= aGridSize[dim];
-        domainUpperBound[dim] /= aGridSize[dim];
+        domainLowerBound[dim] /= NumberTraits<TInteger>::castToDouble( aGridSize[dim] );
+        domainUpperBound[dim] /= NumberTraits<TInteger>::castToDouble( aGridSize[dim] );
       }
       myNewDomain = TDomain(domainLowerBound,
                             domainUpperBound);


### PR DESCRIPTION
# PR Description

Small PR to fix a bug that appears when using a non zero min domain and using subSampler. 
For instance using cat10.vol instead Al.100.vol was producing an error (due to unsigned int and negative coordinates).
Thanks @kenmochi for the bug ;)



# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
