### PR TITLE
Fix loadTable in Windows

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -91,6 +91,8 @@
     (Pablo Hernandez-Cerdan, [#1451](https://github.com/DGtal-team/DGtal/pull/1451))
   - Fix bug in VoxelComplex masks when cell was at the boundary of kspace
     (Pablo Hernandez-Cerdan, [#1488](https://github.com/DGtal-team/DGtal/pull/1488))
+  - Fix loadTable not able to read compressed tables in Windows
+    (Pablo Hernandez-Cerdan, [#1505](https://github.com/DGtal-team/DGtal/pull/1505))
 
 - *Shapes package*
   - Add a moveTo(const RealPoint& point) method to implicit and star shapes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,6 @@
     domain lower bound. (Bertrand Kerautret
     [#1504](https://github.com/DGtal-team/DGtal/pull/1504))
     
-
 - *DEC*
   - Add discrete calculus model of Ambrosio-Tortorelli functional in
     order to make piecewise-smooth approximations of scalar or vector

--- a/src/DGtal/topology/NeighborhoodConfigurations.ih
+++ b/src/DGtal/topology/NeighborhoodConfigurations.ih
@@ -46,8 +46,8 @@ namespace DGtal{
     using ConfigMap = boost::dynamic_bitset<> ;
     CountedPtr<ConfigMap> table(new ConfigMap(known_size));
     try {
-      std::ifstream in_file(input_filename);
       if (compressed) {
+        std::ifstream in_file(input_filename, std::ios::binary);
         namespace io = boost::iostreams ;
         io::filtering_streambuf<io::input> filter;
         filter.push(io::zlib_decompressor());
@@ -56,9 +56,9 @@ namespace DGtal{
         io::copy(filter,compressed_stream);
         compressed_stream >> *table ;
       } else {
+        std::ifstream in_file(input_filename);
         in_file >> *table ;
       }
-      in_file.close();
     } catch(std::exception &e) {
       throw std::runtime_error("loadTable error in: " + input_filename + " with exception: " +  e.what());
     }


### PR DESCRIPTION
Add `std::io::binary` flag to `ifstream`

In Linux the missing flag wasn't a problem:
https://stackoverflow.com/questions/60915861/decompression-with-boost-zlib-crashes-on-windows

Reported: https://github.com/phcerdan/SGEXT/issues/48

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
