### PR TITLE
CMake: Abort compilation if compiler is gcc 10.1 due to compiler bug.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -213,6 +213,9 @@
     ConstIteratorAdapter class that does not satisfy the _is_forward concept of the STL:
     using boost::first_max_element instead std::max_element. 
     (Bertrand Kerautret, [#1437](https://github.com/DGtal-team/DGtal/pull/1437))  
+  - Abort compilation at configure time when the compiler is gcc 10.1 due to compiler bug.
+    Fix issue #1501.
+    (Pablo Hernandez-Cerdan, [#1506](https://github.com/DGtal-team/DGtal/pull/1506))
 
 # DGtal 1.0
 

--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -44,6 +44,15 @@ IF (MSVC)
 ENDIF (MSVC)
 
 # -----------------------------------------------------------------------------
+# GCC 10.1 Incompatibility
+# -----------------------------------------------------------------------------
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 10.1)
+  message("CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
+  message(FATAL_ERROR "DGtal cannot be compiled in GCC 10.1 due to a bug in the compiler. "
+    "Try llvm, or other version of gcc (solved in gcc 10.2). Issue: https://github.com/DGtal-team/DGtal/issues/1501")
+endif()
+
+# -----------------------------------------------------------------------------
 # Doxygen targets
 # -----------------------------------------------------------------------------
 message(STATUS "-------------------------------------------------------------------------------")


### PR DESCRIPTION
Triggers a CMake FATAL_ERROR at configure time.

Fix #1501

# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
