### PR TITLE
Travis: Fix broken Eigen url. Update Eigen to 3.3.7.

### DIFF
--- a/.travis/install_eigen.sh
+++ b/.travis/install_eigen.sh
@@ -8,11 +8,11 @@ if [ "$TRAVIS_OS_NAME" == linux ];
 then
     cd "$HOME"
 
-    wget http://bitbucket.org/eigen/eigen/get/3.2.10.tar.bz2
-    bunzip2 3.2.10.tar.bz2
-    tar xf 3.2.10.tar
+    wget https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2
+    bunzip2 eigen-3.3.7.tar.bz2
+    tar xf eigen-3.3.7.tar
 
-    cd eigen-eigen-b9cd8366d4e8
+    cd eigen-3.3.7
     mkdir build ; cd build
 
     cmake .. -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,8 @@
   - Add CMake option `DGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS` to control enabling
     `feenableexcept` (only applies in Linux when in Debug mode).
     (Pablo Hernandez-Cerdan, [#1489](https://github.com/DGtal-team/DGtal/pull/1489))
+  - Travis: Fix broken Eigen url. Update Eigen in travis to 3.3.7.
+    (Pablo Hernandez, [#1508](https://github.com/DGtal-team/DGtal/pull/1508))
 
 - *Geometry*
   - New Integral Invariant functor to retrieve the curvature tensor (principal curvature


### PR DESCRIPTION
Fix #1507

# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
