### PR TITLE
Fix fillData in CubicalComplex

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -129,6 +129,8 @@
     (Pablo Hernandez-Cerdan, [#1488](https://github.com/DGtal-team/DGtal/pull/1488))
   - Fix loadTable not able to read compressed tables in Windows
     (Pablo Hernandez-Cerdan, [#1505](https://github.com/DGtal-team/DGtal/pull/1505))
+  - Fix fillData in CubicalComplex
+    (Pablo Hernandez-Cerdan, [#1519](https://github.com/DGtal-team/DGtal/pull/1519))
 
 - *Shapes package*
   - Add a moveTo(const RealPoint& point) method to implicit and star shapes

--- a/src/DGtal/topology/CubicalComplex.ih
+++ b/src/DGtal/topology/CubicalComplex.ih
@@ -198,7 +198,7 @@ DGtal::CubicalComplex<TKSpace, TCellContainer>::
 fillData( Data data )
 {
   for ( Dimension d = 0; d <= dimension; ++d )
-    clearData( d, data );
+    fillData( d, data );
 }
 //-----------------------------------------------------------------------------
 template <typename TKSpace, typename TCellContainer>


### PR DESCRIPTION
It was calling clear instead of fill

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
