### PR TITLE
Point2DEmbedderIn3D edit origin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,7 +44,7 @@
   - Point2DEmbedderIn3D edit to recover behavior of version 0.9.4 in
      the origin point placement.
     (Florian Delconte and Bertrand Kerautret 
-    [#1520](https://github.com/DGtal-team/DGtal/pull/1520)) 
+    [#1520](https://github.com/DGtal-team/DGtal/pull/1520))
 
 - *DEC*
   - Add discrete calculus model of Ambrosio-Tortorelli functional in

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,7 +44,7 @@
   - Point2DEmbedderIn3D edit to recover behavior of version 0.9.4 in
      the origin point placement.
     (Florian Delconte and Bertrand Kerautret 
-    [#1520](https://github.com/DGtal-team/DGtal/pull/#1520)) 
+    [#1520](https://github.com/DGtal-team/DGtal/pull/1520)) 
 
 - *DEC*
   - Add discrete calculus model of Ambrosio-Tortorelli functional in

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -147,7 +147,6 @@
   - Add const directives to some curve estimators on shapes.
     (Adrien Krähenbühl [#1429](https://github.com/DGtal-team/DGtal/pull/1429))
 
-
 - *IO*
   - When the 3D built-in viewer is enabled (libqglviewer), the default
     required Qt version is now Qt5 instead of Qt4. You can revert to
@@ -221,8 +220,8 @@
 
 - *Shapes*
   - Fix bug in Astroid parameter() method : orientation correction
-   (Adrien Krähenbühl,
-   [#1325](https://github.com/DGtal-team/DGtal/pull/1426))
+    (Adrien Krähenbühl,
+    [#1325](https://github.com/DGtal-team/DGtal/pull/1426))
   - Add missing constraint to flips in TriangulatedSurface
     (Jacques-Olivier Lachaud,[#1498](https://github.com/DGtal-team/DGtal/pull/1498))
 
@@ -253,11 +252,11 @@
   - Fix issue (https://github.com/DGtal-team/DGtal/issues/1478),
     that is a Visual Studio 2019 build error related to befriend
     template specializations
-   (Jacques-Olivier Lachaud [#1481](https://github.com/DGtal-team/DGtal/pull/1481))
+    (Jacques-Olivier Lachaud [#1481](https://github.com/DGtal-team/DGtal/pull/1481))
   - Removing the homemade CPP11 checks, using cmake macro instead
-  (David Coeurjolly, [#1446](https://github.com/DGtal-team/DGtal/pull/1446))
+    (David Coeurjolly, [#1446](https://github.com/DGtal-team/DGtal/pull/1446))
   - Removes the check for CPP11 when building WITH_ITK
-  (Pablo Hernandez-Cerdan, [#1453](https://github.com/DGtal-team/DGtal/pull/1453))
+    (Pablo Hernandez-Cerdan, [#1453](https://github.com/DGtal-team/DGtal/pull/1453))
   - Fix apple clang  compilation issue with a workaround to the
     ConstIteratorAdapter class that does not satisfy the _is_forward concept of the STL:
     using boost::first_max_element instead std::max_element.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,10 @@
   - Fix bug in BasicDomainSubSampler for negative coordinates of the
     domain lower bound. (Bertrand Kerautret
     [#1504](https://github.com/DGtal-team/DGtal/pull/1504))
+  - Point2DEmbedderIn3D edit to recover behavior of version 0.9.4 in
+     the origin point placement.
+    (Florian Delconte and Bertrand Kerautret 
+    [#1520](https://github.com/DGtal-team/DGtal/pull/#1520)) 
 
 - *DEC*
   - Add discrete calculus model of Ambrosio-Tortorelli functional in

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,10 +41,6 @@
   - Fix bug in BasicDomainSubSampler for negative coordinates of the
     domain lower bound. (Bertrand Kerautret
     [#1504](https://github.com/DGtal-team/DGtal/pull/1504))
-  - Point2DEmbedderIn3D edit to recover behavior of version 0.9.4 in
-     the origin point placement.
-    (Florian Delconte and Bertrand Kerautret 
-    [#1520](https://github.com/DGtal-team/DGtal/pull/1520))
 
 - *DEC*
   - Add discrete calculus model of Ambrosio-Tortorelli functional in
@@ -180,6 +176,11 @@
   - Fix initialisation in BoundedLatticePolytope when creating non full
     dimensional simplices in 3D (segments, triangles). (Jacques-Olivier Lachaud,
     [#1502](https://github.com/DGtal-team/DGtal/pull/1502))
+
+- *Kernel*
+  - Point2DEmbedderIn3D edit to recover behavior of version 0.9.4 in
+    the origin point placement. (Florian Delconte and Bertrand Kerautret 
+    [#1520](https://github.com/DGtal-team/DGtal/pull/1520))
 
 - *Helpers*
   - Fix Metric problem due to implicit RealPoint toward Point conversion when computing

--- a/src/DGtal/kernel/BasicPointFunctors.h
+++ b/src/DGtal/kernel/BasicPointFunctors.h
@@ -457,8 +457,8 @@ namespace functors
       uDir2[2] = uDir1[0]*anNormalVector[1]-uDir1[1]*anNormalVector[0];
 
       uDir2/=uDir2.norm();
-
-      myOriginPointEmbeddedIn3D = Point(anOriginPoint + uDir1*anWidth/2 + uDir2*anWidth/2, functors::Round<>());
+      
+      myOriginPointEmbeddedIn3D = anOriginPoint + Point(uDir1*anWidth/2) + Point(uDir2*anWidth/2);
       myFirstAxisEmbeddedDirection = -uDir1;
       mySecondAxisEmbeddedDirection = -uDir2;
     }

--- a/tests/kernel/testBasicPointFunctors.cpp
+++ b/tests/kernel/testBasicPointFunctors.cpp
@@ -148,16 +148,16 @@ bool testProjector()
 									 4); 
   PointVector<2, int> pt2b(0, 0);  
   PointVector<2, int> pt2_2b(2, 2);  
-  //trace.info() << "pt " << pt2b << " => " << embedder2(pt2b) << " == " << PointVector<3,int>(3,5,3) << std::endl;
-  //nbok += ( embedder2(pt2b) == PointVector<3,int>(3,5,3) ) ? 1 : 0;
-  trace.info() << "pt " << pt2b << " => " << embedder2(pt2b) << " == " << PointVector<3,int>(2,5,3) << std::endl;
-  nbok += ( embedder2(pt2b) == PointVector<3,int>(2,5,3) ) ? 1 : 0; // TODO: check expected result
+  trace.info() << "pt " << pt2b << " => " << embedder2(pt2b) << " == " << PointVector<3,int>(3,5,3) << std::endl;
+  nbok += ( embedder2(pt2b) == PointVector<3,int>(3,5,3) ) ? 1 : 0;
+  //trace.info() << "pt " << pt2b << " => " << embedder2(pt2b) << " == " << PointVector<3,int>(2,5,3) << std::endl;
+  //nbok += ( embedder2(pt2b) == PointVector<3,int>(2,5,3) ) ? 1 : 0; // TODO: check expected result
   nb++;
   
-  //trace.info() << "pt " << pt2_2b << " => " << embedder2(pt2_2b) << " == " << PointVector<3,int>(5,4,3) << std::endl;
-  //nbok += ( embedder2(pt2_2b) ==  PointVector<3,int>(5,4,3)  ) ? 1 : 0;
-  trace.info() << "pt " << pt2_2b << " => " << embedder2(pt2_2b) << " == " << PointVector<3,int>(4,4,3) << std::endl;
-  nbok += ( embedder2(pt2_2b) ==  PointVector<3,int>(4,4,3)  ) ? 1 : 0; // TODO: check expected result
+  trace.info() << "pt " << pt2_2b << " => " << embedder2(pt2_2b) << " == " << PointVector<3,int>(5,4,3) << std::endl;
+  nbok += ( embedder2(pt2_2b) ==  PointVector<3,int>(5,4,3)  ) ? 1 : 0;
+  //trace.info() << "pt " << pt2_2b << " => " << embedder2(pt2_2b) << " == " << PointVector<3,int>(4,4,3) << std::endl;
+  //nbok += ( embedder2(pt2_2b) ==  PointVector<3,int>(4,4,3)  ) ? 1 : 0; // TODO: check expected result
   nb++;
 
  

--- a/tests/kernel/testBasicPointFunctors.cpp
+++ b/tests/kernel/testBasicPointFunctors.cpp
@@ -150,14 +150,10 @@ bool testProjector()
   PointVector<2, int> pt2_2b(2, 2);  
   trace.info() << "pt " << pt2b << " => " << embedder2(pt2b) << " == " << PointVector<3,int>(3,5,3) << std::endl;
   nbok += ( embedder2(pt2b) == PointVector<3,int>(3,5,3) ) ? 1 : 0;
-  //trace.info() << "pt " << pt2b << " => " << embedder2(pt2b) << " == " << PointVector<3,int>(2,5,3) << std::endl;
-  //nbok += ( embedder2(pt2b) == PointVector<3,int>(2,5,3) ) ? 1 : 0; // TODO: check expected result
   nb++;
   
   trace.info() << "pt " << pt2_2b << " => " << embedder2(pt2_2b) << " == " << PointVector<3,int>(5,4,3) << std::endl;
   nbok += ( embedder2(pt2_2b) ==  PointVector<3,int>(5,4,3)  ) ? 1 : 0;
-  //trace.info() << "pt " << pt2_2b << " => " << embedder2(pt2_2b) << " == " << PointVector<3,int>(4,4,3) << std::endl;
-  //nbok += ( embedder2(pt2_2b) ==  PointVector<3,int>(4,4,3)  ) ? 1 : 0; // TODO: check expected result
   nb++;
 
  


### PR DESCRIPTION
# PR Description

Small edit on the origin of the Point2DEmbedderIn3D to recover initial behavior of version 0.9.4.
Thanks @FlorianDelconte 

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
