### PR TITLE
Only set CMAKE_CXX_STANDARD if not defined already

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
   - Fix some small errors : includes, variable names, code example
     (adrien Krähenbühl, [#1525](https://github.com/DGtal-team/DGtal/pull/1525))
 
+- *General*
+  - Only set CMAKE_CXX_STANDARD if not defined already
+    (Pablo Hernandez-Cerdan [#1526](https://github.com/DGtal-team/DGtal/pull/1526))
+
 # DGtal 1.1
 
 ## New Features / Critical Changes

--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -31,10 +31,21 @@ endforeach()
 
 
 # -----------------------------------------------------------------------------
-# CPP11 
+# CPP11
 # -----------------------------------------------------------------------------
-set (CMAKE_CXX_STANDARD 11)
-set (CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(DGTAL_CMAKE_CXX_STANDARD_MIN_REQUIRED 11)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD ${DGTAL_CMAKE_CXX_STANDARD_MIN_REQUIRED})
+else()
+  # Throw if CMAKE_CXX_STANDARD is 98
+  if(${CMAKE_CXX_STANDARD} EQUAL 98)
+    message(FATAL_ERROR "CMAKE_CXX_STANDARD is set to ${CMAKE_CXX_STANDARD}, "
+      "but DGtal requires at least ${DGTAL_CMAKE_CXX_STANDARD_MIN_REQUIRED}.")
+  endif()
+endif()
+if(NOT CMAKE_CXX_STANDARD_REQUIRED)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 
 # -----------------------------------------------------------------------------
 # Visual Studio : to distinguish between debug and release lib


### PR DESCRIPTION
This allow users to compile with their own standard.

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
