### PR TITLE
Azure: Simplify the mock azure-pipelines even more

### DIFF
--- a/wrap/azure-pipelines.yml
+++ b/wrap/azure-pipelines.yml
@@ -13,9 +13,5 @@ stages:
     - task: Bash@3
       inputs:
         targetType: 'inline'
-        script: 'echo Hi ; cat > delete_me.txt  '
+        script: 'echo Hi!'
         workingDirectory: '$(Build.SourcesDirectory)'
-    - task: PublishPipelineArtifact@1
-      inputs:
-        targetPath: '$(Build.SourcesDirectory)/delete_me.txt'
-        artifactName: 'LinuxWheels'


### PR DESCRIPTION
Details
DeployLinuxWithDockcross
2 error(s), 0 warning(s)

We stopped hearing from agent Hosted Agent.
Verify the agent machine is running and has a healthy network connection.
Anything that terminates an agent process, starves it for CPU, or blocks its network access can cause this error.
For more information, see:


# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [NA] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [NA] All continuous integration tests pass (Travis & appveyor)
