### PR TITLE
Fix BoundedLatticePolytope::init 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,15 @@
   - Only set CMAKE_CXX_STANDARD if not defined already
     (Pablo Hernandez-Cerdan [#1526](https://github.com/DGtal-team/DGtal/pull/1526))
 
+- *Arithmetic*
+  - Add default constructor to ClosedIntegerHalfSpace
+    (Jacques-Olivier Lachaud,[#1531](https://github.com/DGtal-team/DGtal/pull/1531))
+
+- *Geometry*
+  - Fix BoundedLatticePolytope::init when using half-spaces initialization
+    (Jacques-Olivier Lachaud,[#1531](https://github.com/DGtal-team/DGtal/pull/1531))
+
+
 # DGtal 1.1
 
 ## New Features / Critical Changes

--- a/src/DGtal/arithmetic/ClosedIntegerHalfPlane.h
+++ b/src/DGtal/arithmetic/ClosedIntegerHalfPlane.h
@@ -83,6 +83,10 @@ namespace DGtal
      * Destructor.
      */
     ~ClosedIntegerHalfPlane();
+    /**
+     * Default constructor.
+     */
+    ClosedIntegerHalfPlane() = default;
 
     /**
        Constructor from normal and constant.

--- a/src/DGtal/geometry/volumes/BoundedLatticePolytope.ih
+++ b/src/DGtal/geometry/volumes/BoundedLatticePolytope.ih
@@ -111,12 +111,12 @@ init( const Domain& domain,
     }
   // Add other halfplanes
   Integer nb_hp = 0;
-  for ( auto it = itB; itB != itE; ++it, ++nb_hp ) {
+  for ( auto it = itB; it != itE; ++it, ++nb_hp ) {
     // Checks that is not inside.
     auto a = it->N;
     auto b = it->c;
     auto itF = std::find( A.begin(), A.begin()+2*d, a );
-    if ( itF == A.end() )
+    if ( itF == A.begin()+2*d )
       {
 	A.push_back( a );
 	B.push_back( b );


### PR DESCRIPTION
# PR Description

Fix BoundedLatticePolytope::init (method based on half-spaces)  and add default constructor to ClosedIntegerHalfPlane for convenience.

# Checklist

- [X] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
