### PR TITLE
Add container member function to DigitalSets and ImageContainers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@
 - *General*
   - Only set CMAKE_CXX_STANDARD if not defined already
     (Pablo Hernandez-Cerdan [#1526](https://github.com/DGtal-team/DGtal/pull/1526))
+  - Add `container()` member function to DigitalSets and ImageContainers
+    (Pablo Hernandez-Cerdan [#1532](https://github.com/DGtal-team/DGtal/pull/1532))
 
 - *Arithmetic*
   - Add default constructor to ClosedIntegerHalfSpace

--- a/src/DGtal/images/ImageContainerByHashTree.h
+++ b/src/DGtal/images/ImageContainerByHashTree.h
@@ -276,6 +276,21 @@ namespace DGtal
      */
     Range range() ;
 
+    /**
+     * Give access to the underlying container.
+     * @return a (might be const) reference to the container.
+     */
+    const Self & container() const { return *this; };
+    /** @copydoc container() */
+    Self & container() { return *this; };
+
+    /**
+     * Give access to the underlying data.
+     * @return a (might be const) reference to the data.
+    */
+    const Node** & data() const noexcept { return myData; };
+    /** @copydoc data() */
+    Node** & data() noexcept { return myData; };
 
     /**
      * Returns the value corresponding to a key.

--- a/src/DGtal/images/ImageContainerByITKImage.h
+++ b/src/DGtal/images/ImageContainerByITKImage.h
@@ -116,6 +116,7 @@ namespace DGtal
 
       typedef typename itk::Image< TValue, dimension> ITKImage;
       typedef typename ITKImage::Pointer ITKImagePointer;
+      typedef typename ITKImage::PixelContainer Container;
       typedef typename itk::ImageRegionConstIterator< ITKImage > ConstIterator;
       typedef typename itk::ImageRegionIterator< ITKImage > Iterator;
 
@@ -188,6 +189,20 @@ namespace DGtal
       Range range()
       {
           return Range(*this);
+      }
+
+      /**
+       * Give access to the underlying container.
+       * @return a (might be const) reference to the container.
+      */
+      const Container & container() const
+      {
+        return *(myITKImagePointer->GetPixelContainer());
+      }
+      /** @copydoc container() */
+      Container & container()
+      {
+        return *(myITKImagePointer->GetPixelContainer());
       }
 
       /**

--- a/src/DGtal/images/ImageContainerBySTLMap.h
+++ b/src/DGtal/images/ImageContainerBySTLMap.h
@@ -101,6 +101,7 @@ namespace DGtal
 
     typedef ImageContainerBySTLMap<TDomain,TValue> Self;
     typedef std::map<typename TDomain::Point, TValue > Parent;
+    typedef Parent Container;
 
     /// domain
     BOOST_CONCEPT_ASSERT(( concepts::CDomain<TDomain> ));
@@ -215,6 +216,14 @@ namespace DGtal
      * and output iterators on the values of the image.
      */
     Range range();
+
+    /**
+     * Give access to the underlying container.
+     * @return a (might be const) reference to the container.
+    */
+    const Container & container() const { return static_cast<Parent>(*this); };
+    /** @copydoc container() */
+    Container & container() { return static_cast<Parent>(*this); };
 
     /**
      * Writes/Displays the object on an output stream.

--- a/src/DGtal/images/ImageContainerBySTLVector.h
+++ b/src/DGtal/images/ImageContainerBySTLVector.h
@@ -129,6 +129,8 @@ namespace DGtal
   public:
 
     typedef ImageContainerBySTLVector<TDomain, TValue> Self;
+    typedef std::vector<TValue> Parent;
+    typedef Parent Container;
 
     /// domain
     BOOST_CONCEPT_ASSERT ( ( concepts::CDomain<TDomain> ) );
@@ -283,6 +285,14 @@ namespace DGtal
      * iterators to scan the values of image.
      */
     Range range();
+
+    /**
+     * Give access to the underlying container.
+     * @return a (might be const) reference to the container.
+    */
+    const Container & container() const { return static_cast<Parent>(*this); };
+    /** @copydoc container() */
+    Container & container() { return static_cast<Parent>(*this); };
 
 
     /////////////////////////// Custom Iterator ///////////////

--- a/src/DGtal/kernel/PointVector.h
+++ b/src/DGtal/kernel/PointVector.h
@@ -972,11 +972,12 @@ namespace DGtal
     ConstReverseIterator rend() const;
 
     /**
-     * PointVector data() access to raw data of a std container
+     * PointVector data() (const and non-const) access to raw data of a std container
      *
      * @return container.data()
      */
     inline const Component* data() const noexcept;
+    /** @copydoc data() */
     inline Component* data() noexcept;
 
     // ----------------------- Array services ------------------------------

--- a/src/DGtal/kernel/sets/DigitalSetByAssociativeContainer.h
+++ b/src/DGtal/kernel/sets/DigitalSetByAssociativeContainer.h
@@ -272,6 +272,14 @@ namespace DGtal
     Iterator end();
 
     /**
+     * Give access to the underlying container.
+     * @return a (might be const) reference to the stored container.
+    */
+    const Container & container() const;
+    /** @copydoc container() */
+    Container & container();
+
+    /**
      * set union to left.
      * @param aSet any other set.
      */

--- a/src/DGtal/kernel/sets/DigitalSetByAssociativeContainer.ih
+++ b/src/DGtal/kernel/sets/DigitalSetByAssociativeContainer.ih
@@ -325,6 +325,22 @@ DGtal::DigitalSetByAssociativeContainer<Domain, Container>::end()
   return mySet.end();
 }
 
+template <typename Domain, typename Container>
+inline
+const typename DGtal::DigitalSetByAssociativeContainer<Domain, Container>::Container &
+DGtal::DigitalSetByAssociativeContainer<Domain, Container>::container() const
+{
+  return mySet;
+}
+
+template <typename Domain, typename Container>
+inline
+typename DGtal::DigitalSetByAssociativeContainer<Domain, Container>::Container &
+DGtal::DigitalSetByAssociativeContainer<Domain, Container>::container()
+{
+  return mySet;
+}
+
 /**
  * set union to left.
  * @param aSet any other set.

--- a/src/DGtal/kernel/sets/DigitalSetBySTLSet.h
+++ b/src/DGtal/kernel/sets/DigitalSetBySTLSet.h
@@ -90,6 +90,7 @@ namespace DGtal
     typedef typename Domain::Space Space;
     typedef typename Domain::Point Point;
     typedef typename Domain::Size Size;
+    typedef std::set<Point> Container;
     typedef typename std::set<Point>::iterator Iterator;
     typedef typename std::set<Point>::const_iterator ConstIterator;
 
@@ -253,6 +254,14 @@ namespace DGtal
      * @return a iterator on the element after the last in this set.
      */
     Iterator end();
+
+    /**
+     * Give access to the underlying container.
+     * @return a (might be const) reference to the stored container.
+    */
+    const Container & container() const;
+    /** @copydoc container() */
+    Container & container();
 
     /**
      * set union to left.

--- a/src/DGtal/kernel/sets/DigitalSetBySTLSet.ih
+++ b/src/DGtal/kernel/sets/DigitalSetBySTLSet.ih
@@ -320,6 +320,22 @@ DGtal::DigitalSetBySTLSet<Domain, Compare>::end()
   return mySet.end();
 }
 
+template <typename Domain, typename Compare>
+inline
+const typename DGtal::DigitalSetBySTLSet<Domain, Compare>::Container &
+DGtal::DigitalSetBySTLSet<Domain, Compare>::container() const
+{
+  return mySet;
+}
+
+template <typename Domain, typename Compare>
+inline
+typename DGtal::DigitalSetBySTLSet<Domain, Compare>::Container &
+DGtal::DigitalSetBySTLSet<Domain, Compare>::container()
+{
+  return mySet;
+}
+
 /**
  * set union to left.
  * @param aSet any other set.

--- a/src/DGtal/kernel/sets/DigitalSetBySTLVector.h
+++ b/src/DGtal/kernel/sets/DigitalSetBySTLVector.h
@@ -85,7 +85,8 @@ namespace DGtal
     typedef typename Domain::Space Space;
     typedef typename Domain::Point Point;
     typedef typename Domain::Size Size;
-    typedef typename std::vector<Point>::const_iterator Iterator;
+    typedef std::vector<Point> Container;
+    typedef typename std::vector<Point>::iterator Iterator;
     typedef typename std::vector<Point>::const_iterator ConstIterator;
     typedef typename std::vector<Point>::iterator MutableIterator;
 
@@ -252,6 +253,13 @@ namespace DGtal
      * @return a iterator on the element after the last in this set.
      */
     Iterator end();
+
+    /**
+     * Give access to the underlying container.
+     * @return a (might be const) reference to the stored container.
+    */
+    const Container & container() const;
+    Container & container();
 
     /**
      * set union to left.

--- a/src/DGtal/kernel/sets/DigitalSetBySTLVector.ih
+++ b/src/DGtal/kernel/sets/DigitalSetBySTLVector.ih
@@ -379,6 +379,22 @@ DGtal::DigitalSetBySTLVector<Domain>::end()
   return myVector.end();
 }
 
+template <typename Domain>
+inline
+const typename DGtal::DigitalSetBySTLVector<Domain>::Container &
+DGtal::DigitalSetBySTLVector<Domain>::container() const
+{
+  return myVector;
+}
+
+template <typename Domain>
+inline
+typename DGtal::DigitalSetBySTLVector<Domain>::Container &
+DGtal::DigitalSetBySTLVector<Domain>::container()
+{
+  return myVector;
+}
+
 /**
  * set union to left.
  * @param aSet any other set.

--- a/src/DGtal/kernel/sets/DigitalSetFromMap.h
+++ b/src/DGtal/kernel/sets/DigitalSetFromMap.h
@@ -76,6 +76,7 @@ namespace DGtal
   public:
 
     typedef TMapImage Image;
+    typedef Image Container;
     typedef std::pair<const typename Image::Point, 
 		      typename Image::Value> Pair;
     typedef DigitalSetFromMap<Image> Self; 
@@ -268,6 +269,14 @@ namespace DGtal
      * @return a iterator on the element after the last in this set.
      */
     Iterator end();
+
+    /**
+     * Give access to the underlying container.
+     * @return a (might be const) reference to the stored container.
+    */
+    const Container & container() const { return *myImgPtr;};
+    /** @copydoc container() */
+    Container & container(){ return *myImgPtr;};
 
     /**
      * set union to left.

--- a/tests/images/testITKImage.cpp
+++ b/tests/images/testITKImage.cpp
@@ -122,6 +122,9 @@ bool testITKImage()
     trace.warning() << myImage(it) << " ";
   trace.info() << endl;
 
+  auto & container = myImage.container();
+  (void)container;
+
 
   trace.info() << "(" << nbok << "/" << nb << ") "
   << "true == true" << std::endl;

--- a/tests/kernel/testDigitalSet.cpp
+++ b/tests/kernel/testDigitalSet.cpp
@@ -197,6 +197,10 @@ bool testDigitalSet( const DigitalSetType& aSet1, const DigitalSetType& aSet2 )
   trace.info() << "Iterate: (" << nbok << "/" << nb << ") "
   	       << std::endl;
 
+  // access to underlying container
+  auto & container = set1.container();
+  (void)container; // remove unused warning
+
   //erasure
   set1.erase( b );
   nbok += ( (set1.size() == 2)


### PR DESCRIPTION
# PR Description

`container()` returns a reference (might be const) to the underlying
container holding the data.
It might point to an instance of Self type, Parent type, or to a protected/private
data member, depending on the type.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
