### PR TITLE
Fix doxygen errors in SurfaceMesh and DigitalConvexity

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
 - *Documentation*
   - Fix some small errors : includes, variable names, code example
     (adrien Krähenbühl, [#1525](https://github.com/DGtal-team/DGtal/pull/1525))
+  - Fix doxygen errors in DigitalConvexity, SurfaceMesh
+    (Pablo Hernandez-Cerdan [#1534](https://github.com/DGtal-team/DGtal/pull/1534))
 
 - *General*
   - Only set CMAKE_CXX_STANDARD if not defined already

--- a/src/DGtal/geometry/volumes/DigitalConvexity.h
+++ b/src/DGtal/geometry/volumes/DigitalConvexity.h
@@ -255,7 +255,7 @@ namespace DGtal
      * of lattice points.
      *
      * @tparam PointIterator any model of forward iterator on Point.
-     * @param[inout] out the output stream where information is outputed.
+     * @param[in, out] out the output stream where information is outputed.
      * @param itB the start of the range of n+1 points defining the simplex.
      * @param itE past the end the range of n+1 points defining the simplex.
      */
@@ -267,7 +267,7 @@ namespace DGtal
      * Displays information about simplex formed by the given list \a l
      * of lattice points.
      *
-     * @param[inout] out the output stream where information is outputed.
+     * @param[in, out] out the output stream where information is outputed.
      * @param l any list of lattice points.
      */
     static

--- a/src/DGtal/shapes/SurfaceMesh.h
+++ b/src/DGtal/shapes/SurfaceMesh.h
@@ -161,12 +161,13 @@ namespace DGtal
     /// @tparam RealPointIterator any forward iterator on RealPoint.
     /// @tparam VerticesIterator any forward iterator on the range of vertices defining a face.
     ///
-    /// @param itPos,itPosEnd a range of iterators pointing on the positions of all the
-    /// vertices of the mesh.
+    /// @param itPos start of range of iterators pointing on the positions of vertices of the mesh
+    /// @param itPosEnd end of range of iterators pointing on the positions of vertices of the mesh.
     ///
-    /// @param itVertices,itVerticesEnd a range of iterators pointing
-    /// on the (oriented) faces of the mesh, each face being a range
-    /// of vertex indices.
+    /// @param itVertices start of range of iterators pointing on the (oriented)
+    ///   faces of the mesh, each face being a range of vertex indices.
+    /// @param itVerticesEnd end of range of iterators pointing on the (oriented)
+    ///   faces of the mesh, each face being a range of vertex indices.
     ///
     /// A typical construction usage is
     /// @code
@@ -184,12 +185,13 @@ namespace DGtal
     /// @tparam RealPointIterator any forward iterator on RealPoint.
     /// @tparam VerticesIterator any forward iterator on a range of vertices.
     ///
-    /// @param itPos,itPosEnd a range of iterators pointing on the positions of all the
-    /// vertices of the mesh.
+    /// @param itPos start of range of iterators pointing on the positions of vertices of the mesh
+    /// @param itPosEnd end of range of iterators pointing on the positions of vertices of the mesh.
     ///
-    /// @param itVertices,itVerticesEnd a range of iterators pointing
-    /// on the (oriented) faces of the mesh, each face being a range
-    /// of vertex indices.
+    /// @param itVertices start of range of iterators pointing on the (oriented)
+    ///   faces of the mesh, each face being a range of vertex indices.
+    /// @param itVerticesEnd end of range of iterators pointing on the (oriented)
+    ///   faces of the mesh, each face being a range of vertex indices.
     ///
     /// A typical construction usage is
     /// @code


### PR DESCRIPTION
```cpp
[195/454] Building CXX object tests/geometry/volumes/CMakeFiles/testDigitalConvexity.dir/testDigitalConvexity.cpp.o

In file included from ../tests/geometry/volumes/testDigitalConvexity.cpp:38:

../src/DGtal/geometry/volumes/DigitalConvexity.h:258:14: warning: unrecognized parameter passing direction, valid directions are '[in]', '[out]' and '[in,out]' [-Wdocumentation]

     * @param[inout] out the output stream where information is outputed.

             ^~~~~~~

../src/DGtal/geometry/volumes/DigitalConvexity.h:270:14: warning: unrecognized parameter passing direction, valid directions are '[in]', '[out]' and '[in,out]' [-Wdocumentation]

     * @param[inout] out the output stream where information is outputed.

             ^~~~~~~

2 warnings generated.

[245/454] Building CXX object tests/geometry/surfaces/CMakeFiles/testShroudsRegularization.dir/testShroudsRegularization.cpp.o

In file included from ../tests/geometry/surfaces/testShroudsRegularization.cpp:35:

In file included from ../src/DGtal/helpers/Shortcuts.h:62:

In file included from ../src/DGtal/shapes/MeshHelpers.h:51:

../src/DGtal/shapes/SurfaceMesh.h:164:16: warning: parameter 'itPos,itPosEnd' not found in the function declaration [-Wdocumentation]

    /// @param itPos,itPosEnd a range of iterators pointing on the positions of all the

               ^~~~~~~~~~~~~~

../src/DGtal/shapes/SurfaceMesh.h:167:16: warning: parameter 'itVertices,itVerticesEnd' not found in the function declaration [-Wdocumentation]

    /// @param itVertices,itVerticesEnd a range of iterators pointing

               ^~~~~~~~~~~~~~~~~~~~~~~~

../src/DGtal/shapes/SurfaceMesh.h:187:16: warning: parameter 'itPos,itPosEnd' not found in the function declaration [-Wdocumentation]

    /// @param itPos,itPosEnd a range of iterators pointing on the positions of all the

               ^~~~~~~~~~~~~~

../src/DGtal/shapes/SurfaceMesh.h:190:16: warning: parameter 'itVertices,itVerticesEnd' not found in the function declaration [-Wdocumentation]

    /// @param itVertices,itVerticesEnd a range of iterators pointing

               ^~~~~~~~~~~~~~~~~~~~~~~~

In file included from ../tests/geometry/surfaces/testShroudsRegularization.cpp:36:

../src/DGtal/geometry/surfaces/ShroudsRegularization.h:63:11: warning: empty paragraph passed to '@see' command [-Wdocumentation]

  /// @see \ref moduleShrouds

      ~~~~^

5 warnings generated.

[247/454] Building CXX object tests/geometry/surfaces/CMakeFiles/testIntegralInvariantShortcuts.dir/testIntegralInvariantShortcuts.cpp.o

In file included from ../tests/geometry/surfaces/testIntegralInvariantShortcuts.cpp:38:

In file included from ../src/DGtal/helpers/Shortcuts.h:62:

In file included from ../src/DGtal/shapes/MeshHelpers.h:51:

../src/DGtal/shapes/SurfaceMesh.h:164:16: warning: parameter 'itPos,itPosEnd' not found in the function declaration [-Wdocumentation]

    /// @param itPos,itPosEnd a range of iterators pointing on the positions of all the

               ^~~~~~~~~~~~~~

../src/DGtal/shapes/SurfaceMesh.h:167:16: warning: parameter 'itVertices,itVerticesEnd' not found in the function declaration [-Wdocumentation]

    /// @param itVertices,itVerticesEnd a range of iterators pointing

               ^~~~~~~~~~~~~~~~~~~~~~~~

../src/DGtal/shapes/SurfaceMesh.h:187:16: warning: parameter 'itPos,itPosEnd' not found in the function declaration [-Wdocumentation]

    /// @param itPos,itPosEnd a range of iterators pointing on the positions of all the

               ^~~~~~~~~~~~~~

../src/DGtal/shapes/SurfaceMesh.h:190:16: warning: parameter 'itVertices,itVerticesEnd' not found in the function declaration [-Wdocumentation]

    /// @param itVertices,itVerticesEnd a range of iterators pointing

               ^~~~~~~~~~~~~~~~~~~~~~~~

In file included from ../tests/geometry/surfaces/testIntegralInvariantShortcuts.cpp:39:

In file included from ../src/DGtal/helpers/ShortcutsGeometry.h:54:

../src/DGtal/dec/ATSolver2D.h:201:13: warning: empty paragraph passed to '@see' command [-Wdocumentation]

    /// @see \ref DiscreteExteriorCalculusFactory for creating calculus objects.

        ~~~~^

In file included from ../tests/geometry/surfaces/testIntegralInvariantShortcuts.cpp:39:

../src/DGtal/helpers/ShortcutsGeometry.h:1378:15: warning: empty paragraph passed to '@see' command [-Wdocumentation]

      /// @see \ref moduleAT

          ~~~~^

../src/DGtal/helpers/ShortcutsGeometry.h:1433:15: warning: empty paragraph passed to '@see' command [-Wdocumentation]

      /// @see \ref moduleAT

          ~~~~^

../src/DGtal/helpers/ShortcutsGeometry.h:1501:15: warning: empty paragraph passed to '@see' command [-Wdocumentation]

      /// @see \ref moduleAT

          ~~~~^

../src/DGtal/helpers/ShortcutsGeometry.h:1556:15: warning: empty paragraph passed to '@see' command [-Wdocumentation]

      /// @see \ref moduleAT

          ~~~~^

9 warnings generated.

[253/454] Building CXX object tests/geometry/surfaces/CMakeFiles/testDigitalSurfaceRegularization.dir/testDigitalSurfaceRegularization.cpp.o

In file included from ../tests/geometry/surfaces/testDigitalSurfaceRegularization.cpp:35:

In file included from ../src/DGtal/helpers/Shortcuts.h:62:

In file included from ../src/DGtal/shapes/MeshHelpers.h:51:

../src/DGtal/shapes/SurfaceMesh.h:164:16: warning: parameter 'itPos,itPosEnd' not found in the function declaration [-Wdocumentation]

    /// @param itPos,itPosEnd a range of iterators pointing on the positions of all the

               ^~~~~~~~~~~~~~

../src/DGtal/shapes/SurfaceMesh.h:167:16: warning: parameter 'itVertices,itVerticesEnd' not found in the function declaration [-Wdocumentation]

    /// @param itVertices,itVerticesEnd a range of iterators pointing

               ^~~~~~~~~~~~~~~~~~~~~~~~

../src/DGtal/shapes/SurfaceMesh.h:187:16: warning: parameter 'itPos,itPosEnd' not found in the function declaration [-Wdocumentation]

    /// @param itPos,itPosEnd a range of iterators pointing on the positions of all the

               ^~~~~~~~~~~~~~

../src/DGtal/shapes/SurfaceMesh.h:190:16: warning: parameter 'itVertices,itVerticesEnd' not found in the function declaration [-Wdocumentation]

    /// @param itVertices,itVerticesEnd a range of iterators pointing

               ^~~~~~~~~~~~~~~~~~~~~~~~

In file included from ../tests/geometry/surfaces/testDigitalSurfaceRegularization.cpp:36:

In file included from ../src/DGtal/helpers/ShortcutsGeometry.h:54:

../src/DGtal/dec/ATSolver2D.h:201:13: warning: empty paragraph passed to '@see' command [-Wdocumentation]

    /// @see \ref DiscreteExteriorCalculusFactory for creating calculus objects.

        ~~~~^

In file included from ../tests/geometry/surfaces/testDigitalSurfaceRegularization.cpp:36:

../src/DGtal/helpers/ShortcutsGeometry.h:1378:15: warning: empty paragraph passed to '@see' command [-Wdocumentation]

      /// @see \ref moduleAT

          ~~~~^

../src/DGtal/helpers/ShortcutsGeometry.h:1433:15: warning: empty paragraph passed to '@see' command [-Wdocumentation]

      /// @see \ref moduleAT

          ~~~~^

../src/DGtal/helpers/ShortcutsGeometry.h:1501:15: warning: empty paragraph passed to '@see' command [-Wdocumentation]

      /// @see \ref moduleAT

          ~~~~^

../src/DGtal/helpers/ShortcutsGeometry.h:1556:15: warning: empty paragraph passed to '@see' command [-Wdocumentation]

      /// @see \ref moduleAT

          ~~~~^

9 warnings generated.
```

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
