### PR TITLE
Fix Color::getRGBA

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,10 @@
   - Fix BoundedLatticePolytope::init when using half-spaces initialization
     (Jacques-Olivier Lachaud,[#1531](https://github.com/DGtal-team/DGtal/pull/1531))
 
+- *IO*
+  - Fix Color::getRGBA
+    (Pablo Hernandez-Cerdan [#1535](https://github.com/DGtal-team/DGtal/pull/1535))
+
 
 # DGtal 1.1
 

--- a/src/DGtal/io/Color.h
+++ b/src/DGtal/io/Color.h
@@ -139,7 +139,7 @@ namespace DGtal
     Color& setRGBi( const unsigned char aRedValue,
 		    const unsigned char aGreenValue,
 		    const unsigned char aBlueValue,
-		    const unsigned char aAlphaValue );
+		    const unsigned char aAlphaValue = 255);
 
     /**
      * Set the color parameter from an unsigned integer coding each canal.

--- a/src/DGtal/io/Color.ih
+++ b/src/DGtal/io/Color.ih
@@ -174,7 +174,7 @@ DGtal::Color::getRGBA() const
 {
   return (((DGtal::uint32_t) myRed) <<  24) 
     |  (((DGtal::uint32_t) myGreen) << 16)
-    |  (((DGtal::uint32_t) myBlue)<< 16) 
+    |  (((DGtal::uint32_t) myBlue)<< 8) 
     |  ((DGtal::uint32_t) myAlpha); 
 }
  


### PR DESCRIPTION
Also add a default alpha to setRGBi for consistency with all the other
methods.

Spotted testing the wrappings in python.

# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
