### PR TITLE
Fix a plane probing unit test

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -66,7 +66,8 @@
     (Jacques-Olivier Lachaud,[#1531](https://github.com/DGtal-team/DGtal/pull/1531))
   - Fix an issue in DigitalSurfaceRegularization about bad buffer init
     (David Coeurjolly, [#1548](https://github.com/DGtal-team/DGtal/pull/1548))
-  - Fix an issue about a plane-probing unit test taking too long
+  - Fix issue [#1552](https://github.com/DGtal-team/DGtal/issues/1552) about a
+    plane-probing unit test taking too long
     (Jocelyn Meyron, [#1553](https://github.com/DGtal-team/DGtal/pull/1553))
 
 - *Shapes package*

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -66,6 +66,8 @@
     (Jacques-Olivier Lachaud,[#1531](https://github.com/DGtal-team/DGtal/pull/1531))
   - Fix an issue in DigitalSurfaceRegularization about bad buffer init
     (David Coeurjolly, [#1548](https://github.com/DGtal-team/DGtal/pull/1548))
+  - Fix an issue about a plane-probing unit test taking too long
+    (Jocelyn Meyron, [#1553](https://github.com/DGtal-team/DGtal/pull/1553))
 
 - *Shapes package*
   - Fix the use of uninitialized variable in NGon2D.

--- a/tests/geometry/surfaces/testPlaneProbingParallelepipedEstimator.cpp
+++ b/tests/geometry/surfaces/testPlaneProbingParallelepipedEstimator.cpp
@@ -86,13 +86,15 @@ struct TestPlaneProbingParallelepipedEstimator
 
 TEST_CASE( "Testing PlaneProbingParallelepipedEstimator" )
 {
+    static const int MAX_HEIGHT = 10;
+
     SECTION("H-algorithm should return the correct normal")
     {
         int nbNormals = 0;
         int nbOk = 0;
 
         for (const auto& n: NORMALS) {
-            for (int height = 0; height < int(n.normInfinity()); ++height) {
+            for (int height = 0; height < min(int(n.normInfinity()), MAX_HEIGHT); ++height) {
                 ++nbNormals;
 
                 TestPlaneProbingParallelepipedEstimator<int, ProbingMode::H>::compute
@@ -118,7 +120,7 @@ TEST_CASE( "Testing PlaneProbingParallelepipedEstimator" )
         int nbOk = 0;
 
         for (const auto& n: NORMALS) {
-            for (int height = 0; height < int(n.normInfinity()); ++height) {
+            for (int height = 0; height < min(int(n.normInfinity()), MAX_HEIGHT); ++height) {
                 ++nbNormals;
 
                 TestPlaneProbingParallelepipedEstimator<int, ProbingMode::R1>::compute
@@ -143,7 +145,6 @@ TEST_CASE( "Testing PlaneProbingParallelepipedEstimator" )
     {
         int nbNormals = 0;
         int nbOk = 0;
-        const int MAX_HEIGHT = 10;
 
         for (const auto& n: NORMALS_BIG) {
             for (int height = 0; height < MAX_HEIGHT; ++height) {


### PR DESCRIPTION
# PR Description

Fix a unit test about plane-probing estimators that is taking way too long.

Should I add en entry in the ChangeLog.md or is it not useful?

# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
