### PR TITLE
Cmake warning

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,10 +49,6 @@
 
 ## Bug fixes
 
-- *General*
-  - Comply with cmake Policy CMP0115 "Source file extensions must be
-  explicit". (David Coeurjolly, [#1557](https://github.com/DGtal-team/DGtal/pull/1557))
-
 - *Documentation*
   - Removing collaboration graphs in doxygen. Fixing doxygen warnings (David Coeurjolly,
     [#1537](https://github.com/DGtal-team/DGtal/pull/1537))
@@ -86,6 +82,8 @@
     [#1550](https://github.com/DGtal-team/DGtal/issues/1550))
   - Speedup of the compilation of the tests that rely on Catch2
     (Roland Denis [#1551](https://github.com/DGtal-team/DGtal/pull/1551))
+  - Comply with cmake Policy CMP0115 "Source file extensions must be
+    explicit". (David Coeurjolly, [#1557](https://github.com/DGtal-team/DGtal/pull/1557))
   
   
 # DGtal 1.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,10 @@
 
 ## Bug fixes
 
+- *General*
+  - Comply with cmake Policy CMP0115 "Source file extensions must be
+  explicit". (David Coeurjolly, [#1537](https://github.com/DGtal-team/DGtal/pull/1537))
+
 - *Documentation*
   - Removing collaboration graphs in doxygen. Fixing doxygen warnings (David Coeurjolly,
     [#1537](https://github.com/DGtal-team/DGtal/pull/1537))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -51,7 +51,7 @@
 
 - *General*
   - Comply with cmake Policy CMP0115 "Source file extensions must be
-  explicit". (David Coeurjolly, [#1537](https://github.com/DGtal-team/DGtal/pull/1537))
+  explicit". (David Coeurjolly, [#1557](https://github.com/DGtal-team/DGtal/pull/1557))
 
 - *Documentation*
   - Removing collaboration graphs in doxygen. Fixing doxygen warnings (David Coeurjolly,

--- a/examples/arithmetic/CMakeLists.txt
+++ b/examples/arithmetic/CMakeLists.txt
@@ -7,7 +7,7 @@ set(DGTAL_EXAMPLES_SRC
 )
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries ( ${FILE} DGtal)
 endforeach()
 
@@ -17,7 +17,7 @@ if ( WITH_GMP )
       extended-euclid
   )
   foreach(FILE ${DGTAL_EXAMPLES_GMP_SRC})
-    add_executable(${FILE} ${FILE})
+    add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries (${FILE} DGtal)
   endforeach()
 

--- a/examples/base/CMakeLists.txt
+++ b/examples/base/CMakeLists.txt
@@ -4,6 +4,6 @@ set(DGTAL_EXAMPLES_SRC
 )
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()

--- a/examples/dec/CMakeLists.txt
+++ b/examples/dec/CMakeLists.txt
@@ -9,7 +9,7 @@ if (WITH_CAIRO AND WITH_EIGEN AND WITH_QGLVIEWER)
         )
 
     foreach(FILE ${DGTAL_EXAMPLES_SRC_DEC})
-        add_executable(${FILE} ${FILE})
+        add_executable(${FILE} ${FILE}.cpp)
         target_link_libraries (${FILE} DGtal)
     endforeach()
 
@@ -22,7 +22,7 @@ if (WITH_EIGEN)
         )
 
     foreach(FILE ${DGTAL_EXAMPLES_SRC2_DEC})
-        add_executable(${FILE} ${FILE})
+        add_executable(${FILE} ${FILE}.cpp)
         target_link_libraries (${FILE} DGtal)
     endforeach()
 endif()

--- a/examples/doc-examples/CMakeLists.txt
+++ b/examples/doc-examples/CMakeLists.txt
@@ -11,7 +11,7 @@ if( WITH_VISU3D_QGLVIEWER  )
      )
 
 foreach(FILE ${DGTAL_DOC_EX_SRC_QGL})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE}  DGtal)
 endforeach()
 
@@ -19,7 +19,7 @@ endif()
 
 
 foreach(FILE ${DGTAL_DOC_EX_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal )
 endforeach()
 

--- a/examples/geometry/curves/CMakeLists.txt
+++ b/examples/geometry/curves/CMakeLists.txt
@@ -23,7 +23,7 @@ set(DGTAL_EXAMPLES_SRC
 
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal)
 endforeach()
 
@@ -34,7 +34,7 @@ if(MAGICK++_FOUND)
     freemanChainDisplay
     )
   foreach(FILE ${DGTALE_EXAMPLES_IO_Magick})
-    add_executable(${FILE} ${FILE})
+    add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries (${FILE} DGtal)
   endforeach()
 endif()
@@ -52,7 +52,7 @@ if (  WITH_VISU3D_QGLVIEWER )
      )
 
   foreach(FILE ${DGTAL_EXAMPLES_QGL_SRC} )
-   add_executable(${FILE} ${FILE})
+   add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries (${FILE} DGtal)
   endforeach()
 

--- a/examples/geometry/curves/estimation/CMakeLists.txt
+++ b/examples/geometry/curves/estimation/CMakeLists.txt
@@ -7,6 +7,6 @@ set(DGTAL_EXAMPLES_SRC
 
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()

--- a/examples/geometry/surfaces/CMakeLists.txt
+++ b/examples/geometry/surfaces/CMakeLists.txt
@@ -8,7 +8,7 @@ set(DGTAL_EXAMPLES_SRC
 )
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()
 
@@ -25,7 +25,7 @@ if (  WITH_VISU3D_QGLVIEWER )
     exampleMaximalSegmentSliceEstimation
    )
   foreach(FILE ${DGTAL_EXAMPLES_QGL_SRC})
-   add_executable(${FILE} ${FILE})
+   add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries ( ${FILE}  DGtal)
   endforeach()
 

--- a/examples/geometry/tools/CMakeLists.txt
+++ b/examples/geometry/tools/CMakeLists.txt
@@ -8,7 +8,7 @@ set(DGTAL_EXAMPLES_SRC
 
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()
 

--- a/examples/geometry/tools/determinant/CMakeLists.txt
+++ b/examples/geometry/tools/determinant/CMakeLists.txt
@@ -4,7 +4,7 @@ set(DGTAL_EXAMPLES_SRC
 
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()
 

--- a/examples/geometry/volumes/CMakeLists.txt
+++ b/examples/geometry/volumes/CMakeLists.txt
@@ -5,7 +5,7 @@ set(DGTAL_EXAMPLES_SRC
 )
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()
 

--- a/examples/geometry/volumes/distance/CMakeLists.txt
+++ b/examples/geometry/volumes/distance/CMakeLists.txt
@@ -7,7 +7,7 @@ set(DGTAL_EXAMPLES_SRC
 
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()
 
@@ -17,7 +17,7 @@ if (  WITH_VISU3D_QGLVIEWER )
   exampleFMM3D
    )
   foreach(FILE ${DGTAL_EXAMPLES_QGL_SRC}) 
-   add_executable(${FILE} ${FILE})
+   add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries ( ${FILE}  DGtal)   
   endforeach()
 

--- a/examples/graph/CMakeLists.txt
+++ b/examples/graph/CMakeLists.txt
@@ -3,7 +3,7 @@ set(DGTAL_EXAMPLES_TOPO_SRC
 )
 
 foreach(FILE ${DGTAL_EXAMPLES_TOPO_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE}  DGtal)
 endforeach()
 
@@ -13,7 +13,7 @@ if ( WITH_VISU3D_QGLVIEWER )
      volDistanceTraversal
    )
    foreach(FILE ${DGTAL_EXAMPLES_QGL_SRC})
-     add_executable(${FILE} ${FILE})
+     add_executable(${FILE} ${FILE}.cpp)
      target_link_libraries (${FILE}  DGtal)
    endforeach()
 endif()

--- a/examples/images/CMakeLists.txt
+++ b/examples/images/CMakeLists.txt
@@ -4,7 +4,7 @@ set(QGLVIEWER_EXAMPLES_SRC
 
 if (  WITH_VISU3D_QGLVIEWER )
   foreach(FILE ${QGLVIEWER_EXAMPLES_SRC})
-    add_executable(${FILE} ${FILE})
+    add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries (${FILE} DGtal)
   endforeach()
 endif()
@@ -28,6 +28,6 @@ if( WITH_HDF5 )
 endif()
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal)
 endforeach()

--- a/examples/io/CMakeLists.txt
+++ b/examples/io/CMakeLists.txt
@@ -3,7 +3,7 @@ set(DGTAL_EXAMPLES_IO_SRC
 )
 
 foreach(FILE ${DGTAL_EXAMPLES_IO_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal)
 endforeach()
 
@@ -16,7 +16,7 @@ if (  WITH_VISU3D_QGLVIEWER )
     viewDualSurface
     )
   foreach(FILE ${DGTAL_EXAMPLES_QGL_SRC})
-    add_executable(${FILE} ${FILE})
+    add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries (${FILE} DGtal)
   endforeach()
 

--- a/examples/io/boards/CMakeLists.txt
+++ b/examples/io/boards/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 
 FOREACH(FILE ${DGTAL_TESTS_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal )
 endforeach()
 

--- a/examples/io/viewers/CMakeLists.txt
+++ b/examples/io/viewers/CMakeLists.txt
@@ -22,13 +22,13 @@ set(DGTAL_TESTS_GMP_SRC
 )
 
 foreach(FILE ${DGTAL_TESTS_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal)
 endforeach()
 
 if(GMP_FOUND)
   foreach(FILE ${DGTAL_TESTS_GMP_SRC})
-    add_executable(${FILE} ${FILE})
+    add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries (${FILE} DGtal)
   endforeach()
 endif()

--- a/examples/kernel/CMakeLists.txt
+++ b/examples/kernel/CMakeLists.txt
@@ -9,6 +9,6 @@ if(WITH_OPENMP)
 endif()
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()

--- a/examples/math/CMakeLists.txt
+++ b/examples/math/CMakeLists.txt
@@ -5,6 +5,6 @@ set(DGTAL_EXAMPLES_MATH_SRC
 )
 
 foreach(FILE ${DGTAL_EXAMPLES_MATH_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal)
 endforeach()

--- a/examples/shapes/CMakeLists.txt
+++ b/examples/shapes/CMakeLists.txt
@@ -4,7 +4,7 @@ set(DGTAL_EXAMPLES_SRC
 )
 
 foreach(FILE ${DGTAL_EXAMPLES_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()
 
@@ -17,7 +17,7 @@ if (  WITH_VISU3D_QGLVIEWER )
      exampleSurfaceMesh
   )
   foreach(FILE ${DGTAL_SHAPES_EXAMPLES_QGL_SRC})
-    add_executable(${FILE} ${FILE})
+    add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries (${FILE} DGtal)
   endforeach()
 
@@ -30,7 +30,7 @@ if (WITH_EIGEN AND WITH_QGLVIEWER)
         )
 
     foreach(FILE ${DGTAL_EXAMPLES_SRC_DEC})
-        add_executable(${FILE} ${FILE})
+        add_executable(${FILE} ${FILE}.cpp)
         target_link_libraries (${FILE} DGtal )
     endforeach()
 

--- a/examples/topology/CMakeLists.txt
+++ b/examples/topology/CMakeLists.txt
@@ -17,7 +17,7 @@ set(DGTAL_EXAMPLES_TOPO_SRC
 )
 
 foreach(FILE ${DGTAL_EXAMPLES_TOPO_SRC})
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal)
 endforeach()
 
@@ -39,7 +39,7 @@ if (  WITH_VISU3D_QGLVIEWER )
      digitalSurfaceSlice
    )
   foreach(FILE ${DGTAL_EXAMPLES_QGL_SRC})
-    add_executable(${FILE} ${FILE})
+    add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries (${FILE} DGtal)
   endforeach()
 

--- a/examples/tutorial-examples/CMakeLists.txt
+++ b/examples/tutorial-examples/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach(FILE ${DGTAL_TUTO_EXAMPLES_SRC})
     set_source_files_properties( ${FILE} PROPERTIES COMPILE_FLAGS "/bigobj" )
   endif()
 
-  add_executable(${FILE} ${FILE})
+  add_executable(${FILE} ${FILE}.cpp)
   target_link_libraries (${FILE} DGtal  )
 endforeach()
 
@@ -28,7 +28,7 @@ if (WITH_VISU3D_QGLVIEWER)
     polyhedralizer
   )
   foreach(FILE ${DGTAL_TUTO_EXAMPLES_QGL_SRC})
-    add_executable(${FILE} ${FILE})
+    add_executable(${FILE} ${FILE}.cpp)
     target_link_libraries ( ${FILE} DGtal)
   endforeach()
 

--- a/src/Board/ModuleSRC.cmake
+++ b/src/Board/ModuleSRC.cmake
@@ -1,10 +1,10 @@
 
 set(BOARD_SRC ${BOARD_SRC}
-  Board/Board
-  Board/Path
-  Board/PSFonts
-  Board/Rect
-  Board/ShapeList
-  Board/Shapes
-  Board/Tools
-  Board/Transforms)
+  Board/Board.cpp
+  Board/Path.cpp
+  Board/PSFonts.cpp
+  Board/Rect.cpp
+  Board/ShapeList.cpp
+  Board/Shapes.cpp
+  Board/Tools.cpp
+  Board/Transforms.cpp)

--- a/tests/TestFunctions.cmake
+++ b/tests/TestFunctions.cmake
@@ -1,5 +1,5 @@
 function(DGtal_add_test test_file) #optional_avoid_add_test
-  add_executable(${test_file} ${test_file})
+  add_executable(${test_file} ${test_file}.cpp)
   target_link_libraries (${test_file} PRIVATE DGtal Catch2::Catch2 DGtalCatch)
   target_include_directories(${test_file} PRIVATE ${PROJECT_SOURCE_DIR}/tests/)
   target_include_directories(${test_file} PRIVATE ${PROJECT_BINARY_DIR}/tests/)

--- a/wrap/deploy/download_azure_artifacts.sh
+++ b/wrap/deploy/download_azure_artifacts.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Download all the wheels (artifacts) from the PythonDeploy pipeline.
 # The wheels are downloaded into /tmp/dist
 # They can be uploaded to pypi after that:


### PR DESCRIPTION
# PR Description

Making sure to comply with the new cmake Policy: 
 
```
   Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
```

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Travis & appveyor)
