### PR TITLE
Fix url app veyor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -103,6 +103,8 @@
     (Roland Denis [#1551](https://github.com/DGtal-team/DGtal/pull/1551))
   - Comply with cmake Policy CMP0115 "Source file extensions must be
     explicit". (David Coeurjolly, [#1557](https://github.com/DGtal-team/DGtal/pull/1557))
+  - Fix AppVeyor issue using new zlib URL.
+    (Bertrand Kerautret, [#1571](https://github.com/DGtal-team/DGtal/pull/1571))
   
   
 # DGtal 1.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ before_build:
 
   # install zlib
   - cmd: mkdir c:\zlib
-  - appveyor DownloadFile "http://ker.iutsd.univ-lorraine.fr/zlib-1.2.11.zip" -FileName zlib.zip
+  - appveyor DownloadFile "https://ipol-geometry.loria.fr/Sites/zlib-1.2.11.zip" -FileName zlib.zip
   - 7z x zlib.zip -oC:\zlib
   - cmd: cd C:\zlib
   - cmd: mkdir C:\zlib-install


### PR DESCRIPTION
# PR Description

Fix AppVeyor issue using new zlib URL

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Travis & appveyor)
