### PR TITLE
Fix Tools threshold for DGtalTools build 

### DIFF
--- a/.github/workflows/buildAndDocumentation.yml
+++ b/.github/workflows/buildAndDocumentation.yml
@@ -74,7 +74,7 @@ jobs:
            mkdir buildDGtalTools
            cd buildDGtalTools
            echo  cmake .. -DDGTAL_DIR=${{runner.workspace}}/build  -DDGTALTOOLS_RANDOMIZED_BUILD_THRESHOLD=25 -G Ninja
-           cmake .. -DDGtal_DIR=${{runner.workspace}}/build  -G Ninja
+           cmake .. -DDGtal_DIR=${{runner.workspace}}/build  -DDGTALTOOLS_RANDOMIZED_BUILD_THRESHOLD=25 -G Ninja
            ninja
 
   # Documentatin (build, check and deploy)


### PR DESCRIPTION
# PR Description

Fix Tools threshold for DGtalTools build not only in echo.

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor)
