### PR TITLE
bug fix in initialization of plane-probing computers on to digital surfaces

### DIFF
--- a/src/DGtal/geometry/surfaces/estimation/PlaneProbingDigitalSurfaceLocalEstimator.h
+++ b/src/DGtal/geometry/surfaces/estimation/PlaneProbingDigitalSurfaceLocalEstimator.h
@@ -309,9 +309,10 @@ namespace DGtal
      *
      * @param aInitialFrame an initial probing frame.
      * @param aPreEstimation a pre-estimation vector.
-     * @return aInitialFrame if no frame were found, the new frame otherwise.
+     * @return a pair (false, aInitialFrame) if no frame was found, 
+     * a pair (true, newFrame) if a frame 'newFrame' was found. 
      */
-    ProbingFrame probingFrameWithPreEstimation (ProbingFrame const& aInitialFrame, RealPoint const& aPreEstimation) const;
+    std::pair<bool, ProbingFrame> probingFrameWithPreEstimation (ProbingFrame const& aInitialFrame, RealPoint const& aPreEstimation) const;
 
     /**
      * @param x a scalar.

--- a/src/DGtal/geometry/surfaces/estimation/PlaneProbingDigitalSurfaceLocalEstimator.ih
+++ b/src/DGtal/geometry/surfaces/estimation/PlaneProbingDigitalSurfaceLocalEstimator.ih
@@ -114,48 +114,46 @@ eval (SurfelConstIterator it)
     // If no pre-estimation is given, we make one using maximal segments
     RealPoint preEstimation = getPreEstimation(it);
 
-    // Compute an initial frame using the pre-estimation
+    // Compute an initial frame from the surfel
     Surfel s = *it;
     ProbingFrame initialFrame = probingFrameFromSurfel(s);
-    ProbingFrame frame = probingFrameWithPreEstimation(initialFrame, preEstimation);
+    // Compute a frame from the initial one using the pre-estimation
+    std::pair<bool, ProbingFrame> res =
+      probingFrameWithPreEstimation(initialFrame, preEstimation);
 
-    // If the constructor of the probing estimator throws, we return the normal of the frame
-    // (this happens for instance when using a tetrahedron estimator on a digital surface,
-    // the initial frame will be considered invalid since not all the points of the upper
-    // triangle belong to the surface)
-    try
-    {
-        myProbingAlgorithm = myProbingFactory(frame, myPredicate);
-    }
-    catch (std::runtime_error const& e)
-    {
-        return frame.normal;
-    }
+    if (res.first) {
+      //If we have found a frame, we initialize the plane-probing algorithm
+      myProbingAlgorithm = myProbingFactory(res.second, myPredicate);
 
-    // We use slightly different versions depending on the number of zeros
-    // in the pre-estimation vector.
-    const auto zeros = findZeros(preEstimation);
+      // We use slightly different versions depending on the number of zeros
+      // in the pre-estimation vector.
+      const auto zeros = findZeros(preEstimation);
 
-    Point normal;
-    if (zeros.size() == 0)
-    {
-        normal = myProbingAlgorithm->compute();
-    }
-    else if (zeros.size() == 1)
-    {
-        int index = zeros[0];
-        normal = myProbingAlgorithm->compute(getProbingRaysOneFlatDirection(index));
-        // normal = getNormalOneFlatDirection(index);
-    }
-    else if (zeros.size() == 2)
-    {
-        normal = frame.normal;
-    }
+      Point normal;
+      if (zeros.size() == 0)
+	{
+	  normal = myProbingAlgorithm->compute();
+	}
+      else if (zeros.size() == 1)
+	{
+	  int index = zeros[0];
+	  normal = myProbingAlgorithm->compute(getProbingRaysOneFlatDirection(index));
+	}
+      else if (zeros.size() == 2)
+	{
+	  normal = res.second.normal;
+	}
 
-    delete myProbingAlgorithm;
-    myProbingAlgorithm = nullptr;
+      delete myProbingAlgorithm;
+      myProbingAlgorithm = nullptr;
 
-    return normal;
+      return normal;
+      
+    } else {
+      // If we have found no way to properly initialize the plane-probing estimator,
+      // we return the initial frame normal, i.e. the trivial normal of the surfel.  
+      return initialFrame.normal;
+    }
 }
 
 // ------------------------------------------------------------------------
@@ -261,20 +259,19 @@ probingFrameFromSurfel (Surfel const& aSurfel) const
 // ------------------------------------------------------------------------
 template < typename TSurface, typename TInternalProbingAlgorithm >
 inline
-typename DGtal::PlaneProbingDigitalSurfaceLocalEstimator<TSurface, TInternalProbingAlgorithm>::ProbingFrame
+std::pair<bool, typename DGtal::PlaneProbingDigitalSurfaceLocalEstimator<TSurface, TInternalProbingAlgorithm>::ProbingFrame >
 DGtal::PlaneProbingDigitalSurfaceLocalEstimator<TSurface, TInternalProbingAlgorithm>::
 probingFrameWithPreEstimation (ProbingFrame const& aInitialFrame, RealPoint const& aPreEstimation) const
 {
     ProbingFrame frame = aInitialFrame;
-    ProbingFrame frameQExt;
 
     for (int i = 0; i < 4; ++i)
     {
         Point shift = frame.shift();
+	// We search for a frame whose shift point is outside...
         if (! myPredicate(frame.p + shift))
         {
-            frameQExt = frame;
-
+	    //... and that matches the pre-estimation
             int signs = 0;
             signs += int(signComponent(shift[0]) == signComponent(aPreEstimation[0]));
             signs += int(signComponent(shift[1]) == signComponent(aPreEstimation[1]));
@@ -282,14 +279,15 @@ probingFrameWithPreEstimation (ProbingFrame const& aInitialFrame, RealPoint cons
 
             if (signs == 3)
             {
-                return frame;
+	        return std::make_pair(true, frame);
             }
         }
 
         frame = frame.rotatedCopy();
     }
 
-    return frameQExt;
+    // No frame that matches the pre-estimation found,
+    return std::make_pair(false, aInitialFrame); 
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/DGtal/geometry/surfaces/estimation/PlaneProbingParallelepipedEstimator.h
+++ b/src/DGtal/geometry/surfaces/estimation/PlaneProbingParallelepipedEstimator.h
@@ -107,7 +107,7 @@ namespace DGtal
            * @param aPoint any digital point.
            * @return true if the point is inside, false otherwise.
            */
-          bool InPlane (Point const& aPoint) const;
+          bool inPlane (Point const& aPoint) const;
 
           /**
            * The NotAbove predicate, see @cite LMRJMIV2020.
@@ -308,6 +308,14 @@ namespace DGtal
      * @return 'true' if the parallelepiped is still separating, 'false' otherwise.
      */
     bool translateIf (UpdateOperation const& aOp);
+
+    /**
+     * A shortcut to the inPlane function of 'myNotAbovePredicate'
+     * @param aPoint any digital point.
+     * @return true if the point is inside, false otherwise.
+     */
+    bool inPlane (Point const& aPoint) const;
+
   }; // end of class PlaneProbingParallelepipedEstimator
 
 

--- a/src/DGtal/geometry/surfaces/estimation/PlaneProbingParallelepipedEstimator.ih
+++ b/src/DGtal/geometry/surfaces/estimation/PlaneProbingParallelepipedEstimator.ih
@@ -89,7 +89,7 @@ template < typename TPredicate, DGtal::ProbingMode mode >
 inline
 bool
 DGtal::PlaneProbingParallelepipedEstimator<TPredicate, mode>::NotAbovePredicate::
-InPlane (Point const& aPoint) const
+inPlane (Point const& aPoint) const
 {
     return (*myPredicate)(aPoint);
 }
@@ -103,18 +103,18 @@ operator() (Point const& aPoint) const
 {
     Point u = aPoint - q(), s = q();
 
-    ASSERT(! InPlane(s));
+    ASSERT(! inPlane(s));
 
     Integer l = DGtal::NumberTraits<Integer>::ONE;
 
     while (l < myBound)
     {
-        if (InPlane(s + u * l))
+        if (inPlane(s + u * l))
         {
             return true;
         }
 
-        if (InPlane(s - u * l))
+        if (inPlane(s - u * l))
         {
             return false;
         }
@@ -169,7 +169,7 @@ inline
 bool
 DGtal::PlaneProbingParallelepipedEstimator<TPredicate, mode>::isSeparating () const
 {
-    return myNotAbovePredicate.InPlane(getOrigin()) != myNotAbovePredicate.InPlane(q());
+    return myNotAbovePredicate.inPlane(getOrigin()) != myNotAbovePredicate.inPlane(q());
 }
 
 // ------------------------------------------------------------------------
@@ -387,13 +387,22 @@ DGtal::PlaneProbingParallelepipedEstimator<TPredicate, mode>::getState () const
 
     for (int i = 0; i < 8; ++i)
     {
-        if (myNotAbovePredicate.InPlane(parallelepiped[i]))
+        if (inPlane(parallelepiped[i]))
         {
             ++inside;
         }
     }
 
     return inside;
+}
+
+// ------------------------------------------------------------------------
+template < typename TPredicate, DGtal::ProbingMode mode >
+inline
+bool
+DGtal::PlaneProbingParallelepipedEstimator<TPredicate, mode>::inPlane (const Point& aPoint) const
+{
+  return myNotAbovePredicate.inPlane(aPoint); 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -420,7 +429,10 @@ inline
 bool
 DGtal::PlaneProbingParallelepipedEstimator<TPredicate, mode>::isValid() const
 {
-    return myTetrahedronEstimator.isValid();
+  return ( ( ! inPlane( myTetrahedronEstimator.q() ) )
+	   && inPlane( myTetrahedronEstimator.getOrigin() )
+	   && myTetrahedronEstimator.isUnimodular()
+	   && myTetrahedronEstimator.isProjectedInside() );
 }
 
 

--- a/src/DGtal/geometry/surfaces/estimation/PlaneProbingTetrahedronEstimator.h
+++ b/src/DGtal/geometry/surfaces/estimation/PlaneProbingTetrahedronEstimator.h
@@ -273,12 +273,33 @@ namespace DGtal
      * @param out the output stream where the object is written.
      */
     void selfDisplay ( std::ostream & out ) const;
-
     /**
      * Checks the validity/consistency of the object.
      * @return 'true' if the object is valid, 'false' otherwise.
      */
     bool isValid() const;
+    /**
+     * Tests whether the fixed point 'q' projects the given triangle, along the current estimated normal.
+     *
+     * @param aTriangle the 3 points of the triangle.
+     */
+    bool isProjectedInside (Triangle const& aTriangle) const;
+    /**
+     * Tests whether the fixed point 'q' projects into the base, along the current estimated normal.
+     */
+    bool isProjectedInside () const;
+    /**
+     * Checks whether the predicate is true for all vertices of 
+     * the base triangle or not.
+     * @return 'true' if the object is valid, 'false' otherwise.
+     */
+    bool isInside() const; 
+    /**
+     * Checks whether the three vectors stored in 'myM'
+     * are the columns of a unimodular matrix or not.
+     * @return 'true' if the object is valid, 'false' otherwise.
+     */
+    bool isUnimodular() const;
 
     // ------------------------- Protected Datas ------------------------------
   protected:
@@ -294,13 +315,7 @@ namespace DGtal
 
     // ------------------------- Hidden services ------------------------------
   protected:
-    /**
-     * Tests whether the fixed point 'q' projects the given triangle, along the current estimated normal.
-     *
-     * @param aTriangle the 3 points of the triangle.
-     */
-    bool isProjectedInside (Triangle const& aTriangle) const;
-
+    
     // ------------------------- Internals ------------------------------------
   private:
     /**

--- a/src/DGtal/geometry/surfaces/estimation/PlaneProbingTetrahedronEstimator.ih
+++ b/src/DGtal/geometry/surfaces/estimation/PlaneProbingTetrahedronEstimator.ih
@@ -309,6 +309,76 @@ DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::translateQ ()
 // ------------------------------------------------------------------------
 template < typename TPredicate, DGtal::ProbingMode mode >
 inline
+void
+DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::applyOperation (UpdateOperation const& aOp)
+{
+    myM[aOp.sigma[0]] = aOp.coeffs[0] * myM[aOp.sigma[0]] + aOp.coeffs[1] * myM[aOp.sigma[1]] + aOp.coeffs[2] * myM[aOp.sigma[2]];
+}
+
+// ------------------------------------------------------------------------
+template < typename TPredicate, DGtal::ProbingMode mode >
+inline
+void
+DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::update (UpdateOperation const& aOp)
+{
+    applyOperation(aOp);
+    myOperations.push_back(aOp);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Interface - public :
+
+// ------------------------------------------------------------------------
+template <typename TPredicate, DGtal::ProbingMode mode>
+inline
+void
+DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::selfDisplay ( std::ostream & out ) const
+{
+  out << "[PlaneProbingTetrahedronEstimator]";
+}
+
+// ------------------------------------------------------------------------
+template <typename TPredicate, DGtal::ProbingMode mode>
+inline
+bool
+DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::isValid() const
+{
+  return ( isUnimodular() && isProjectedInside() );
+}
+
+// ------------------------------------------------------------------------
+template <typename TPredicate, DGtal::ProbingMode mode>
+inline
+bool
+DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::isInside() const
+{
+    Triangle v = vertices();
+    for (int i = 0; i < 3; ++i) {
+        if (! myPredicate(v[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// ------------------------------------------------------------------------
+template <typename TPredicate, DGtal::ProbingMode mode>
+inline
+bool
+DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::isUnimodular() const
+{
+    Point nest = getNormal();
+    for (int i = 0; i < 3; ++i) {
+        if (myM[i].dot(nest) != 1) {
+            return false;
+        }
+    }
+    return true; 
+}
+
+// ------------------------------------------------------------------------
+template < typename TPredicate, DGtal::ProbingMode mode >
+inline
 bool
 DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::isProjectedInside (Triangle const& aTriangle) const
 {
@@ -331,66 +401,12 @@ DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::isProjectedInside (Tr
 // ------------------------------------------------------------------------
 template < typename TPredicate, DGtal::ProbingMode mode >
 inline
-void
-DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::applyOperation (UpdateOperation const& aOp)
-{
-    myM[aOp.sigma[0]] = aOp.coeffs[0] * myM[aOp.sigma[0]] + aOp.coeffs[1] * myM[aOp.sigma[1]] + aOp.coeffs[2] * myM[aOp.sigma[2]];
-}
-
-// ------------------------------------------------------------------------
-template < typename TPredicate, DGtal::ProbingMode mode >
-inline
-void
-DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::update (UpdateOperation const& aOp)
-{
-    applyOperation(aOp);
-    myOperations.push_back(aOp);
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Interface - public :
-
-/**
- * Writes/Displays the object on an output stream.
- * @param out the output stream where the object is written.
- */
-template <typename TPredicate, DGtal::ProbingMode mode>
-inline
-void
-DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::selfDisplay ( std::ostream & out ) const
-{
-  out << "[PlaneProbingTetrahedronEstimator]";
-}
-
-/**
- * Checks the validity/consistency of the object.
- * @return 'true' if the object is valid, 'false' otherwise.
- */
-template <typename TPredicate, DGtal::ProbingMode mode>
-inline
 bool
-DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::isValid() const
+DGtal::PlaneProbingTetrahedronEstimator<TPredicate, mode>::isProjectedInside () const
 {
-    Triangle v = vertices();
-    for (int i = 0; i < 3; ++i) {
-        if (! myPredicate(v[i])) {
-            return false;
-        }
-    }
-
-    Point nest = getNormal();
-    for (int i = 0; i < 3; ++i) {
-        if (myM[i].dot(nest) != 1) {
-            return false;
-        }
-    }
-
-    if (! isProjectedInside(v)) {
-        return false;
-    }
-
-    return true;
+  return isProjectedInside(vertices()); 
 }
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // Implementation of inline functions                                        //


### PR DESCRIPTION
# PR Description

There was a bug in ExamplePlaneProbingSurfaceLocalEstimator (when built in Debug mode). It was caused by a bad validity check and a corner case in the initialization step, because a computer may not be always initialized (See method 'eval' in PlaneProbingDigitalSurfaceLocalEstimator). ExamplePlaneProbingSurfaceLocalEstimator can now be run without error. 

# Checklist

(Not relevant for a bug fix)

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.

- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor)
