### PR TITLE
Disabling examples build by default.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,7 +22,7 @@
   - New cmake targets to collect cmake, doxygen and markdown files (David Coeurjolly,
     [#1609](https://github.com/DGtal-team/DGtal/pull/1609))
   - Examples are not built anymore by default (BUILD_EXAMPLES now set to OFF by default).
-    (David Coeurjolly, [#16xx](https://github.com/DGtal-team/DGtal/pull/16xx))
+    (David Coeurjolly, [#1630](https://github.com/DGtal-team/DGtal/pull/1630))
 
 - *DEC*
   - New discrete differential operators on polygonal meshes have been

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,8 @@
     Actions. (David Coeurjolly, [#1591](https://github.com/DGtal-team/DGtal/pull/1591))
   - New cmake targets to collect cmake, doxygen and markdown files (David Coeurjolly,
     [#1609](https://github.com/DGtal-team/DGtal/pull/1609))
+  - Examples are not built anymore by default (BUILD_EXAMPLES now set to OFF by default).
+    (David Coeurjolly, [#16xx](https://github.com/DGtal-team/DGtal/pull/16xx))
 
 - *DEC*
   - New discrete differential operators on polygonal meshes have been

--- a/cmake/BuildExamples.cmake
+++ b/cmake/BuildExamples.cmake
@@ -1,4 +1,4 @@
-option(BUILD_EXAMPLES "Build examples." ON)
+option(BUILD_EXAMPLES "Build examples." OFF)
 if (BUILD_EXAMPLES)
   message(STATUS "Build examples ENABLED")
   add_subdirectory (${PROJECT_SOURCE_DIR}/examples)

--- a/tests/io/writers/testCompressedVolWriter.cpp
+++ b/tests/io/writers/testCompressedVolWriter.cpp
@@ -79,9 +79,11 @@ TEST_CASE( "Testing CompressedVolWriter" )
   SECTION("Testing write/read of CompressedVolWriter")
   {
     Image read = VolReader<Image>::importVol("test.vol");
+    trace.info()<<read<<std::endl;
     REQUIRE( (checkImage(image,read) == true)) ;
     
     Image readz = VolReader<Image>::importVol("testz.vol");
+    trace.info()<<readz<<std::endl;
     REQUIRE( (checkImage(image,readz) == true)) ;
   }
 }


### PR DESCRIPTION
# PR Description

Setting BUILD_EXAMPLES to OFF by default.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions & appveyor)
