### PR TITLE
Fix testLongvol and testCompressedVolWriter

### DIFF
--- a/.github/workflows/buildAndDocumentation-PR.yml
+++ b/.github/workflows/buildAndDocumentation-PR.yml
@@ -9,7 +9,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE:   Release
-  TESTBLACKLIST: "(testCompressedVolWriter|testLongvol|testLinearStructure)"
+  TESTBLACKLIST: "(testLinearStructure)"
   CONFIG_GLOBAL: -DBUILD_EXAMPLES=true -DBUILD_TESTING=true -DDGTAL_RANDOMIZED_TESTING_THRESHOLD=25
   CONFIG_LINUX:  -DWITH_MAGICK=true -DWITH_GMP=true -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DWITH_HDF5=true -DWITH_QGLVIEWER=true -DWITH_CAIRO=true    -DWITH_EIGEN=true  -DWITH_ITK=true -DDGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS=true
   CONFIG_MAC:  -DWITH_EIGEN=true -DWITH_GMP=true

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -123,6 +123,9 @@
     (Bertrand Kerautret, [#1611](https://github.com/DGtal-team/DGtal/pull/1611)
   - Minor fixes in VolReader and LongVolReader to be able to load large vol files.
     (David Coeurjolly, [#1637](https://github.com/DGtal-team/DGtal/pull/1637))
+  - Fix LongVolReader that fails to read large values. It was why testLongvol and
+    testCompressedVolWriter were failing on some configurations.
+    (Roland Denis, [#1638](https://github.com/DGtal-team/DGtal/pull/1638))
 
 - *Geometry package*
   - the following changes have been made to fix a bug in `examplePlaneProbingSurfaceLocalEstimator`:

--- a/src/DGtal/io/readers/LongvolReader.h
+++ b/src/DGtal/io/readers/LongvolReader.h
@@ -130,14 +130,7 @@ namespace DGtal
     static
     std::stringstream& read_word( std::stringstream & fin, Word& aValue )
     {
-      aValue = 0;
-      char c;
-      for (unsigned int size = 0; size < sizeof( Word ); ++size)
-      {
-        fin.get( c ) ;
-        unsigned char cc=static_cast<unsigned char>(c);
-        aValue |= (cc << (8 * size));
-      }
+      fin.get(reinterpret_cast<char*>(&aValue), sizeof(Word) + 1);
       return fin;
     }
     

--- a/src/DGtal/io/readers/LongvolReader.h
+++ b/src/DGtal/io/readers/LongvolReader.h
@@ -130,7 +130,9 @@ namespace DGtal
     static
     std::stringstream& read_word( std::stringstream & fin, Word& aValue )
     {
-      fin.get(reinterpret_cast<char*>(&aValue), sizeof(Word) + 1);
+      char* raw = reinterpret_cast<char*>(&aValue);
+      for (std::size_t i = 0; i < sizeof(Word); ++i)
+          raw[i] = fin.get();
       return fin;
     }
     

--- a/tests/io/testLongvol.cpp
+++ b/tests/io/testLongvol.cpp
@@ -62,7 +62,7 @@ bool testLongvol()
   typedef ImageContainerBySTLVector<Z3i::Domain, DGtal::uint64_t> Image;
   Image image(Z3i::Domain(a,b));
   
-  image.setValue(c,45693);
+  image.setValue(c,0X8899AABBCCDDEEFFull);
   
   LongvolWriter<Image>::exportLongvol("export-longvol.longvol",image);
  
@@ -72,8 +72,7 @@ bool testLongvol()
   Image::ConstIterator ito = image.begin();
   for(Image::ConstIterator it = image2.begin(), itend=image2.end();
       it != itend; ++it, ++ito)
-    if (((*it) != 0 ) || ((*ito) != 0))
-    allFine &= ( ((*it)*(*ito)) != 0);
+    allFine &= (*it) == (*ito);
       
   nbok += allFine ? 1 : 0; 
   nb++;

--- a/tests/io/writers/testCompressedVolWriter.cpp
+++ b/tests/io/writers/testCompressedVolWriter.cpp
@@ -93,7 +93,7 @@ TEST_CASE( "Testing CompressedLongvol" )
   Domain domain(Point(0,0,0), Point(2,2,2));
   typedef ImageContainerBySTLVector<Domain, DGtal::uint64_t> Image;
   Image image(domain);
-  image.setValue(Point(1,1,1), 4222222);
+  image.setValue(Point(1,1,1), 0X8899AABBCCDDEEFFull);
   
   SECTION("Testing API of CompressedVolWriter")
     {


### PR DESCRIPTION
# PR Description

Fix `testLongvol` and `testCompressedVolWriter` that was failing on some configurations.

Actually, it was due to a left-shift overflow (eg a 56 bits left-shift of a `char`) in the `read_word` method of `LongvolReader` and it was possible to make tests failing on more configurations by making tested value larger (see first commit).

# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions & appveyor)
