### PR TITLE
Adding DEC examples

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -110,7 +110,7 @@
     (David Coeurjolly, [#1628](https://github.com/DGtal-team/DGtal/pull/1628))
   - OpenMP fix in DGtalConfig on macOS M1 (David Coeurjolly,
     [#1641](https://github.com/DGtal-team/DGtal/pull/1641))
-    
+
 - *Examples*
   - We can now have examples using [polyscope](https://polyscope.run)
     as viewer (`BUILD_POLYSCOPE_EXAMPLES` cmake variable). (David
@@ -130,16 +130,20 @@
     (Roland Denis, [#1638](https://github.com/DGtal-team/DGtal/pull/1638))
 
 - *Geometry package*
-  - the following changes have been made to fix a bug in `examplePlaneProbingSurfaceLocalEstimator`:
+  - The following changes have been made to fix a bug in `examplePlaneProbingSurfaceLocalEstimator`:
     - in `PlaneProbingDigitalSurfaceLocalEstimator`, the method `probingFrameWithPreEstimation` now
       returns a pair bool-frame instead of just a frame, in order to tell whether the frame will lead
       to a valid initialization or not. The method `eval` now uses this boolean value and returns the
       trivial normal vector if it has been set to 'False'.
-  - in `PlaneProbingParallelepipedEstimator`: `isValid` does not call the `isValid` method of the
-    delegate, but only checks the relevant parts (which have been pushed in to separate methods).
-    (Tristan Roussillon, [#1607](https://github.com/DGtal-team/DGtal/pull/1607))
+    - in `PlaneProbingParallelepipedEstimator`: `isValid` does not call the `isValid` method of the
+     delegate, but only checks the relevant parts (which have been pushed in to separate methods).
+     (Tristan Roussillon, [#1607](https://github.com/DGtal-team/DGtal/pull/1607))
   - Fixing issue with the automatic deploy of the "nightly" documentation.
-    (Davi Coeurjolly, [#1620](https://github.com/DGtal-team/DGtal/pull/1620)
+    (David Coeurjolly, [#1620](https://github.com/DGtal-team/DGtal/pull/1620))
+
+- *DEC*
+  - More DEC examples can be built without QGLViewer (they didn't need it).
+    (David Coeurjolly, [#1642](https://github.com/DGtal-team/DGtal/pull/1642))
 
 # DGtal 1.2
 

--- a/examples/dec/CMakeLists.txt
+++ b/examples/dec/CMakeLists.txt
@@ -2,10 +2,7 @@ if (WITH_CAIRO AND WITH_EIGEN AND WITH_QGLVIEWER)
 
     set(DGTAL_EXAMPLES_SRC_DEC
         exampleDECSurface
-        exampleDiscreteExteriorCalculusUsage
         exampleDiscreteExteriorCalculusSolve
-        exampleDiscreteExteriorCalculusChladni
-        exampleHeatLaplace
         )
 
     foreach(FILE ${DGTAL_EXAMPLES_SRC_DEC})
@@ -18,6 +15,10 @@ if (WITH_EIGEN)
     set(DGTAL_EXAMPLES_SRC2_DEC
         examplePropagation
         exampleSurfaceATNormals
+        exampleHeatLaplace
+        exampleDiscreteExteriorCalculusChladni
+        exampleDiscreteExteriorCalculusUsage
+
         )
 
     foreach(FILE ${DGTAL_EXAMPLES_SRC2_DEC})

--- a/examples/dec/exampleHeatLaplace.cpp
+++ b/examples/dec/exampleHeatLaplace.cpp
@@ -42,7 +42,6 @@
 
 #include <DGtal/io/readers/GenericReader.h>
 #include <DGtal/io/colormaps/ColorBrightnessColorMap.h>
-#include <DGtal/io/viewers/Viewer3D.h>
 #include <DGtal/io/colormaps/TickedColorMap.h>
 #include "DGtal/io/readers/GenericReader.h"
 

--- a/src/DGtal/dec/doc/moduleDECEmbedding.dox
+++ b/src/DGtal/dec/doc/moduleDECEmbedding.dox
@@ -82,8 +82,8 @@ See \ref sectDECPoisson1D for an example.
 
 | @a add_border | boundary condition of primal operators                          | boundary condition of dual operators                            |
 |---------------|-----------------------------------------------------------------|-----------------------------------------------------------------|
-| @a true       | Neumann \f$\Delta f(x) \cdot n(x)=0~\forall x \in \partial M\f$ | Dirichlet \f$f(x)=0~\forall x \in \partial M\f$                 |
-| @a false      | Dirichlet \f$f(x)=0~\forall x \in \partial M\f$                 | Neumann \f$\Delta f(x) \cdot n(x)=0~\forall x \in \partial M\f$ |
+| @a true       | Neumann \f$\nabla f(x) \cdot n(x)=0~\forall x \in \partial M\f$ | Dirichlet \f$f(x)=0~\forall x \in \partial M\f$                 |
+| @a false      | Dirichlet \f$f(x)=0~\forall x \in \partial M\f$                 | Neumann \f$\nabla f(x) \cdot n(x)=0~\forall x \in \partial M\f$ |
 
 \section sectDECEmbeddingExample1D 1D examples
 


### PR DESCRIPTION
# PR Description

Some DEC examples were not built without QGLViewer but they didn't use it. 

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions & appveyor)
