### PR TITLE
Add missing <map> header in MeshReader.h files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Johanna Delanoy <johanna.delanoy@inria.fr>
 Phuc Ngo <hoai-diem-phuc.ngo@loria.fr>
 J. Miguel Salazar <msalazar@centrogeo.edu.mx>
 Robin Lamy <robin.lamy1@grenoble-inp.org>
+Jeremy Fix <https://github.com/jeremyfix>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -139,6 +139,7 @@
   - Fix LongVolReader that fails to read large values. It was why testLongvol and
     testCompressedVolWriter were failing on some configurations.
     (Roland Denis, [#1638](https://github.com/DGtal-team/DGtal/pull/1638))
+  - Fix missing `#include<map>` in MeshReaeder (Jeremy Fix, [#1649](https://github.com/DGtal-team/DGtal/pull/1649))
 
 - *Geometry package*
   - The following changes have been made to fix a bug in `examplePlaneProbingSurfaceLocalEstimator`:

--- a/src/DGtal/io/readers/MeshReader.h
+++ b/src/DGtal/io/readers/MeshReader.h
@@ -42,6 +42,7 @@
 // Inclusions
 #include <iostream>
 #include <map>
+#include <string>
 #include <DGtal/kernel/SpaceND.h>
 #include "DGtal/base/Common.h"
 #include "DGtal/shapes/Mesh.h"

--- a/src/DGtal/io/readers/MeshReader.h
+++ b/src/DGtal/io/readers/MeshReader.h
@@ -41,6 +41,7 @@
 //////////////////////////////////////////////////////////////////////////////
 // Inclusions
 #include <iostream>
+#include <map>
 #include <DGtal/kernel/SpaceND.h>
 #include "DGtal/base/Common.h"
 #include "DGtal/shapes/Mesh.h"

--- a/src/DGtal/io/readers/MeshReader.ih
+++ b/src/DGtal/io/readers/MeshReader.ih
@@ -37,6 +37,7 @@
 #include <fstream>
 #include <sstream>
 #include <map>
+#include <string>
 //////////////////////////////////////////////////////////////////////////////
 
 #include "DGtal/helpers/StdDefs.h"

--- a/src/DGtal/io/readers/MeshReader.ih
+++ b/src/DGtal/io/readers/MeshReader.ih
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <map>
 //////////////////////////////////////////////////////////////////////////////
 
 #include "DGtal/helpers/StdDefs.h"


### PR DESCRIPTION
This adds the <map> header in MeshReader.h and MeshReader.ih which appears to be missing although these headers use std::map ;

This was pointed out on my side when compiling the DGTalTools binaries; One of them included MeshReader.h (I think that was not the ih being included) and the compilation failed due to unknown map class. 