### PR TITLE
Try to fix warning in DistanceBreadthFirstVisitor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -175,6 +175,10 @@
   - Improving PolygonalCalculus and VectorHeatMethod for vector field processing on non-manifold surfaces.
     (David Coeurjolly, [#1659](https://github.com/DGtal-team/DGtal/pull/1659))
 
+- *graph*
+  - Fix warning related to copy assignment in class DistanceBreadthFirstVisitor
+    (Jacques-Olivier Lachaud, [#1662](https://github.com/DGtal-team/DGtal/pull/1662))
+
 # DGtal 1.2
 
 ## New Features / Critical Changes

--- a/src/DGtal/graph/DistanceBreadthFirstVisitor.h
+++ b/src/DGtal/graph/DistanceBreadthFirstVisitor.h
@@ -232,12 +232,8 @@ while ( ! visitor.finished() )
       using Base::first;
       using Base::second;
 
-      inline Node()
-        : std::pair< Vertex, Scalar >()
-      {}
-      inline Node( const Node & other )
-        : std::pair< Vertex, Scalar >( other )
-      {}
+      inline Node() = default;
+      inline Node( const Node & other ) = default;
       inline Node( const Vertex & v, Scalar d )
         : std::pair< Vertex, Scalar >( v, d )
       {}


### PR DESCRIPTION
# PR Description

Fix warning in DistanceBreadthFirstVisitor about implicit copy assignment operator definition.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions & appveyor)
