### PR TITLE
Removing WITH_BENCHMARK

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,8 @@
 - *General*
   - Fix of couple of doxygen warnings that cause errors on Github Actions
     CI bots. (David Coeurjolly, [#1672](https://github.com/DGtal-team/DGtal/pull/1672))
+  - Removing "WITH_BENCHMARK" option as Google Benchmark is already included when building
+    the unit tests. (David Coeurjolly, [#16xx](https://github.com/DGtal-team/DGtal/pull/16xx))
 
 # DGtal 1.3
 

--- a/cmake/CheckDGtalOptionalDependencies.cmake
+++ b/cmake/CheckDGtalOptionalDependencies.cmake
@@ -20,7 +20,6 @@ option(WITH_CAIRO "With CairoGraphics." OFF)
 option(WITH_HDF5 "With HDF5." OFF)
 option(WITH_QGLVIEWER "With LibQGLViewer for 3D visualization (Qt5 required)." OFF)
 option(WITH_PATATE "With Patate library for geometry OFF (Eigen required)." processing)
-option(WITH_BENCHMARK "With Google Benchmark." OFF)
 option(WITH_FFTW3 "With FFTW3 discrete Fourier Transform library." OFF)
 
 #----------------------------------


### PR DESCRIPTION
# PR Description

Removing the WITH_BENCHMARK option (already included)
# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions & appveyor)
