### PR TITLE
fix KhalimskySpaceND to get it work with BigInteger

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,10 @@
   - Removing "WITH_BENCHMARK" option as Google Benchmark is already included when building
     the unit tests. (David Coeurjolly, [#1674](https://github.com/DGtal-team/DGtal/pull/1674))
 
+- *Topology package*
+  - Fix KhalimskySpaceND to get it work with BigInteger (Tristan Roussillon,
+    [#1681](https://github.com/DGtal-team/DGtal/pull/1681)
+
 - *IO*
   - Fix of the `getHSV` method in the `Color` class. (David Coeurjolly,
     [#1674](https://github.com/DGtal-team/DGtal/pull/1674))

--- a/src/DGtal/kernel/domains/HyperRectDomain.h
+++ b/src/DGtal/kernel/domains/HyperRectDomain.h
@@ -565,7 +565,7 @@ namespace DGtal
     Size size() const
       {
         Size res = 1;
-        for(auto i=0; i < Space::dimension; ++i)
+        for(Dimension i=0; i < Space::dimension; ++i)
           res *= static_cast<Size>(NumberTraits<Coordinate>::castToUInt64_t(myUpperBound[i] - myLowerBound[i] + 1));
         return res;
       }

--- a/src/DGtal/topology/KhalimskyPreSpaceND.ih
+++ b/src/DGtal/topology/KhalimskyPreSpaceND.ih
@@ -657,7 +657,7 @@ DGtal::Dimension
 DGtal::KhalimskyPreSpaceND< dim, TInteger>::
 uDim( const Cell & p )
 {
-  Integer i = NumberTraits<Integer>::ZERO;
+  DGtal::Dimension i = NumberTraits<DGtal::Dimension>::ZERO;
   for ( DGtal::Dimension k = 0; k < DIM; ++k )
     if ( NumberTraits<Integer>::odd( p.coordinates[ k ] ) )
       ++i;
@@ -670,7 +670,7 @@ DGtal::Dimension
 DGtal::KhalimskyPreSpaceND< dim, TInteger>::
 sDim( const SCell & p )
 {
-  Integer i = NumberTraits<Integer>::ZERO;
+  DGtal::Dimension i = NumberTraits<DGtal::Dimension>::ZERO;
   for ( DGtal::Dimension k = 0; k < DIM; ++k )
     if ( NumberTraits<Integer>::odd( p.coordinates[ k ] ) )
       ++i;

--- a/src/DGtal/topology/KhalimskySpaceND.h
+++ b/src/DGtal/topology/KhalimskySpaceND.h
@@ -486,7 +486,20 @@ namespace DGtal
 
     /// Default constructor.
     KhalimskySpaceND();
-
+    
+    /** @brief Constructor from upper and lower bounds for the maximal cells in
+     * this space.
+     *
+     * @param lower the lowest point in this space (digital coords)
+     * @param upper the upper point in this space (digital coords)
+     * @param isClosed 'true' if this space is closed and non-periodic in every dimension, 'false' if open.
+     *
+     * @see init()
+     */
+    KhalimskySpaceND( const Point & lower,
+		      const Point & upper,
+		      bool isClosed );
+    
     /** @brief Copy constructor.
      *
      * @param other the object to clone.

--- a/src/DGtal/topology/KhalimskySpaceND.ih
+++ b/src/DGtal/topology/KhalimskySpaceND.ih
@@ -452,6 +452,16 @@ KhalimskySpaceND()
 //-----------------------------------------------------------------------------
 template < DGtal::Dimension dim, typename TInteger>
 inline
+DGtal::KhalimskySpaceND< dim, TInteger>::
+KhalimskySpaceND( const Point & lower,
+		  const Point & upper,
+		  bool isClosed)
+{
+  init( lower, upper, isClosed );
+}
+//-----------------------------------------------------------------------------
+template < DGtal::Dimension dim, typename TInteger>
+inline
 bool
 DGtal::KhalimskySpaceND< dim, TInteger>::
 init( const Point & lower,

--- a/tests/topology/testKhalimskySpaceND.cpp
+++ b/tests/topology/testKhalimskySpaceND.cpp
@@ -968,3 +968,11 @@ TEST_CASE("3D test interior/exterior voxels to a digital surface")
   
   
 }
+
+#ifdef WITH_BIGINTEGER
+TEST_CASE("with BigInteger")
+{
+  KhalimskySpaceND<3,BigInteger> K( {0,0,0}, {1000,1000,1000}, true );
+  REQUIRE(true); 
+}
+#endif


### PR DESCRIPTION
# PR Description

We've modified types in  two functions (uDim, sDim) to get KhalimskySpaceND work with BigInteger. 
We've also added a ctor because the default one cannot deal with unbounded integers.  

# Checklist

- [x ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions & appveyor)
