### PR TITLE
option to put material part inside obj file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
 - *IO*
   - New method to change the mode of the light position in Viewer3D (fixed to 
     camera or the scene) (Bertrand Kerautret, [#1683](https://github.com/DGtal-team/DGtal/pull/1683))
-  - Add alternative to store material inside obj file in MeshReader and MeshWriter.
+  - Add a new method to store material information in obj file in MeshReader and MeshWriter.
     (Bertrand Kerautret, [#1686](https://github.com/DGtal-team/DGtal/pull/1686))
 
 - *Github*

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,8 @@
 - *IO*
   - New method to change the mode of the light position in Viewer3D (fixed to 
     camera or the scene) (Bertrand Kerautret, [#1683](https://github.com/DGtal-team/DGtal/pull/1683))
-
+  - Add alternative to store material inside obj file in MeshReader and MeshWriter.
+    (Bertrand Kerautret, [#1685](https://github.com/DGtal-team/DGtal/pull/1685))
 
 - *Github*
   - New `/builddoc` and `/fullbuild` commands on PR comments (David Coeurjolly, 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@
   - New method to change the mode of the light position in Viewer3D (fixed to 
     camera or the scene) (Bertrand Kerautret, [#1683](https://github.com/DGtal-team/DGtal/pull/1683))
   - Add alternative to store material inside obj file in MeshReader and MeshWriter.
-    (Bertrand Kerautret, [#1685](https://github.com/DGtal-team/DGtal/pull/1685))
+    (Bertrand Kerautret, [#1686](https://github.com/DGtal-team/DGtal/pull/1686))
 
 - *Github*
   - New `/builddoc` and `/fullbuild` commands on PR comments (David Coeurjolly, 

--- a/src/DGtal/io/readers/MeshReader.ih
+++ b/src/DGtal/io/readers/MeshReader.ih
@@ -393,8 +393,10 @@ importOBJFile( const std::string & filename, DGtal::Mesh<TPoint> & mesh )
         std::stringstream matPathName ;
         matPathName << path << name;
         std::ifstream is (matPathName.str());
-        material = MeshReader<TPoint>::readMaterial(is);
-        useMtllib = true;
+        if (is.good()){
+          material = MeshReader<TPoint>::readMaterial(is);
+          useMtllib = true;
+        }
       }
       else if (keyword ==  "usemtl")
       {

--- a/src/DGtal/io/readers/MeshReader.ih
+++ b/src/DGtal/io/readers/MeshReader.ih
@@ -336,6 +336,10 @@ importOBJFile( const std::string & filename, DGtal::Mesh<TPoint> & mesh )
       trace.error() << "MeshReader : can't open " << filename << std::endl;
       throw dgtalio;
     }
+  material = MeshReader<TPoint>::readMaterial(input);
+  useMtllib = !material.empty();
+  input.close();
+  input.open (filename.c_str(), std::ifstream::in);
   std::getline( input, linestr );
   Index l = 0;
   for ( ; input.good() && ! input.eof(); std::getline( input, linestr ), l++ )

--- a/src/DGtal/io/writers/MeshWriter.h
+++ b/src/DGtal/io/writers/MeshWriter.h
@@ -111,13 +111,24 @@ namespace DGtal
      * 
      * @param[out] out the output stream of the exported OBJ object.
      * @param[out] outMTL the output stream associated to the material file.
-     * @param[in] nameMTLFile the file name of the material file.
+     * @param[in] nameMTLFile the file name of the material file. If an empty string is given, the material will be written inside the output stream.
      * @param[in] aMesh the Mesh object to be exported.
      * @return true if no errors occur.
      */
     
     static bool export2OBJ_colors(std::ostream &out, std::ostream &outMTL,
                                   const std::string nameMTLFile,
+                                  const  Mesh<TPoint>  &aMesh);
+
+     /** 
+     * Export a Mesh towards a OBJ format including face colors.
+     * The material containing face colors will be written inside the resulting .obj file.
+     * @param[out] out the output stream of the exported OBJ object.
+     * @param[in] aMesh the Mesh object to be exported.
+     * @return true if no errors occur.
+     */
+    
+    static bool export2OBJ_colors(std::ostream &out,
                                   const  Mesh<TPoint>  &aMesh);
     
     

--- a/src/DGtal/io/writers/MeshWriter.ih
+++ b/src/DGtal/io/writers/MeshWriter.ih
@@ -135,11 +135,13 @@ DGtal::MeshWriter<TPoint>::export2OBJ_colors(std::ostream &out, std::ostream &ou
       out << std::endl;
       out << "o anObj" << std::endl;
       out << std::endl;
-      out << "mtllib " << nameMTLFile << std::endl;
-      
-      
-      outMTL << "#  MTL format"<< std::endl;
-      outMTL << "# generated from MeshWriter from the DGTal library"<< std::endl;
+      if (nameMTLFile != "")
+      {
+        out << "mtllib " << nameMTLFile << std::endl;
+        outMTL << "#  MTL format"<< std::endl;
+        outMTL << "# generated from MeshWriter from the DGTal library"<< std::endl;
+ 
+      }
       
       std::map<DGtal::Color, unsigned int > mapMaterial;
       
@@ -160,10 +162,10 @@ DGtal::MeshWriter<TPoint>::export2OBJ_colors(std::ostream &out, std::ostream &ou
           colF.first = c;
           colF.second = mapMaterial.size();
           // add new color in material
-          outMTL << "newmtl material_" << mapMaterial.size() << std::endl;
-          outMTL << "Ka 0.200000 0.200000 0.200000" << std::endl;
-          outMTL << "Kd " << colF.first.red()/255.0 << " " << colF.first.green()/255.0 << " " <<  colF.first.blue()/255.0 << std::endl;
-          outMTL << "Ks 1.000000 1.000000 1.000000" << std::endl;
+          (nameMTLFile != "" ? outMTL : out) << "newmtl material_" << mapMaterial.size() << std::endl;
+          (nameMTLFile != "" ? outMTL : out) << "Ka 0.200000 0.200000 0.200000" << std::endl;
+          (nameMTLFile != "" ? outMTL : out) << "Kd " << colF.first.red()/255.0 << " " << colF.first.green()/255.0 << " " <<  colF.first.blue()/255.0 << std::endl;
+          (nameMTLFile != "" ? outMTL : out) << "Ks 1.000000 1.000000 1.000000" << std::endl;
           mapMaterial.insert(colF);
         }else{
           materialIndex = mapMaterial[c];
@@ -186,6 +188,13 @@ DGtal::MeshWriter<TPoint>::export2OBJ_colors(std::ostream &out, std::ostream &ou
   return true;
 }
 
+template<typename TPoint>
+inline
+bool 
+DGtal::MeshWriter<TPoint>::export2OBJ_colors(std::ostream &out,  
+                                             const  DGtal::Mesh<TPoint> & aMesh) {
+  return DGtal::MeshWriter<TPoint>::export2OBJ_colors(out, out, "", aMesh);
+}
 
 
 


### PR DESCRIPTION
# PR Description
Even if it is not the default behavior this option can usefully to simplify the display and archive of online demonstrations.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions & appveyor)
