### PR TITLE
Add option to CMake: DGTAL_WRAP_PYTHON

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,9 @@
 ## Changes
 - *General*
   - Renaming AUTHORS→CONTRIBUTORS for HAL (David Coeurjolly, [#1699](https://github.com/DGtal-team/DGtal/pull/1699))
+
+- *Project*
+  - Add CMake option DGTAL_WRAP_PYTHON (Pablo Hernandez-Cerdan, [#1700](https://github.com/DGtal-team/DGtal/pull/1700))
     
 - *IO*
   - New method to change the mode of the light position in Viewer3D (fixed to

--- a/cmake/PythonWrappings.cmake
+++ b/cmake/PythonWrappings.cmake
@@ -1,3 +1,4 @@
+option(DGTAL_WRAP_PYTHON "Compile python wrappings" OFF)
 if(DGTAL_WRAP_PYTHON)
   # Fetch pybind11
   include(FetchContent)

--- a/src/DGtal/topology/VoxelComplex.ih
+++ b/src/DGtal/topology/VoxelComplex.ih
@@ -190,8 +190,7 @@ inline void
 DGtal::VoxelComplex<TKSpace, TCellContainer>::insertVoxelCell(
     const Cell &kcell, const bool &close_it, const Data &data)
 {
-    const auto &ks = this->space();
-    ASSERT(ks.uDim(kcell) == 3);
+    ASSERT(this->space().uDim(kcell) == 3);
     this->insertCell(3, kcell, data);
     if (close_it)
         voxelClose(kcell);
@@ -513,8 +512,7 @@ DGtal::VoxelComplex<TKSpace, TCellContainer>::K_2(const Cell &face2,
     ASSERT(ks.uIsSurfel(face2));
     using KPreSpace = typename TKSpace::PreCellularGridSpace;
     const auto co_faces = KPreSpace::uCoFaces(face2);
-    const auto nco_faces = co_faces.size();
-    ASSERT(nco_faces == 2);
+    ASSERT(co_faces.size() == 2);
     const auto &cf0 = co_faces[0];
     const auto &cf1 = co_faces[1];
     // spels must belong to complex.

--- a/wrap/images/ImageContainerBySTLVector_declare_py.h
+++ b/wrap/images/ImageContainerBySTLVector_declare_py.h
@@ -64,14 +64,14 @@ using Is3D = typename std::enable_if<TPoint::dimension == 3>::type;
 template<typename TT>
 void def_toindices(pybind11::class_<TT> & py_class,
         Is2D<typename TT::Point> * = nullptr) {
-    py_class.def("toindices", [](const TT & self, const typename TT::Point & a_point) {
+    py_class.def("toindices", [](const TT &, const typename TT::Point & a_point) {
             return pybind11::make_tuple(a_point[1], a_point[0]);
     }, "Return tuple of the i,j,k-coordinates of the input point in the c_style format: (k,j,i)");
 }
 template<typename TT>
 void def_toindices(pybind11::class_<TT> & py_class,
         Is3D<typename TT::Point> * = nullptr) {
-    py_class.def("toindices", [](const TT & self, const typename TT::Point & a_point) {
+    py_class.def("toindices", [](const TT &, const typename TT::Point & a_point) {
             return pybind11::make_tuple(a_point[2], a_point[1], a_point[0]);
     }, "Return tuple of the i,j,k-coordinates of the input point in the c_style format: (k,j,i)");
 }

--- a/wrap/kernel/HyperRectDomain_declare_py.h
+++ b/wrap/kernel/HyperRectDomain_declare_py.h
@@ -45,7 +45,7 @@ The following code snippet demonstrates how to use \p HyperRectDomain
 )";
     auto py_class = py::class_<TT>(m, typestr.c_str(), docs.c_str());
 
-    py_class.def("dtype", [](const TT &self) {
+    py_class.def("dtype", [](const TT &) {
             return DGtal::Python::Integer_str;
             });
     // ----------------------- Constructors -----------------------------------


### PR DESCRIPTION
# PR Description

Add option to CMake: DGTAL_WRAP_PYTHON for it to appear in ccmake and
other GUI interfaces to CMake.

OFF by default.

Also fix a few warnings in release mode

# Checklist

- [NA] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [NA] Doxygen documentation of the code completed (classes, methods, types, members...)
- [NA] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions & appveyor)