### PR TITLE
Fix typo in SurfaceMeshWriter::writeIsoLinesOBJ

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -57,6 +57,8 @@
 - *IO*
   - Fix of the `getHSV` method in the `Color` class. (David Coeurjolly,
     [#1674](https://github.com/DGtal-team/DGtal/pull/1674))
+  - Fix of `SurfaceMeshWriter::writeIsoLinesOBJ` 
+    (Jacques-Olivier Lachaud, [#1701](https://github.com/DGtal-team/DGtal/pull/1701))
 
 - *Examples*
   - Fix Issue #1675, add missing SymmetricConvexExpander.h file

--- a/src/DGtal/io/writers/SurfaceMeshWriter.ih
+++ b/src/DGtal/io/writers/SurfaceMeshWriter.ih
@@ -326,7 +326,7 @@ writeIsoLinesOBJ( std::string            objfile,
                                 << " Weird iso-line on face " << f << std::endl;
               else {
                 for ( Size ii = 0; ii < crossings.size(); ++ii )
-                  for ( Size j = i+1; j < crossings.size(); ++j )
+                  for ( Size j = ii+1; j < crossings.size(); ++j )
                     {
                       RealVector pq = crossings[ j ] - crossings[ ii ];
                       if ( pq.squaredNorm() < 1e-8 ) continue;


### PR DESCRIPTION
# PR Description

When outputting several isolines on a SurfaceMesh with method SurfaceMeshWriter::writeIsoLinesOBJ, the isolines were only partially outputted. The problem was the reuse of an outer variable loop in an inner loop. The fix has been checked in an external project.

# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions & appveyor)
