### PR TITLE
Fix cmake conan download issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,4 @@
 - [ ] Documentation module page added or updated.
 - [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
 - [ ] No warning raised in Debug mode.
-- [ ] All continuous integration tests pass (Github Actions & appveyor)
+- [ ] All continuous integration tests pass (Github Actions)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,7 +35,7 @@
 ## Bug fixes
 - *General*
   - Fix conan file upload issue and log message. (Bertrand Kerautret,
-    [#1702](https://github.com/DGtal-team/DGtal/pull/1702))
+    [#1704](https://github.com/DGtal-team/DGtal/pull/1704))
   - Fix of couple of doxygen warnings that cause errors on Github Actions
     CI bots. (David Coeurjolly, [#1672](https://github.com/DGtal-team/DGtal/pull/1672))
   - Removing "WITH_BENCHMARK" option as Google Benchmark is already included when building

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,6 +34,8 @@
 
 ## Bug fixes
 - *General*
+  - Fix conan file upload issue and log message. (Bertrand Kerautret,
+    [#1702](https://github.com/DGtal-team/DGtal/pull/1702))
   - Fix of couple of doxygen warnings that cause errors on Github Actions
     CI bots. (David Coeurjolly, [#1672](https://github.com/DGtal-team/DGtal/pull/1672))
   - Removing "WITH_BENCHMARK" option as Google Benchmark is already included when building

--- a/cmake/CheckDGtalDependencies.cmake
+++ b/cmake/CheckDGtalDependencies.cmake
@@ -22,7 +22,7 @@ if (ENABLE_CONAN)
                 TLS_VERIFY ON)
   endif()
 
-  include(${CMAKE_BINARY_DIR}/conan.cmake)
+  include("${CMAKE_BINARY_DIR}/conan.cmake")
 
   conan_cmake_configure(REQUIRES zlib/1.2.13
                                  boost/1.81.0

--- a/cmake/CheckDGtalDependencies.cmake
+++ b/cmake/CheckDGtalDependencies.cmake
@@ -19,7 +19,17 @@ if (ENABLE_CONAN)
     message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
     file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
                 "${CMAKE_BINARY_DIR}/conan.cmake"
+                 STATUS DOWNLOAD_STATUS
                 TLS_VERIFY ON)
+    list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+    list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
+    # Check if download was successful.
+    if(${STATUS_CODE} EQUAL 0)
+       message(STATUS "Download completed successfully!")
+    else()
+     # Exit CMake if the download failed, printing the error message.
+       message(FATAL_ERROR "Error occurred during download: ${ERROR_MESSAGE}")
+    endif()
   endif()
 
   include("${CMAKE_BINARY_DIR}/conan.cmake")

--- a/cmake/CheckDGtalDependencies.cmake
+++ b/cmake/CheckDGtalDependencies.cmake
@@ -20,15 +20,24 @@ if (ENABLE_CONAN)
     file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
                 "${CMAKE_BINARY_DIR}/conan.cmake"
                  STATUS DOWNLOAD_STATUS
-                TLS_VERIFY OFF)
+                 TLS_VERIFY ON)
     list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
     list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
     # Check if download was successful.
     if(${STATUS_CODE} EQUAL 0)
        message(STATUS "Download completed successfully!")
     else()
-     # Exit CMake if the download failed, printing the error message.
-       message(FATAL_ERROR "Error occurred during download: ${ERROR_MESSAGE}")
+       message(STATUS "Error occurred during download: ${ERROR_MESSAGE}")
+       message(STATUS "Trying turning TLS_VERIFY OFF")
+       file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
+                     "${CMAKE_BINARY_DIR}/conan.cmake"
+                      STATUS DOWNLOAD_STATUS
+                      TLS_VERIFY OFF)
+       if(${STATUS_CODE} EQUAL 0)
+         message(STATUS "Download completed successfully!")
+       else()
+         message(FATAL_ERROR "Error occurred during download: ${ERROR_MESSAGE}")
+       endif()
     endif()
   endif()
 

--- a/cmake/CheckDGtalDependencies.cmake
+++ b/cmake/CheckDGtalDependencies.cmake
@@ -33,6 +33,8 @@ if (ENABLE_CONAN)
                      "${CMAKE_BINARY_DIR}/conan.cmake"
                       STATUS DOWNLOAD_STATUS
                       TLS_VERIFY OFF)
+       list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+       list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)                   
        if(${STATUS_CODE} EQUAL 0)
          message(STATUS "Download completed successfully!")
        else()

--- a/cmake/CheckDGtalDependencies.cmake
+++ b/cmake/CheckDGtalDependencies.cmake
@@ -20,7 +20,7 @@ if (ENABLE_CONAN)
     file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
                 "${CMAKE_BINARY_DIR}/conan.cmake"
                  STATUS DOWNLOAD_STATUS
-                TLS_VERIFY ON)
+                TLS_VERIFY OFF)
     list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
     list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
     # Check if download was successful.


### PR DESCRIPTION
# PR Description

Sometimes the conan file download fails due to TLS mode, if PR check the download issue and turn off TLS to avoid the problem.

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions & appveyor)
