### PR TITLE
Checking the Conan build time (6h) on windows debug

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,9 @@
 
 ## Bug fixes
 - *General*
+  - For now, removing Cairo deps install on windows (6hours long build 
+    with conan in the windows debug mode). (David Coeurjolly, 
+    [#1705](https://github.com/DGtal-team/DGtal/pull/1705))
   - Fix conan file upload issue and log message. (Bertrand Kerautret,
     [#1704](https://github.com/DGtal-team/DGtal/pull/1704))
   - Fix of couple of doxygen warnings that cause errors on Github Actions

--- a/cmake/CheckDGtalDependencies.cmake
+++ b/cmake/CheckDGtalDependencies.cmake
@@ -49,11 +49,11 @@ if (ENABLE_CONAN)
                                  boost/1.81.0
                                  gmp/6.2.1
                                  fftw/3.3.9
-                                 cairo/1.17.6
-                                 libpng/1.6.39 #Explicit fix deps (compat issues)
-                                 expat/2.5.0
-                                 openssl/1.1.1s
-                                 libiconv/1.17
+                                 #cairo/1.17.6
+                                 #libpng/1.6.39 #Explicit fix deps (compat issues)
+                                 #expat/2.5.0
+                                 #openssl/1.1.1s
+                                 #libiconv/1.17
                       OPTIONS boost:header_only=True
                               gmp:enable_cxx=True
                       GENERATORS cmake_find_package)


### PR DESCRIPTION
# PR Description

At this point, removing Cairo (and its numerous deps) from Conan on windows.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions)
