### PR TITLE
Activate Ctest on windows

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -100,7 +100,8 @@ jobs:
        shell: bash
        run: |
            echo ctest -C ${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
-           ctest -C $${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
+           ctest -C ${{ matrix.BUILD_TYPE }} --output-on-failure -E $TESTBLACKLIST  
+
 
      - name: DGtalTools (linux only, we check this PR against DGtalTools master)
        if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -94,6 +94,13 @@ jobs:
            echo ctest -C ${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
            ctest -C $${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
 
+     - name: Test
+       working-directory: ${{runner.workspace}}/build
+       if: matrix.os == 'windows-latest' 
+       shell: bash
+       run: |
+           echo ctest -C ${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
+           ctest -C $${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
 
      - name: DGtalTools (linux only, we check this PR against DGtalTools master)
        if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/buildAndDocumentation-PR.yml
+++ b/.github/workflows/buildAndDocumentation-PR.yml
@@ -100,7 +100,7 @@ jobs:
        shell: bash
        run: |
            echo ctest -C ${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
-           ctest -C ${{ matrix.BUILD_TYPE }} -E $TESTBLACKLIST  
+           ctest -C ${{ matrix.BUILD_TYPE }} --output-on-failure -E $TESTBLACKLIST  
 
 
      - name: DGtalTools (linux only, we check this PR against DGtalTools master)

--- a/.github/workflows/buildAndDocumentation-PR.yml
+++ b/.github/workflows/buildAndDocumentation-PR.yml
@@ -94,6 +94,14 @@ jobs:
            echo ctest -C ${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
            ctest -C $${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
 
+     - name: Test
+       working-directory: ${{runner.workspace}}/build
+       if: matrix.os == 'windows-latest' 
+       shell: bash
+       run: |
+           echo ctest -C ${{ matrix.BUILD_TYPE }}  --output-on-failure -E $TESTBLACKLIST
+           ctest -C ${{ matrix.BUILD_TYPE }} -E $TESTBLACKLIST  
+
 
      - name: DGtalTools (linux only, we check this PR against DGtalTools master)
        if: matrix.os == 'ubuntu-latest'

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,8 @@
 
 ## Bug fixes
 - *General*
+  - Activate and fix CTest tests on windows system. (Bertrand Kerautret,
+    [#1706](https://github.com/DGtal-team/DGtal/pull/1706))
   - For now, removing Cairo deps install on windows (6hours long build 
     with conan in the windows debug mode). (David Coeurjolly, 
     [#1705](https://github.com/DGtal-team/DGtal/pull/1705))

--- a/tests/TestFunctions.cmake
+++ b/tests/TestFunctions.cmake
@@ -8,7 +8,7 @@ function(DGtal_add_test test_file) #optional_avoid_add_test
     target_include_directories(${test_file} PRIVATE ${PROJECT_SOURCE_DIR}/tests/)
     target_include_directories(${test_file} PRIVATE ${PROJECT_BINARY_DIR}/tests/)
     if(NOT ${ARGC} GREATER 1)
-      add_test(${test_file} ${test_file})
+      add_test(NAME ${test_file} COMMAND ${test_file})
     endif()
   endif()
 endfunction()


### PR DESCRIPTION
# PR Description
Fix issue #1693 
The key issue was to use the signature with NAME and COMMAND that allows to replace test command with full path (as mentioned in the cmake add_test doc [here](https://cmake.org/cmake/help/v3.7/command/add_test.html) 

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions)
