### PR TITLE
Cleaning up unnecessary  ModuleSRC files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ message(STATUS "Done.")
 # each subdir can contain a ModuleSRC.txt file
 # with a set command on the variable ${DGTAL_SRC}
 #
-include(src/DGtal/kernel/ModuleSRC.cmake)
 include(src/DGtal/base/ModuleSRC.cmake)
 include(src/DGtal/io/ModuleSRC.cmake)
 include(src/DGtal/helpers/ModuleSRC.cmake)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -63,6 +63,8 @@
     [#1691](https://github.com/DGtal-team/DGtal/pull/1691))
   - Cleanup of cmake targets when BUILD_TESTING is disabled (David Coeurjolly
     [#1698](https://github.com/DGtal-team/DGtal/pull/1698))
+  - Cleaning up unnecessary ModuleSRC.cmake files (David Coeurjolly
+    [#16xx](https://github.com/DGtal-team/DGtal/pull/16xx))
 
 - *Topology package*
   - Fix KhalimskySpaceND to get it work with BigInteger (Tristan Roussillon,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -64,7 +64,7 @@
   - Cleanup of cmake targets when BUILD_TESTING is disabled (David Coeurjolly
     [#1698](https://github.com/DGtal-team/DGtal/pull/1698))
   - Cleaning up unnecessary ModuleSRC.cmake files (David Coeurjolly
-    [#16xx](https://github.com/DGtal-team/DGtal/pull/16xx))
+    [#1711](https://github.com/DGtal-team/DGtal/pull/1711))
 
 - *Topology package*
   - Fix KhalimskySpaceND to get it work with BigInteger (Tristan Roussillon,

--- a/src/DGtal/helpers/ModuleSRC.cmake
+++ b/src/DGtal/helpers/ModuleSRC.cmake
@@ -1,4 +1,4 @@
 
 set(DGTAL_SRC ${DGTAL_SRC} 
-    DGtal/helpers/StdDefs)
+    DGtal/helpers/StdDefs.cpp)
 

--- a/src/DGtal/kernel/ModuleSRC.cmake
+++ b/src/DGtal/kernel/ModuleSRC.cmake
@@ -1,6 +1,0 @@
-## Sources associated to the module kernel
-##
-
-set(DGTAL_SRC ${DGTAL_SRC} 
-		DGtal/kernel/NumberTraits)
-


### PR DESCRIPTION
# PR Description

This should fix some cmake issues.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions)
