### PR TITLE
Removing warnings for libIGL related code on GCC and Clang

### DIFF
--- a/src/DGtal/shapes/WindingNumbersShape.h
+++ b/src/DGtal/shapes/WindingNumbersShape.h
@@ -41,12 +41,23 @@
 #include <DGtal/base/Common.h>
 #include <DGtal/base/CountedConstPtrOrConstPtr.h>
 #include <DGtal/base/ConstAlias.h>
-
 #include <DGtal/shapes/CEuclideanOrientedShape.h>
+
+
+//Removing Warnings from libIGL for gcc and clang
+#pragma GCC system_header  // For GCC
+#pragma clang system_header  // For Clang
+
 #include <igl/fast_winding_number.h>
 #include <igl/octree.h>
 #include <igl/knn.h>
 #include <igl/copyleft/cgal/point_areas.h>
+
+#pragma GCC diagnostic pop  // For GCC
+#pragma clang diagnostic pop  // For Clang
+
+
+
 namespace DGtal
 {
   /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# PR Description


# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions)
