### PR TITLE
Minor typos in the CMakeLists

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,9 @@
 
 ## Bug fixes
 
+- *General*
+  - Fixing typos int the cmake script (David Coeurjolly, [#1739](https://github.com/DGtal-team/DGtal/pull/1739))
+
 - *DEC*
   - Minor update of the DEC package documentation (David Coeurjolly, [#1734](https://github.com/DGtal-team/DGtal/pull/1734))
 

--- a/cmake/CheckDGtalOptionalDependencies.cmake
+++ b/cmake/CheckDGtalOptionalDependencies.cmake
@@ -99,7 +99,7 @@ endif()
 
 
 if (WITH_LIBIGL)
-  set(LIST_OPTION ${LIST_OPTION} [FFTW3]\ )
+  set(LIST_OPTION ${LIST_OPTION} [LIBIGL]\ )
   message(STATUS "      WITH_LIBIGL        true    (libIGL)")
 else (WITH_LIBIGL)
   message(STATUS "      WITH_LIBIGL        false   (libIGL)")

--- a/src/DGtal/shapes/WindingNumbersShape.h
+++ b/src/DGtal/shapes/WindingNumbersShape.h
@@ -201,7 +201,7 @@ namespace DGtal
       Eigen::VectorXd O_R;
       Eigen::MatrixXd O_EC;
       
-      //Checking if the areas
+      //Computing the WN values
       igl::fast_winding_number(*myPoints,*myNormals,myPointAreas,myO_PI,myO_CH,2,O_CM,O_R,O_EC);
       igl::fast_winding_number(*myPoints,*myNormals,myPointAreas,myO_PI,myO_CH,O_CM,O_R,O_EC,queries,2,W);
     }


### PR DESCRIPTION
# PR Description

Just minor typos.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions)
