### PR TITLE
Bugfix in TestArithmeticalDSSOnSurfels

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # DGtal 1.5beta
 
+## Bug fixes
+- *Geometry*
+  - Bug fix in ArithmeticalDSSComputerOnSurfels (Tristan Roussillon, [#1742](https://github.com/DGtal-team/DGtal/pull/1742))
 
 # DGtal 1.4.1
 

--- a/src/DGtal/geometry/doc/moduleMaximalSegmentSliceEstimation.dox
+++ b/src/DGtal/geometry/doc/moduleMaximalSegmentSliceEstimation.dox
@@ -69,7 +69,7 @@ using Surfel    = KSpace::SCell;
 using Container = std::vector<Surfel>;
 using Integer   = int;
 short adjacency = 4;
-using SegmentComputerOnSurfels = ArithmeticalDSSComputerOnSurfels<KSpace, Container::const_iterator, Integer, adjacency>;
+using SegmentComputerOnSurfels = ArithmeticalDSSComputerOnSurfels<KSpace, Container::const_iterator, Integer>;
 
 // Instantiation
 SegmentComputerOnSurfels computer(kspace, // A 3D Khalimsky space

--- a/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.h
+++ b/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.h
@@ -48,7 +48,7 @@
 #include "DGtal/base/Common.h"
 #include "DGtal/kernel/SpaceND.h"
 #include "DGtal/kernel/PointVector.h"
-#include <DGtal/kernel/BasicPointFunctors.h>
+#include "DGtal/kernel/BasicPointFunctors.h"
 #include "DGtal/kernel/CInteger.h"
 #include "DGtal/base/ReverseIterator.h"
 #include "DGtal/geometry/curves/ArithmeticalDSS.h"

--- a/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.h
+++ b/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.h
@@ -400,7 +400,7 @@ namespace DGtal
      * Returns the ends of a unit segment corresponding 
      * to the projection of a given signed linel. 
      *
-     * @param aSurfel any signed surfel.
+     * @param aLinel any signed linel.
      * @return a pair of 2D points. 
      */
     std::pair<Point,Point> getProjectedPointsFromLinel(SCell const& aLinel) const; 

--- a/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.h
+++ b/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.h
@@ -62,8 +62,10 @@ namespace DGtal
   // class ArithmeticalDSSComputerOnSurfels
   /**
    * \brief Aim: This class is a wrapper around ArithmeticalDSS that is devoted
-   * to the dynamic recognition of digital straight segments (DSS) along any
-   * sequence of 3D surfels.
+   * to the dynamic recognition of digital straight segments (DSS) along a 
+   * sequence of surfels lying on a slice of the digital surface (i.e., the 
+   * orthogonal direction of all surfels belong to a same plane, most pairs
+   * of consecutive surfels share a common linel).
    *
    * @tparam TKSpace type of Khalimsky space
    * @tparam TIterator type of iterator on 3d surfels,
@@ -150,7 +152,31 @@ namespace DGtal
      */
     typedef Point Vector;
 
+    /**
+     * Alias of this class
+     */
     typedef ArithmeticalDSSComputerOnSurfels<KSpace,ConstIterator,TInteger> Self;
+
+    /**
+     * Helpers used to extract relevant points from a pair of points
+     */
+    struct DirectPairExtractor {
+
+      virtual Point first(const std::pair<Point,Point>& aPair) const { return aPair.first; }
+      virtual Point second(const std::pair<Point,Point>& aPair) const { return aPair.second; }
+      
+    };
+    struct IndirectPairExtractor : public DirectPairExtractor {
+      
+      Point first(const std::pair<Point,Point>& aPair) const { return  aPair.second; }
+      Point second(const std::pair<Point,Point>& aPair) const { return aPair.first; }
+
+    }; 
+    typedef std::shared_ptr<DirectPairExtractor> PairExtractor;  
+    
+    /**
+     * Reversed version of this class (using reverse iterators)
+     */
     typedef ArithmeticalDSSComputerOnSurfels<KSpace,ReverseIterator<ConstIterator>,TInteger> Reverse;
 
     // ----------------------- Standard services ------------------------------
@@ -167,8 +193,11 @@ namespace DGtal
      * @param aKSpace a Khalimsky space
      * @param aDim1 a first direction that describes the projection plane
      * @param aDim2 a second direction that describes the projection plane
+     * @param aFlagToReverse a boolean telling whether one has to reverse 
+     * the orientation of the points associated to a surfel or not 
+     * ('false' by default)
      */
-    ArithmeticalDSSComputerOnSurfels(const KSpace& aKSpace, Dimension aDim1, Dimension aDim2);
+    ArithmeticalDSSComputerOnSurfels(const KSpace& aKSpace, Dimension aDim1, Dimension aDim2, bool aFlagToReverse = false);
     
     /**
      * Initialisation.
@@ -413,6 +442,12 @@ namespace DGtal
      */
     Projector my2DProjector; 
 
+    /**
+     * Smart pointer on an object used to extract relevant points 
+     * from a pair of points
+     */
+    PairExtractor myExtractor; 
+    
     /**
     * DSS representation
     */

--- a/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.h
+++ b/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.h
@@ -18,10 +18,10 @@
 
 /**
  * @file ArithmeticalDSSComputerOnSurfels.h
- * @author Jocelyn Meyron (\c
- * jocelyn.meyron@liris.cnrs.fr ) Laboratoire d'InfoRmatique en
- * Image et Systèmes d'information - LIRIS (CNRS, UMR 5205), CNRS,
- * France
+ * @author Jocelyn Meyron (\c jocelyn.meyron@liris.cnrs.fr )
+ * Laboratoire d'InfoRmatique en Image et Systèmes d'information - LIRIS (CNRS, UMR 5205), CNRS, France
+ * @author Tristan Roussillon (\c tristan.roussillon@liris.cnrs.fr )
+ * Laboratoire d'InfoRmatique en Image et Systèmes d'information - LIRIS (CNRS, UMR 5205), CNRS, France
  *
  * @date 2021/01/22
  *
@@ -46,7 +46,9 @@
 #include <list>
 #include "DGtal/base/Exceptions.h"
 #include "DGtal/base/Common.h"
+#include "DGtal/kernel/SpaceND.h"
 #include "DGtal/kernel/PointVector.h"
+#include <DGtal/kernel/BasicPointFunctors.h>
 #include "DGtal/kernel/CInteger.h"
 #include "DGtal/base/ReverseIterator.h"
 #include "DGtal/geometry/curves/ArithmeticalDSS.h"
@@ -77,8 +79,7 @@ namespace DGtal
    * @see ArithmeticalDSS NaiveDSS8 StandardDSS4
    */
   template <typename TKSpace, typename TIterator,
-    typename TInteger = typename TKSpace::Space::Integer,
-    unsigned short adjacency = 8>
+    typename TInteger = typename TKSpace::Space::Integer>
   class ArithmeticalDSSComputerOnSurfels
   {
     BOOST_CONCEPT_ASSERT(( concepts::CCellularGridSpaceND< TKSpace > ));
@@ -96,11 +97,6 @@ namespace DGtal
      * Type of signed cell
      */
     typedef typename KSpace::SCell  SCell; 
-
-    /**
-     * Type of unsigned cell
-     */
-    typedef typename KSpace::Cell  Cell; 
 
     /**
      * Type of iterator, at least readable and forward
@@ -121,6 +117,11 @@ namespace DGtal
     typedef PointVector<2, TInteger> Point;
 
     /**
+     * Type of 3d to 2d projector 
+     */
+    typedef functors::Projector<SpaceND<2,TInteger> > Projector; 
+    
+    /**
      * Type of coordinate
      */
     typedef typename Point::Coordinate Coordinate;
@@ -135,7 +136,7 @@ namespace DGtal
     /**
      * Type of objects that represents DSSs
      */
-    typedef ArithmeticalDSS<Coordinate, Integer, adjacency> DSS;
+    typedef ArithmeticalDSS<Coordinate, Integer, 4> DSS;
     //we expect that the iterator type returned DGtal points, used in the DSS representation
     BOOST_STATIC_ASSERT(( concepts::ConceptUtils::SameType< Point, typename DSS::Point >::value ));
 
@@ -149,8 +150,8 @@ namespace DGtal
      */
     typedef Point Vector;
 
-    typedef ArithmeticalDSSComputerOnSurfels<KSpace,ConstIterator,TInteger,adjacency> Self;
-    typedef ArithmeticalDSSComputerOnSurfels<KSpace,ReverseIterator<ConstIterator>,TInteger,adjacency> Reverse;
+    typedef ArithmeticalDSSComputerOnSurfels<KSpace,ConstIterator,TInteger> Self;
+    typedef ArithmeticalDSSComputerOnSurfels<KSpace,ReverseIterator<ConstIterator>,TInteger> Reverse;
 
     // ----------------------- Standard services ------------------------------
   public:
@@ -164,11 +165,11 @@ namespace DGtal
     /**
      * Constructor.
      * @param aKSpace a Khalimsky space
-     * @param aDim1 the first direction to project
-     * @param aDim2 the second direction to project
+     * @param aDim1 a first direction that describes the projection plane
+     * @param aDim2 a second direction that describes the projection plane
      */
     ArithmeticalDSSComputerOnSurfels(const KSpace& aKSpace, Dimension aDim1, Dimension aDim2);
-
+    
     /**
      * Initialisation.
      * @param it an iterator on 3D surfels
@@ -227,6 +228,9 @@ namespace DGtal
      * Tests whether the current DSS can be extended at the front.
      *
      * @return 'true' if yes, 'false' otherwise.
+     *
+     * @warning the caller must be sure that the iterator returned  
+     * by 'end()' can be safely dereferenced. 
      */
     bool isExtendableFront();
 
@@ -240,7 +244,11 @@ namespace DGtal
     /**
      * Tests whether the current DSS can be extended at the front.
      * Computes the parameters of the extended DSS if yes.
+     *
      * @return 'true' if yes, 'false' otherwise.
+     *
+     * @warning the caller must be sure that the iterator returned  
+     * by 'end()' can be safely dereferenced. 
      */
     bool extendFront();
 
@@ -265,6 +273,32 @@ namespace DGtal
      */
     bool retractBack();
 
+    /**
+     * Returns the ends of a unit segment corresponding 
+     * to the projection of a given signed surfel. 
+     *
+     * @param aSurfel any signed surfel.
+     * @return a pair of 2D points. 
+     */
+    std::pair<Point,Point> getProjectedPointsFromSurfel(SCell const& aSurfel) const; 
+
+    /**
+     * Front end of the projection of a given surfel. 
+     *
+     * @param aSurfel any signed surfel.
+     * @return the second 2D point.
+     * @see getProjectedPointsFromSurfel
+     */
+    Point getNextProjectedPoint(SCell const& aSurfel) const;
+    
+    /**
+     * Back end of the projection of a given surfel. 
+     *
+     * @param aSurfel any signed surfel.
+     * @return the second 2D point.
+     * @see getProjectedPointsFromSurfel
+     */
+    Point getPreviousProjectedPoint(SCell const& aSurfel) const; 
 
     // ------------------------- Accessors ------------------------------
     /**
@@ -329,92 +363,71 @@ namespace DGtal
      */
     bool isValid() const;
 
-    /**
-     * @param aSCell a surfel.
-     * @return the pair of 2D points projected on the plane defined by \ref myProjection1, \ref myProjection2.
-     */
-    std::pair<Point, Point> projectSurfel(SCell const& aSCell) const;
 
     // ------------------------- Hidden services ------------------------------
   private:
-    /**
-     * @param aSurfel1 the first unsigned surfel.
-     * @param aSurfel2 the second unsigned surfel.
-     * @param aLinel the common unsigned linel if it exists.
-     * @return 'true' if we found a common linel, 'false' otherwise.
-     */
-    bool commonLinel (Cell const& aSurfel1, Cell const& aSurfel2, Cell& aLinel);
 
     /**
-     * @param aPoint a digital 3D point.
-     * @return the 2D orthogonal projection on the plane defined by \ref myProjection1, \ref myProjection2
+     * Returns the ends of a unit segment corresponding 
+     * to the projection of a given signed linel. 
+     *
+     * @param aSurfel any signed surfel.
+     * @return a pair of 2D points. 
      */
-    Point projectInPlane (Point3 const& aPoint) const;
-
+    std::pair<Point,Point> getProjectedPointsFromLinel(SCell const& aLinel) const; 
+    
     /**
-     * @param it an iterator on a surfel.
-     * @param aPoint the new 2D point of 'it' that is not common to the previous surfel (if the update is possible).
-     * @param aUpdatePrevious a boolean that indicates whether to update myPreviousSurfel or not.
-     * @param aIsFront a boolean indicating we want to update in the front or in the back direction.
-     * @return 'true' if the update is possible, 'false' otherwise.
+     * Returns the unique dimension in {0,1,2} \ {aDim1, aDim2}. 
+     *
+     * @param aDim1 a dimension
+     * @param aDim2 a dimension
      */
-    bool getOtherPointFromSurfel (ConstIterator const& it, Point& aPoint, bool aIsFront, bool aUpdatePrevious);
-
+    Dimension dimNotIn(Dimension const& aDim1, Dimension const& aDim2) const; 
+    
     // ------------------------- Protected Datas ------------------------------
   protected:
 
     /**
-     * Khalimsky space
+     * (Pointer to) Khalimsky space
      */
     const KSpace* myKSpace;
 
     /**
-     * The first projection dimension.
+     * A first direction that describes the projection plane
      */
-    Dimension myDim1;
+    Dimension mySliceAxis1;
+    
+    /**
+     * A second direction that describes the projection plane
+     */
+    Dimension mySliceAxis2;
+    
+    /**
+     * A direction along which the points are projected
+     * (and orthogonal to the projection plane) 
+     */
+    Dimension myProjectionAxis;
 
     /**
-     * The second projection dimension.
+     * Functor that projects a 3D point to a 2D point along myProjectionAxis
      */
-    Dimension myDim2;
-
-    /**
-     * The first projection direction.
-     */
-    Point3 myProjection1;
-
-    /**
-     * The second projection direction.
-     */
-    Point3 myProjection2;
-
-    /**
-     * The direction that is orthogonal to the two projection directions.
-     */
-    Point3 myProjectionNormal;
-
-    /**
-     * We store the previous surfel in the 'front' direction to compute the common linel.
-     * Used in \ref getOtherPointFromSurfel.
-     */
-    ConstIterator myPreviousSurfelFront;
-
-    /**
-     * We store the previous surfel in the 'back' direction to compute the common linel.
-     * Used in \ref getOtherPointFromSurfel.
-     */
-    ConstIterator myPreviousSurfelBack;
+    Projector my2DProjector; 
 
     /**
     * DSS representation
     */
     DSS myDSS;
+    
     /**
     * begin iterator
     */
     ConstIterator myBegin;
+    
     /**
     * end iterator
+    *
+    * @warning the user must be sure that it can be safely dereferenced
+    * before calling 'isExtendableFront' and 'extendFront'. 
     */
     ConstIterator myEnd;
 
@@ -438,9 +451,9 @@ namespace DGtal
  * @param object the object of class 'ArithmeticalDSSComputerOnSurfels' to write.
  * @return the output stream after the writing.
  */
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 std::ostream&
-operator<< ( std::ostream & out,  const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency> & object )
+operator<< ( std::ostream & out,  const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger> & object )
 {
   object.selfDisplay( out);
   return out;

--- a/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.ih
+++ b/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.ih
@@ -53,7 +53,8 @@ template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
 ArithmeticalDSSComputerOnSurfels()
-  : myKSpace(nullptr), myDSS( Point(0,0) ), myBegin(), myEnd()
+  : myKSpace(nullptr), mySliceAxis1(), mySliceAxis2(), myProjectionAxis(),
+    my2DProjector(), myExtractor(nullptr), myDSS( Point(0,0) ), myBegin(), myEnd()
 {
 }
 
@@ -61,8 +62,9 @@ ArithmeticalDSSComputerOnSurfels()
 template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
-ArithmeticalDSSComputerOnSurfels(const KSpace& aKSpace, Dimension aDim1, Dimension aDim2)
-  : myKSpace(&aKSpace), mySliceAxis1(aDim1), mySliceAxis2(aDim2), myProjectionAxis(), my2DProjector(), myDSS( Point(0,0) ), myBegin(), myEnd()
+ArithmeticalDSSComputerOnSurfels(const KSpace& aKSpace, Dimension aDim1, Dimension aDim2, bool aFlagToReverse)
+  : myKSpace(&aKSpace), mySliceAxis1(aDim1), mySliceAxis2(aDim2), myProjectionAxis(),
+    my2DProjector(), myExtractor(), myDSS( Point(0,0) ), myBegin(), myEnd()
 {
    ASSERT(aDim1 != aDim2);
    
@@ -70,26 +72,12 @@ ArithmeticalDSSComputerOnSurfels(const KSpace& aKSpace, Dimension aDim1, Dimensi
 
    std::vector<Dimension> v = {aDim1, aDim2}; 
    my2DProjector.init(v.begin(),v.end());
-}
 
-
-//-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger>
-inline
-void DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
-init(const ConstIterator& it)
-{
-  ASSERT(myKSpace != nullptr);
-
-  myBegin = it;
-  myEnd = it;
-  ++myEnd;
-
-  SCell surfel = *it;
-  auto [p,q] = getProjectedPointsFromSurfel(surfel); 
-  myDSS = DSS( p );
-  ASSERT(myDSS.isExtendableFront( q )); 
-  myDSS.extendFront( q ); 
+   if (aFlagToReverse) {
+     myExtractor = PairExtractor(new IndirectPairExtractor()); 
+   } else {
+     myExtractor = PairExtractor(new DirectPairExtractor()); 
+   }
 }
 
 //-----------------------------------------------------------------------------
@@ -98,7 +86,7 @@ inline
 DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
 ArithmeticalDSSComputerOnSurfels ( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger> & other )
   : myKSpace(other.myKSpace), mySliceAxis1(other.mySliceAxis1), mySliceAxis2(other.mySliceAxis2), myProjectionAxis(other.myProjectionAxis),
-      my2DProjector(other.my2DProjector), myDSS(other.myDSS), myBegin(other.myBegin), myEnd(other.myEnd)
+    my2DProjector(other.my2DProjector), myExtractor(other.myExtractor), myDSS(other.myDSS), myBegin(other.myBegin), myEnd(other.myEnd)
 {
 }
 
@@ -116,6 +104,7 @@ operator=( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger> & 
       mySliceAxis2 = other.mySliceAxis2;
       myProjectionAxis = other.myProjectionAxis; 
       my2DProjector = other.my2DProjector;
+      myExtractor = other.myExtractor; 
       myDSS = other.myDSS;
       myBegin = other.myBegin;
       myEnd = other.myEnd;
@@ -130,7 +119,7 @@ typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Re
 DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>
 ::getReverse() const
 {
-  return Reverse(*myKSpace, mySliceAxis1, mySliceAxis2);
+  return Reverse(*myKSpace, mySliceAxis1, mySliceAxis2, true);
 }
 
 //-----------------------------------------------------------------------------
@@ -393,6 +382,31 @@ DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::selfDisplay
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+//                       Initialization                                      //
+///////////////////////////////////////////////////////////////////////////////
+
+//-----------------------------------------------------------------------------
+template <typename TKSpace, typename TIterator, typename TInteger>
+inline
+void DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
+init(const ConstIterator& it)
+{
+  ASSERT(myKSpace != nullptr);
+
+  myBegin = it;
+  myEnd = it;
+  ++myEnd;
+
+  SCell surfel = *it;
+  auto pair = getProjectedPointsFromSurfel(surfel);
+  auto p = myExtractor->first(pair); 
+  myDSS = DSS( p );
+  auto q = myExtractor->second(pair); 
+  ASSERT(myDSS.isExtendableFront( q )); 
+  myDSS.extendFront( q ); 
+}
+
+///////////////////////////////////////////////////////////////////////////////
 //                       Projection                                          //
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -404,10 +418,6 @@ std::pair<typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TIn
 DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::getProjectedPointsFromSurfel(SCell const& aSurfel) const
 {
 
-  // std::cout << myKSpace->sKCoords(aSurfel) << " "
-  // 	    << myProjectionAxis
-  // 	    << std::endl; 
-
   SCell linel1;
   //this convention has been chosen so that
   //linels always stand at the same side
@@ -417,20 +427,7 @@ DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::getProjecte
     linel1 = myKSpace->sIndirectIncident(aSurfel, myProjectionAxis); 
   }
 
-  // std::cout << myKSpace->sKCoords(linel1) << " "
-  // 	    << (*myKSpace->sDirs(linel1))
-  // 	    << std::endl; 
-
-  auto pair1 = getProjectedPointsFromLinel(linel1);
-
-  // /// for debugging
-  // auto [p, q] = pair1; //structured bindings C++17
-  // std::cout << myKSpace->sKCoords(aSurfel) << std::endl; 
-  // std::cout << myKSpace->sKCoords(linel1) << std::endl; 
-  // std::cout << p << q << std::endl;
-  // ///
-  
-  return pair1; 
+  return getProjectedPointsFromLinel(linel1);
 }
 
 //-----------------------------------------------------------------
@@ -439,7 +436,7 @@ inline
 typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
 DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::getNextProjectedPoint(SCell const& aSurfel) const
 {
-  return getProjectedPointsFromSurfel(aSurfel).second; 
+  return myExtractor->second(getProjectedPointsFromSurfel(aSurfel)); 
 }
 
 //-----------------------------------------------------------------
@@ -448,7 +445,7 @@ inline
 typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
 DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::getPreviousProjectedPoint(SCell const& aSurfel) const
 {
-  return getProjectedPointsFromSurfel(aSurfel).first; 
+  return myExtractor->first(getProjectedPointsFromSurfel(aSurfel)); 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -467,17 +464,9 @@ DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::getProjecte
   
   auto pointel1 = myKSpace->sIndirectIncident(aLinel, dim);
   auto p1 = my2DProjector(myKSpace->sCoords(pointel1));  
-  // std::cout << myKSpace->sKCoords(pointel1) << " "
-  // 	    << myKSpace->sCoords(pointel1) << " "
-  // 	    << p1 
-  // 	    << std::endl; 
 
   auto pointel2 = myKSpace->sDirectIncident(aLinel, dim); 
   auto p2 = my2DProjector(myKSpace->sCoords(pointel2));  
-  // std::cout << myKSpace->sKCoords(pointel2) << " "
-  // 	    << myKSpace->sCoords(pointel2) << " "
-  // 	    << p2
-  // 	    << std::endl; 
 
   return {p1, p2}; 
 }

--- a/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.ih
+++ b/src/DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.ih
@@ -18,6 +18,8 @@
  * @file ArithmeticalDSSComputerOnSurfels.ih
  * @author Jocelyn Meyron (\c jocelyn.meyron@liris.cnrs.fr )
  * Laboratoire d'InfoRmatique en Image et Systèmes d'information - LIRIS (CNRS, UMR 5205), CNRS, France
+ * @author Tristan Roussillon (\c tristan.roussillon@liris.cnrs.fr )
+ * Laboratoire d'InfoRmatique en Image et Systèmes d'information - LIRIS (CNRS, UMR 5205), CNRS, France
  *
  * @date 2021/01/22
  *
@@ -47,35 +49,34 @@
 // Implementation of inline methods                                          //
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
 ArithmeticalDSSComputerOnSurfels()
   : myKSpace(nullptr), myDSS( Point(0,0) ), myBegin(), myEnd()
 {
 }
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
 ArithmeticalDSSComputerOnSurfels(const KSpace& aKSpace, Dimension aDim1, Dimension aDim2)
-  : myKSpace(&aKSpace), myDim1(aDim1), myDim2(aDim2), myDSS( Point(0,0) ), myBegin(), myEnd()
+  : myKSpace(&aKSpace), mySliceAxis1(aDim1), mySliceAxis2(aDim2), myProjectionAxis(), my2DProjector(), myDSS( Point(0,0) ), myBegin(), myEnd()
 {
-    // Initialize projection vectors
-    myProjection1 = Point3::zero;
-    myProjection2 = Point3::zero;
-    myProjection1[myDim1] = 1;
-    myProjection2[myDim2] = 1;
+   ASSERT(aDim1 != aDim2);
+   
+   myProjectionAxis = dimNotIn(aDim1, aDim2); 
 
-    myProjectionNormal = myProjection1.crossProduct(myProjection2);
+   std::vector<Dimension> v = {aDim1, aDim2}; 
+   my2DProjector.init(v.begin(),v.end());
 }
 
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-void DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::
+void DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
 init(const ConstIterator& it)
 {
   ASSERT(myKSpace != nullptr);
@@ -84,66 +85,37 @@ init(const ConstIterator& it)
   myEnd = it;
   ++myEnd;
 
-  SCell s = *it;
-  auto initialPoints = projectSurfel(s);
-  myPreviousSurfelFront = it;
-  myPreviousSurfelBack = it;
-
-  // We ensure that the first two points are inserted in the correct order
-  Point firstPoint = initialPoints.first, secondPoint = initialPoints.second;
-  if (myKSpace->sIsValid(*myEnd)) {
-      auto nextPoints = projectSurfel(*myEnd);
-      if (nextPoints.first == initialPoints.first) {
-          secondPoint = initialPoints.first;
-          firstPoint = initialPoints.second;
-      } else if (nextPoints.first == initialPoints.second) {
-          secondPoint = initialPoints.second;
-          firstPoint = initialPoints.first;
-      } else if (nextPoints.second == initialPoints.first) {
-          secondPoint = initialPoints.first;
-          firstPoint = initialPoints.second;
-      } else if (nextPoints.second == initialPoints.second) {
-          secondPoint = initialPoints.second;
-          firstPoint = initialPoints.first;
-      } else {
-          ASSERT(false);
-      }
-  }
-
-  myDSS = DSS(firstPoint);
-  ASSERT(myDSS.isExtendableFront(secondPoint));
-  myDSS.extendFront(secondPoint);
+  SCell surfel = *it;
+  auto [p,q] = getProjectedPointsFromSurfel(surfel); 
+  myDSS = DSS( p );
+  ASSERT(myDSS.isExtendableFront( q )); 
+  myDSS.extendFront( q ); 
 }
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::
-ArithmeticalDSSComputerOnSurfels ( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency> & other )
-  : myKSpace(other.myKSpace), myDim1(other.myDim1), myDim2(other.myDim2),
-    myProjection1(other.myProjection1), myProjection2(other.myProjection2), myProjectionNormal(other.myProjectionNormal),
-    myPreviousSurfelFront(other.myPreviousSurfelFront), myPreviousSurfelBack(other.myPreviousSurfelBack),
-    myDSS(other.myDSS), myBegin(other.myBegin), myEnd(other.myEnd)
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
+ArithmeticalDSSComputerOnSurfels ( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger> & other )
+  : myKSpace(other.myKSpace), mySliceAxis1(other.mySliceAxis1), mySliceAxis2(other.mySliceAxis2), myProjectionAxis(other.myProjectionAxis),
+      my2DProjector(other.my2DProjector), myDSS(other.myDSS), myBegin(other.myBegin), myEnd(other.myEnd)
 {
 }
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>&
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::
-operator=( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency> & other )
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>&
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
+operator=( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger> & other )
 {
   if ( this != &other )
     {
       myKSpace = other.myKSpace;
-      myDim1 = other.myDim1;
-      myDim2 = other.myDim2;
-      myProjection1 = other.myProjection1;
-      myProjection2 = other.myProjection2;
-      myProjectionNormal = other.myProjectionNormal;
-      myPreviousSurfelFront = other.myPreviousSurfelFront;
-      myPreviousSurfelBack = other.myPreviousSurfelBack;
+      mySliceAxis1 = other.mySliceAxis1;
+      mySliceAxis2 = other.mySliceAxis2;
+      myProjectionAxis = other.myProjectionAxis; 
+      my2DProjector = other.my2DProjector;
       myDSS = other.myDSS;
       myBegin = other.myBegin;
       myEnd = other.myEnd;
@@ -152,31 +124,31 @@ operator=( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adj
 }
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Reverse
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Reverse
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>
 ::getReverse() const
 {
-  return Reverse(*myKSpace, myDim1, myDim2);
+  return Reverse(*myKSpace, mySliceAxis1, mySliceAxis2);
 }
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Self
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Self
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>
 ::getSelf() const
 {
-  return Self(*myKSpace, myDim1, myDim2);
+  return Self(*myKSpace, mySliceAxis1, mySliceAxis2);
 }
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::
-operator==( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>& other ) const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
+operator==( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>& other ) const
 {
   return ( (myBegin == other.myBegin)
            && (myEnd == other.myEnd)
@@ -184,11 +156,11 @@ operator==( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,ad
 }
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::
-operator!=( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency> & other ) const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::
+operator!=( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger> & other ) const
 {
   return (!(*this == other));
 }
@@ -197,391 +169,337 @@ operator!=( const ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,ad
 //                       Update methods                                      //
 ///////////////////////////////////////////////////////////////////////////////
 //--------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::isExtendableFront()
+bool 
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::isExtendableFront()
 {
-  Point p;
-  if (! getOtherPointFromSurfel(myEnd, p, true, false))
-      return false;
-
-  return myDSS.isExtendableFront( p );
+  //the caller must be sure that 'myEnd' can be safely dereferenced 
+  return myDSS.isExtendableFront( getNextProjectedPoint(*myEnd) ); 
 }
 
 //--------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::isExtendableBack()
+bool 
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::isExtendableBack()
 {
-  ConstIterator it = myBegin;
-  --it;
-  Point p;
-  if (! getOtherPointFromSurfel(it, p, false, false))
-      return false;
-
-  return myDSS.isExtendableBack( p );
+  ConstIterator it = myBegin; 
+  --it; 
+  //the caller must be sure that 'it' can be safely dereferenced 
+  return myDSS.isExtendableBack( getPreviousProjectedPoint(*it) ); 
 }
 
 //-----------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::extendFront()
+bool 
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::extendFront()
 {
-  Point p;
-  if (! getOtherPointFromSurfel(myEnd, p, true, true))
-    return false;
-
-  if (myDSS.extendFront(p))
+  //the caller must be sure that 'myEnd' can be safely dereferenced 
+  if (myDSS.extendFront(getNextProjectedPoint(*myEnd)))
     {
       ++myEnd;
-      return true;
+      return true; 
     }
-  else
-    return false;
+  else 
+    return false;  
 }
 
 //--------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::extendBack()
+bool 
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::extendBack()
 {
-  ConstIterator it = myBegin;
-  --it;
-  Point p;
-  if (! getOtherPointFromSurfel(it, p, false, true))
-      return false;
-
-  if (myDSS.extendBack(p))
+  ConstIterator it = myBegin; 
+  --it; 
+  //the caller must be sure that 'it' can be safely dereferenced 
+  if (myDSS.extendBack(getPreviousProjectedPoint(*it)))
     {
       myBegin = it;
-      return true;
+      return true; 
     }
-  else
-    return false;
+  else 
+    return false;  
 }
 
 //--------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::retractFront()
+bool 
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::retractFront()
 {
   if (myDSS.retractFront())
     {
-      --myEnd;
-      return true;
+      --myEnd; 
+      return true; 
     }
-  else
-    return false;
+  else 
+    return false;  
 }
 
 //--------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::retractBack()
+bool 
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::retractBack()
 {
   if (myDSS.retractBack())
     {
       ++myBegin;
-      return true;
+      return true; 
     }
-  else
-    return false;
+  else 
+    return false;  
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 //                       Accessors                                           //
 ///////////////////////////////////////////////////////////////////////////////
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-const typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Primitive&
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::primitive() const
+const typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Primitive&
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::primitive() const
 {
   return myDSS;
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 TInteger
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::a() const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::a() const
 {
   return myDSS.a();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 TInteger
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::b() const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::b() const
 {
   return myDSS.b();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 TInteger
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::mu() const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::mu() const
 {
   return myDSS.mu();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 TInteger
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::omega() const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::omega() const
 {
   return myDSS.omega();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Point
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Uf() const
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Uf() const
 {
   return myDSS.Uf();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Point
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Ul() const
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Ul() const
 {
   return myDSS.Ul();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Point
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Lf() const
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Lf() const
 {
   return myDSS.Lf();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Point
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Ll() const
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Ll() const
 {
   return myDSS.Ll();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Point
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::back() const
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::back() const
 {
   return myDSS.back();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Point
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::front() const
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::front() const
 {
   return myDSS.front();
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 TIterator
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::begin() const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::begin() const
 {
   return myBegin;
 }
 
 //-------------------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 TIterator
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::end() const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::end() const
 {
   return myEnd;
 }
 
 //-----------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::isValid() const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::isValid() const
 {
   return ( (myDSS.isValid())&&(isNotEmpty(myBegin,myEnd)) );
 }
 
 //-----------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
 void
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::selfDisplay ( std::ostream & out) const
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::selfDisplay ( std::ostream & out) const
 {
   out << "[ArithmeticalDSSComputerOnSurfels] " << myDSS;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+//                       Projection                                          //
+///////////////////////////////////////////////////////////////////////////////
+
 //-----------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::commonLinel (Cell const& aSurfel1,
-                                                                                            Cell const& aSurfel2,
-                                                                                            Cell& aLinel)
+std::pair<typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point,
+          typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point>
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::getProjectedPointsFromSurfel(SCell const& aSurfel) const
 {
-    ASSERT(myKSpace != nullptr);
 
-    typename KSpace::DirIterator q1_1 = myKSpace->uDirs(aSurfel1), q1_2 = q1_1;
-    ++q1_2;
-    typename KSpace::DirIterator q2_1 = myKSpace->uDirs(aSurfel2), q2_2 = q2_1;
-    ++q2_2;
+  // std::cout << myKSpace->sKCoords(aSurfel) << " "
+  // 	    << myProjectionAxis
+  // 	    << std::endl; 
 
-    std::set<Cell> linels1 = {
-        myKSpace->uIncident(aSurfel1, *q1_1, true),
-        myKSpace->uIncident(aSurfel1, *q1_1, false),
-        myKSpace->uIncident(aSurfel1, *q1_2, true),
-        myKSpace->uIncident(aSurfel1, *q1_2, false),
-    };
+  SCell linel1;
+  //this convention has been chosen so that
+  //linels always stand at the same side
+  if (myKSpace->sSign(aSurfel) == myKSpace->POS) {
+    linel1 = myKSpace->sDirectIncident(aSurfel, myProjectionAxis); 
+  } else {
+    linel1 = myKSpace->sIndirectIncident(aSurfel, myProjectionAxis); 
+  }
 
-    std::set<Cell> linels2 = {
-        myKSpace->uIncident(aSurfel2, *q2_1, true),
-        myKSpace->uIncident(aSurfel2, *q2_1, false),
-        myKSpace->uIncident(aSurfel2, *q2_2, true),
-        myKSpace->uIncident(aSurfel2, *q2_2, false),
-    };
+  // std::cout << myKSpace->sKCoords(linel1) << " "
+  // 	    << (*myKSpace->sDirs(linel1))
+  // 	    << std::endl; 
 
-    std::vector<Cell> inter;
-    std::set_intersection(linels1.begin(), linels1.end(),
-                          linels2.begin(), linels2.end(),
-                          std::back_inserter(inter));
+  auto pair1 = getProjectedPointsFromLinel(linel1);
 
-    if (inter.size() == 1)
-    {
-        // The two surfels intersect on one linel
-        aLinel = inter[0];
-        return true;
-    }
-
-    // The surfels don't intersect or are the same
-    return false;
+  // /// for debugging
+  // auto [p, q] = pair1; //structured bindings C++17
+  // std::cout << myKSpace->sKCoords(aSurfel) << std::endl; 
+  // std::cout << myKSpace->sKCoords(linel1) << std::endl; 
+  // std::cout << p << q << std::endl;
+  // ///
+  
+  return pair1; 
 }
 
 //-----------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-bool
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::getOtherPointFromSurfel(ConstIterator const& it,
-                                                                                                       Point& aPoint,
-                                                                                                       bool aIsFront,
-                                                                                                       bool aUpdatePrevious)
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::getNextProjectedPoint(SCell const& aSurfel) const
 {
-    ASSERT(myKSpace != nullptr);
-
-    SCell surfel = *it;
-    Point p1, p2;
-    std::tie(p1, p2) = projectSurfel(surfel);
-
-    ConstIterator& previousSurfel = aIsFront ? myPreviousSurfelFront : myPreviousSurfelBack;
-
-    // Find the common unsigned linel between surfel and previousSurfel
-    Cell linel;
-    if (! commonLinel(myKSpace->unsigns(surfel), myKSpace->unsigns(*previousSurfel), linel))
-    {
-        return false;
-    }
-
-    // For the next point, choose the point that is not part of the common linel
-    typename KSpace::DirIterator q_linel = myKSpace->uDirs(linel);
-    Point linel1 = projectInPlane(myKSpace->uCoords(myKSpace->uIncident(linel, *q_linel, true))),
-          linel2 = projectInPlane(myKSpace->uCoords(myKSpace->uIncident(linel, *q_linel, false)));
-
-    if (p1 == linel1)
-    {
-        aPoint = p2;
-    }
-    else if (p1 == linel2)
-    {
-        aPoint = p2;
-    }
-    else if (p2 == linel1)
-    {
-        aPoint = p1;
-    }
-    else if (p2 == linel2)
-    {
-        aPoint = p1;
-    }
-    else
-    {
-        ASSERT(false);
-    }
-
-    if (aUpdatePrevious)
-    {
-        previousSurfel = it;
-    }
-
-    return true;
+  return getProjectedPointsFromSurfel(aSurfel).second; 
 }
 
 //-----------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Point
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::projectInPlane(Point3 const& aPoint) const
+typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::getPreviousProjectedPoint(SCell const& aSurfel) const
 {
-    static const Point3 aOrigin = Point3::zero;
+  return getProjectedPointsFromSurfel(aSurfel).first; 
+}
 
-    // Orthogonal projection on the plane with a given unit normal
-    Point3 h = (aPoint - aOrigin) - myProjectionNormal * (aPoint - aOrigin).dot(myProjectionNormal);
+///////////////////////////////////////////////////////////////////////////////
+//                       Private methods                                      //
+///////////////////////////////////////////////////////////////////////////////
 
-    // We simply project the point on the plane defined by
-    // the two directions 'myProjection1' and 'myProjection2' passing through the origin point 'aOrigin'
-    return Point(h.dot(myProjection1), h.dot(myProjection2));
+
+//-----------------------------------------------------------------
+template <typename TKSpace, typename TIterator, typename TInteger>
+inline
+std::pair<typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point,
+          typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::Point>
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::getProjectedPointsFromLinel(SCell const& aLinel) const
+{
+  auto dim = *myKSpace->sDirs(aLinel); 
+  
+  auto pointel1 = myKSpace->sIndirectIncident(aLinel, dim);
+  auto p1 = my2DProjector(myKSpace->sCoords(pointel1));  
+  // std::cout << myKSpace->sKCoords(pointel1) << " "
+  // 	    << myKSpace->sCoords(pointel1) << " "
+  // 	    << p1 
+  // 	    << std::endl; 
+
+  auto pointel2 = myKSpace->sDirectIncident(aLinel, dim); 
+  auto p2 = my2DProjector(myKSpace->sCoords(pointel2));  
+  // std::cout << myKSpace->sKCoords(pointel2) << " "
+  // 	    << myKSpace->sCoords(pointel2) << " "
+  // 	    << p2
+  // 	    << std::endl; 
+
+  return {p1, p2}; 
 }
 
 //-----------------------------------------------------------------
-template <typename TKSpace, typename TIterator, typename TInteger, unsigned short adjacency>
+template <typename TKSpace, typename TIterator, typename TInteger>
 inline
-std::pair<typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Point,
-          typename DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::Point>
-DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger,adjacency>::projectSurfel(SCell const& aSCell) const
+DGtal::Dimension
+DGtal::ArithmeticalDSSComputerOnSurfels<TKSpace,TIterator,TInteger>::dimNotIn(Dimension const& aDim1, Dimension const& aDim2) const
 {
-    ASSERT(myKSpace != nullptr);
+  ASSERT( KSpace::dimension == 3 );
+  ASSERT( aDim1 != aDim2 );
+  
+  bool marks[3] = {false, false, false};
+  marks[aDim1] = true;
+  marks[aDim2] = true; 
 
-    typename KSpace::DirIterator q1 = myKSpace->sDirs(aSCell), q2 = q1;
-    ++q2;
+  int i = 0;
+  while (marks[i] == true) {
+    i++; 
+  }
 
-    // We pick 2 linels of the surfel
-    SCell linel1 = myKSpace->sIncident(aSCell, *q1, true),
-          linel2 = myKSpace->sIncident(aSCell, *q1, false);
-
-    // 4 points of the surfel
-    Point3 p1_1 = myKSpace->sCoords(myKSpace->sIncident(linel1, *q2, false)),
-           p1_2 = myKSpace->sCoords(myKSpace->sIncident(linel1, *q2, true)),
-           p2_1 = myKSpace->sCoords(myKSpace->sIncident(linel2, *q2, false)),
-           p2_2 = myKSpace->sCoords(myKSpace->sIncident(linel2, *q2, true));
-
-    std::set<Point> points;
-    points.insert(projectInPlane(p1_1));
-    points.insert(projectInPlane(p1_2));
-    points.insert(projectInPlane(p2_1));
-    points.insert(projectInPlane(p2_2));
-
-    ASSERT(points.size() == 2);
-
-    Point p1 = *points.begin(), p2 = *(++points.begin());
-
-    return  { p1, p2 };
+  ASSERT( (marks[i] == false) && (i < 3) );
+  return i; 
 }

--- a/src/DGtal/geometry/surfaces/estimation/MaximalSegmentSliceEstimation.h
+++ b/src/DGtal/geometry/surfaces/estimation/MaximalSegmentSliceEstimation.h
@@ -94,7 +94,7 @@ namespace DGtal
       using RealPoint2  = PointVector<2, double>;
       using Container   = std::deque<SCell>;
       using Iterator    = typename Container::const_iterator;
-      using DSSComputer = ArithmeticalDSSComputerOnSurfels<KSpace, Circulator<Iterator>, Integer, 4>;
+      using DSSComputer = ArithmeticalDSSComputerOnSurfels<KSpace, Circulator<Iterator>, Integer>;
 
     // ----------------------- Standard services ------------------------------
   public:

--- a/tests/geometry/surfaces/testArithmeticalDSSComputerOnSurfels.cpp
+++ b/tests/geometry/surfaces/testArithmeticalDSSComputerOnSurfels.cpp
@@ -40,7 +40,6 @@
 
 #include "DGtal/geometry/curves/ArithmeticalDSSComputer.h"
 #include "DGtal/geometry/surfaces/ArithmeticalDSSComputerOnSurfels.h"
-#include "DGtal/geometry/curves/GreedySegmentation.h"
 #include "DGtal/geometry/curves/SaturatedSegmentation.h"
 
 using namespace std;
@@ -50,17 +49,11 @@ using KSpace = Z3i::KSpace;
 using SH3    = Shortcuts<KSpace>;
 using Surfel = KSpace::SCell;
 
-//using CirculatorOnSurfels =  Circulator<std::vector<Surfel>::const_iterator>;
-//using SegmentComputerOnSurfels = ArithmeticalDSSComputerOnSurfels<KSpace, CirculatorOnSurfels, int, 4>;
 using SegmentComputerOnSurfels = ArithmeticalDSSComputerOnSurfels<KSpace, std::vector<Surfel>::const_iterator, int>;
 using SegmentationSurfels   = SaturatedSegmentation<SegmentComputerOnSurfels>;
-//using SegmentationSurfels   = GreedySegmentation<SegmentComputerOnSurfels>;
 
-//using CirculatorOnPoints =  Circulator<std::vector<Z2i::Point>::const_iterator>;
-//using SegmentComputer = ArithmeticalDSSComputer<CirculatorOnPoints, Z2i::Integer, 4>;
 using SegmentComputer = ArithmeticalDSSComputer<std::vector<Z2i::Point>::const_iterator, int, 4>;
 using Segmentation = SaturatedSegmentation<SegmentComputer>;
-//using Segmentation = GreedySegmentation<SegmentComputer>;
 
 struct Slice
 {
@@ -99,7 +92,7 @@ std::pair<KSpace, Slice> getSlice (std::string const& shape = "ellipsoid", doubl
     return { kspace, slice };
 }
 
-std::vector<Z2i::Point> extractPoints (SegmentComputerOnSurfels const& sc, KSpace const& aKSpace, Slice const& slice)
+std::vector<Z2i::Point> extractPoints (SegmentComputerOnSurfels const& sc, Slice const& slice)
 {
     std::vector<Z2i::Point> points;
 
@@ -111,9 +104,6 @@ std::vector<Z2i::Point> extractPoints (SegmentComputerOnSurfels const& sc, KSpac
     {
         Surfel s = *sit;
         auto pt = sc.getNextProjectedPoint(s);
-	std::cout << pt << " " << s << " "
-		  << ( (aKSpace.sSign(s) == aKSpace.POS)?(aKSpace.sDirectIncident(s, 2)):(aKSpace.sIndirectIncident(s, 2)) )
-		  << std::endl; 
 	points.push_back(pt);
     }
 
@@ -130,43 +120,24 @@ TEST_CASE("Testing ArithmeticalDSSComputerOnSurfels")
 
     // Do a segmentation using the surfel class
     SegmentComputerOnSurfels recognitionAlgorithmSurfels(kspace, slice.dim1, slice.dim2);
-    //auto citSurfels = CirculatorOnSurfels(slice.contour.begin(), slice.contour.begin(), slice.contour.end());
-    //SegmentationSurfels segmentationSurfels(citSurfels, citSurfels, recognitionAlgorithmSurfels);
     SegmentationSurfels segmentationSurfels(slice.contour.begin(), slice.contour.end(), recognitionAlgorithmSurfels);
 
     // Extract the projected points
-    std::vector<Z2i::Point> points = extractPoints(recognitionAlgorithmSurfels, kspace, slice);
+    std::vector<Z2i::Point> points = extractPoints(recognitionAlgorithmSurfels, slice);
 
     // Do a segmentation on the projected points
     SegmentComputer recognitionAlgorithm;
-    //auto cit = CirculatorOnPoints(points.begin(), points.begin(), points.end());
-    //Segmentation segmentation(cit, cit, recognitionAlgorithm);
     Segmentation segmentation(points.begin(), points.end(), recognitionAlgorithm);
 
-    //print for debuging
-    auto segIt = segmentation.begin();
-    while (segIt != segmentation.end()) {
-      std::cout << segIt->primitive() << std::endl; 
-      ++segIt;
-    }
-    std::cout << "------------------------------------------" << std::endl; 
-    auto segSurfelIt = segmentationSurfels.begin();
-    while (segSurfelIt != segmentationSurfels.end()) {
-      std::cout << segSurfelIt->primitive() << std::endl; 
-      ++segSurfelIt;
-    }
-    
     // The two segmentations must be the same
     bool allEqual = true;
-    segIt = segmentation.begin();
-    segSurfelIt = segmentationSurfels.begin();
+    auto segIt = segmentation.begin();
+    auto segSurfelIt = segmentationSurfels.begin();
     while (segIt != segmentation.end() && segSurfelIt != segmentationSurfels.end()) {
-      //std::cout << segSurfelIt->primitive().back() << " - " << segSurfelIt->primitive().front() << std::endl; 
-      //std::cout << segIt->primitive() << " " << segSurfelIt->primitive() << std::endl; 
+      
       allEqual = allEqual && (segIt->primitive() == segSurfelIt->primitive());
-
-        ++segIt;
-        ++segSurfelIt;
+      ++segIt;
+      ++segSurfelIt;
     }
 
     REQUIRE(allEqual);


### PR DESCRIPTION
# PR Description

The main issue was an iterator dereferencing in the `init` method of the class ArithmeticalDSSOnSurfels. This was done because of a bad algorithmic choice: in short, the new point to process was computed by looking at the next surfel, instead of looking at the orientation of the current surfel. Several parts of the class has been rewritten to use the latter strategy, which nicely fixes the bug. 

In summary, in this new version: 
- no `*myEnd` in the `unit` method, 
- for each surfel, an associated point is extracted based on its orientation. 

In addition, the template non-type `adjacency` has been removed, since one always wants to use "standard" digital straight segment and "4"-connectivity in the use-case targeted by the class.  

# Checklist

(the three first entries are not relevant since it is a bug fix, but I will take care of the other ones)
 
- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions)
