### PR TITLE
New option to disable the uninstall target

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 - *General*
   - Fix cmake CGAL 6.0 Breaking change. (David Coeurjolly, [#1745](https://github.com/DGtal-team/DGtal/pull/1745))
-  - Adding a new `DGTAL_REMOVE_UNINSTALL` cmake option to disable the `uninstall` target. (David Coeurjolly, [#1xxx](https://github.com/DGtal-team/DGtal/pull/1xxx)
+  - Adding a new `DGTAL_REMOVE_UNINSTALL` cmake option to disable the `uninstall` target. (David Coeurjolly, [#1746](https://github.com/DGtal-team/DGtal/pull/1746)
 
 
 - *Geometry*

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 - *General*
   - Fix cmake CGAL 6.0 Breaking change. (David Coeurjolly, [#1745](https://github.com/DGtal-team/DGtal/pull/1745))
+  - Adding a new `DGTAL_REMOVE_UNINSTALL` cmake option to disable the `uninstall` target. (David Coeurjolly, [#1xxx](https://github.com/DGtal-team/DGtal/pull/1xxx)
+
 
 - *Geometry*
   - Bug fix in ArithmeticalDSSComputerOnSurfels (Tristan Roussillon, [#1742](https://github.com/DGtal-team/DGtal/pull/1742))

--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -81,12 +81,15 @@ include(TargetDoxygenDox OPTIONAL)
 # -----------------------------------------------------------------------------
 # uninstall target
 # -----------------------------------------------------------------------------
+option(DGTAL_REMOVE_UNINSTALL "Remove DGtal uninstall target." OFF)
+if (NOT DGTAL_REMOVE_UNINSTALL)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TargetUninstall.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/TargetUninstall.cmake
   @ONLY)
 add_custom_target(uninstall
   "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/TargetUninstall.cmake")
+endif()
 
 # -----------------------------------------------------------------------------
 # Parsing cmake options


### PR DESCRIPTION
# PR Description

New  option to disable the uninstall target at cmake step.


# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug mode.
- [x] All continuous integration tests pass (Github Actions)
