### PR TITLE
Add option to use ITK EIGEN configuration (main2.0)

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -131,7 +131,7 @@ jobs:
     - name: Set up
       run: |
          sudo apt-get update
-         sudo apt-get install  zsh libqglviewer-dev-qt5 libboost-dev libcgal-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev libinsighttoolkit4-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev  graphviz texlive doxygen
+         sudo apt-get install  zsh libqglviewer-dev-qt5 libboost-dev libcgal-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev  libinsighttoolkit5-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev  graphviz texlive doxygen
 
     - name: Building pages
       run: |

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -33,7 +33,7 @@ jobs:
        if: matrix.os == 'ubuntu-latest'
        run: |
            sudo apt-get update
-           sudo apt-get install zsh libqglviewer-dev-qt5 libboost-dev libcgal-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev libinsighttoolkit4-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
+           sudo apt-get install zsh libqglviewer-dev-qt5 libboost-dev libcgal-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev libinsighttoolkit5-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
      - name: Install macOS deps
        if: matrix.os == 'macOS-latest'

--- a/.github/workflows/buildAndDocumentation-PR.yml
+++ b/.github/workflows/buildAndDocumentation-PR.yml
@@ -33,7 +33,7 @@ jobs:
        if: matrix.os == 'ubuntu-latest'
        run: |
            sudo apt-get update
-           sudo apt-get install ccache zsh libqglviewer-dev-qt5 libcgal-dev libboost-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev libinsighttoolkit4-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
+           sudo apt-get install ccache zsh libqglviewer-dev-qt5 libcgal-dev libboost-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev libinsighttoolkit5-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
 
      - name: Install macOS deps
        if: matrix.os == 'macOS-latest'

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -186,7 +186,7 @@ jobs:
         if: steps.get_round.outputs.result == 'fullbuild'
         run: |
           set -x
-          sudo apt-get update && sudo apt-get install -y libqglviewer-dev-qt5 libboost-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev libinsighttoolkit4-dev
+          sudo apt-get update && sudo apt-get install -y libqglviewer-dev-qt5 libboost-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev  libinsighttoolkit5-dev
           git config --global user.email "dgtal@dgtal.org"
           git config --global user.name "DGtal"
 

--- a/.github/workflows/pythonBindings-PR.yml
+++ b/.github/workflows/pythonBindings-PR.yml
@@ -37,7 +37,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install zsh libqglviewer-dev-qt5 libboost-dev libcgal-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev libinsighttoolkit4-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          sudo apt-get install zsh libqglviewer-dev-qt5 libboost-dev libcgal-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev  libinsighttoolkit5-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
       
       - name: Installing dependencies (macOS)
         if: matrix.os == 'macOS-latest'

--- a/.github/workflows/pythonBindings-Pypi.yml
+++ b/.github/workflows/pythonBindings-Pypi.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install zsh libqglviewer-dev-qt5 libboost-dev libcgal-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev libinsighttoolkit4-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          sudo apt-get install zsh libqglviewer-dev-qt5 libboost-dev libcgal-dev ninja-build libhdf5-serial-dev libboost-dev libcairo2-dev libgmp-dev libfftw3-dev  libinsighttoolkit5-dev xorg-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
       
       - name: Installing dependencies (macOS)
         if: matrix.os == 'macOS-latest'

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 - *Build*
   - Prefixing main cmake variables with `DGTAL_` (David Coeurjolly, [#1753](https://github.com/DGtal-team/DGtal/pull/1753))
+  - Add a cmake option to use the ITK EIGEN configuration to solve the issue [#347](https://github.com/DGtal-team/DGtalTools/issues/437) of DGTalTools. (Bertrand Kerautret, [#1759](https://github.com/DGtal-team/DGtal/pull/1759)
+
 
 # DGtal 1.4.2
 

--- a/cmake/deps/eigen.cmake
+++ b/cmake/deps/eigen.cmake
@@ -12,10 +12,10 @@
 
 option(EIGEN_WITH_MKL "Use Eigen with MKL" OFF)
 option(EIGEN_DONT_VECTORIZE "Disable Eigen vectorization" OFF)
-option(WITH_EIGEN_ITK "Use the EIGEN configuration of ITK (effective only if WITH_ITK=ON)" ON)
+option(DGTAL_WITH_EIGEN_ITK "Use the EIGEN configuration of ITK (effective only if DGTAL_WITH_ITK=ON)" ON)
 
 
-if (WITH_ITK AND WITH_EIGEN_ITK)
+if (DGTAL_WITH_ITK AND DGTAL_WITH_EIGEN_ITK)
    message(STATUS "Using EIGEN from ITK project, to avoid any eigen conflit version we strongly recommand to compile ITK using cmake option -DITK_USE_SYSTEM_EIGEN:BOOL=on ")
    return()    
 endif()

--- a/cmake/deps/eigen.cmake
+++ b/cmake/deps/eigen.cmake
@@ -9,12 +9,20 @@
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 #
-if(TARGET Eigen3::Eigen)
-    return()
-endif()
 
 option(EIGEN_WITH_MKL "Use Eigen with MKL" OFF)
 option(EIGEN_DONT_VECTORIZE "Disable Eigen vectorization" OFF)
+option(WITH_EIGEN_ITK "Use the EIGEN configuration of ITK (effective only if WITH_ITK=ON)" ON)
+
+
+if (WITH_ITK AND WITH_EIGEN_ITK)
+   message(STATUS "Using EIGEN from ITK project, to avoid any eigen conflit version we strongly recommand to compile ITK using cmake option -DITK_USE_SYSTEM_EIGEN:BOOL=on ")
+   return()    
+endif()
+
+if(TARGET Eigen3::Eigen)
+    return()
+endif()
 
 if(EIGEN_ROOT)
     message(STATUS "Third-party (external): creating target 'Eigen3::Eigen' for external path: ${EIGEN_ROOT}")


### PR DESCRIPTION
# PR Description
In order to avoid issue on conflicting eigen version, this option allows to let use the ITK configuration of eigen (in link to issue like DGtalTools [537](https://github.com/DGtal-team/DGtalTools/issues/437)).
Thanks  @phcerdan for the DGtalTools issue discussion and suggestions.


# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions)
