### PR TITLE
Ensure that the 3D segment results from the intersection of two maximal 2D segments

### DIFF
--- a/src/DGtal/geometry/curves/Naive3DDSSComputer.ih
+++ b/src/DGtal/geometry/curves/Naive3DDSSComputer.ih
@@ -244,6 +244,16 @@ DGtal::Naive3DDSSComputer<TIterator,TInteger,connectivity>::extendFront()
         myEnd++;
         return true;
     }
+
+    /**
+    * Ensure that the last segment is maximal in 2D,
+    * so that the corresponding 3D segment results from
+    * the intersection of two maximal 2D segments.
+    */
+    while (extendFront ( myXYalgo, blockXY ) );;
+    while (extendFront ( myXZalgo, blockXZ ) );;
+    while (extendFront ( myYZalgo, blockYZ ) );;
+
     return test == 1;
 }
 


### PR DESCRIPTION
As in the title. In the previous version we stop extending the 2D segments once we do not have at least two bijective projection, which leads to a problem of the last segment not being maximal. 

# PR Description

*your description here*

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions)
