### PR TITLE
Tiny compilation typo in tutorial-examples (shortcuts-geometry)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,7 @@
   - Add a cmake option to use the ITK EIGEN configuration to solve the issue [#347](https://github.com/DGtal-team/DGtalTools/issues/437) of DGTalTools. (Bertrand Kerautret, [#1759](https://github.com/DGtal-team/DGtal/pull/1759)
   - Building tests does not build the benchmarks anymore (Bastien Doignies, [#1772](https://github.com/DGtal-team/DGtal/pull/1772)
   - Add a cmake option to build benchmark (Bastien Doignies, [#1772](https://github.com/DGtal-team/DGtal/pull/1772)
+  - Fix compilation typo in tutorial-examples (shortcuts-geometry)  (Bertrand Kerautret, [#1787] (https://github.com/DGtal-team/DGtal/pull/1787)) 
 
 - *Documentation*
   - Refactoring of the documentation structure (David Coeurjolly, [#1762](https://github.com/DGtal-team/DGtal/pull/1762))

--- a/examples/tutorial-examples/shortcuts-geometry.cpp
+++ b/examples/tutorial-examples/shortcuts-geometry.cpp
@@ -481,7 +481,7 @@ int main( int /* argc */, char** /* argv */ )
     viewer.show();
     //! [dgtal_shortcuts_ssec2_1_15s]
     nb ++;
-    nbok ++;:
+    nbok ++;
   }
   trace.endBlock();
 #endif // DGTAL_WITH_POLYSCOPE


### PR DESCRIPTION
# PR Description
Fix compilation typo in tutorial-examples (shortcuts-geometry)

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions)
