### PR TITLE
Fix rational polytopes full convexity tests.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -58,6 +58,9 @@
   - Add a new command `make dgtal_benchmark` to run all benchmarks (Bastien Doignies, [#1772](https://github.com/DGtal-team/DGtal/pull/1772))
   - Reusable jobs for Github actions [#1766](https://github.com/DGtal-team/DGtal/pull/1766)
 
+- *Geometry*
+  - Fix rational polytopes tests of digital-k-convexity and full convexity (Jacques-Olivier Lachaud, [#1790](https://github.com/DGtal-team/DGtal/pull/1790))
+	
 # DGtal 1.4.2
 
 ## New features

--- a/src/DGtal/geometry/volumes/BoundedRationalPolytope.h
+++ b/src/DGtal/geometry/volumes/BoundedRationalPolytope.h
@@ -349,6 +349,13 @@ namespace DGtal
   public:
 
     /// @name Check point services (is inside test)
+    ///
+    /// @note These services consider the rational polytope
+    /// embedded as continuous polytope. Therefore even vertices of
+    /// the rational polytope may not be lattice points if their
+    /// coordinates do not reduce to an integer when divided by the
+    /// denominator of the rational polytope.
+    ///
     /// @{
 
     /**

--- a/src/DGtal/geometry/volumes/BoundedRationalPolytope.ih
+++ b/src/DGtal/geometry/volumes/BoundedRationalPolytope.ih
@@ -126,10 +126,10 @@ init( Integer denom,
   for ( Dimension s = 0; s < d; ++s )
     {
       Vector z = Vector::zero;
-      z[ s ]   = 1;
+      z[ s ]   = q;
       A.push_back( z );
       B.push_back( hi[ s ] );
-      z[ s ]   = -1;
+      z[ s ]   = -q;
       A.push_back( z );
       B.push_back( -lo[ s ] );
     }
@@ -147,13 +147,13 @@ init( Integer denom,
           const auto itF  = std::find( A.begin(), itAE, a );
           if ( itF == itAE )
             {
-              A.push_back( a );
-              B.push_back( q * b );
+              A.push_back( q * a );
+              B.push_back( b );
             }
           else
             {
               const auto k = itF - A.begin();
-              B[ k ] = std::min( B[ k ], q * b );
+              B[ k ] = std::min( B[ k ], b );
             }
         }
     }
@@ -161,8 +161,8 @@ init( Integer denom,
     { // Add other halfplanes
       for ( auto it = itB; it != itE; ++it )
         { 
-          A.push_back( it->N );
-          B.push_back( q * it->c );
+          A.push_back( q * it->N );
+          B.push_back( it->c );
           ++nb_hp;
         }
     }
@@ -181,22 +181,22 @@ internalInitFromTriangle3D( Point a, Point b, Point c )
   Vector  n = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ab, bc );
   if ( n == Vector::zero ) { clear(); return false; }
-  A.push_back(  n );
-  B.push_back(  q *a.dot( n ) );
-  A.push_back( -n );
-  B.push_back( -q * a.dot( n ) );
+  A.push_back(  q * n );
+  B.push_back(  a.dot( n ) );
+  A.push_back( -q * n );
+  B.push_back( -a.dot( n ) );
   Vector abn = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ab, n );
-  A.push_back( abn );
-  B.push_back( q * a.dot( abn ) );
+  A.push_back( q * abn );
+  B.push_back( a.dot( abn ) );
   Vector bcn = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( bc, n );
-  A.push_back( bcn );
-  B.push_back( q * b.dot( bcn ) );
+  A.push_back( q * bcn );
+  B.push_back( b.dot( bcn ) );
   Vector can = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ca, n );
-  A.push_back( can );
-  B.push_back( q * c.dot( can ) );
+  A.push_back( q * can );
+  B.push_back( c.dot( can ) );
   I = std::vector<bool>( 2*3+5, true ); // inequalities are large
   return true;
 }
@@ -218,16 +218,16 @@ internalInitFromSegment3D( Point a, Point b )
       n = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ab, t );
     }
-  A.push_back(  n );
-  B.push_back(  q * a.dot( n ) );
-  A.push_back( -n );
-  B.push_back( -q * a.dot( n ) );
+  A.push_back(  q * n );
+  B.push_back(  a.dot( n ) );
+  A.push_back( -q * n );
+  B.push_back( -a.dot( n ) );
   Vector w = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ab, n );
-  A.push_back(  w );
-  B.push_back(  q* a.dot( w ) );
-  A.push_back( -w );
-  B.push_back( -q * a.dot( w ) );
+  A.push_back(  q * w );
+  B.push_back(  a.dot( w ) );
+  A.push_back( -q * w );
+  B.push_back( -a.dot( w ) );
   I = std::vector<bool>( 2*3+4, true ); // inequalities are large
   return true;
 }
@@ -241,10 +241,10 @@ internalInitFromSegment2D( Point a, Point b )
   Vector ab = b - a;
   if ( ab == Vector::zero ) return true; // domain and constraints already computed
   Vector  n( -ab[ 1 ], ab[ 0 ] );
-  A.push_back(  n );
-  B.push_back(  q * a.dot( n ) );
-  A.push_back( -n );
-  B.push_back( -q * a.dot( n ) );
+  A.push_back(  q * n );
+  B.push_back(  a.dot( n ) );
+  A.push_back( -q * n );
+  B.push_back( -a.dot( n ) );
   I = std::vector<bool>( 2*2+2, true ); // inequalities are large
   return true;
 }
@@ -302,10 +302,10 @@ init( Integer denom, PointIterator itB, PointIterator itE )
   for ( Dimension s = 0; s < d; ++s )
     {
       Vector z = Vector::zero;
-      z[ s ]   = 1;
+      z[ s ]   = q;
       A.push_back( z );
       B.push_back( hi[ s ] );
-      z[ s ]   = -1;
+      z[ s ]   = -q;
       A.push_back( z );
       B.push_back( -lo[ s ] );
     }
@@ -358,8 +358,8 @@ init( Integer denom, PointIterator itB, PointIterator itE )
       b       += a.dot( pts[ s ] );
       // Check sign
       if ( a.dot( pts[ s ] ) > b ) { a *= (Integer) -1; b *= (Integer) -1; }
-      A.push_back( a );
-      B.push_back( q * b );
+      A.push_back( q * a );
+      B.push_back( b );
     }
   myValidEdgeConstraints = true;
   if ( dimension >= 3 )
@@ -600,7 +600,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 count() const
 {
   Integer nb = 0;
-  for ( const Point & p : rationalD )
+  for ( const Point & p : latticeD )
     nb += isDomainPointInside( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
   return nb;
 }
@@ -612,7 +612,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 countInterior() const
 {
   Integer nb = 0;
-  for ( const Point & p : rationalD )
+  for ( const Point & p : latticeD )
     nb += isInterior( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
   return nb;
 }
@@ -623,7 +623,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 countBoundary() const
 {
   Integer nb = 0;
-  for ( const Point & p : rationalD )
+  for ( const Point & p : latticeD )
     nb += isBoundary( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
   return nb;
 }
@@ -634,7 +634,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 countWithin( Point lo, Point hi ) const
 {
   Integer nb = 0;
-  Domain D1( lo.sup( rationalD.lowerBound() ), hi.inf( rationalD.upperBound() ) );
+  Domain D1( lo.sup( latticeD.lowerBound() ), hi.inf( latticeD.upperBound() ) );
   for ( const Point & p : D1 )
     nb += isDomainPointInside( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
   return nb;
@@ -646,7 +646,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 countUpTo( Integer max) const
 {
   Integer nb = 0;
-  for ( const Point & p : rationalD ) {
+  for ( const Point & p : latticeD ) {
     nb += isDomainPointInside( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
     if ( nb >= max ) return max;
   }
@@ -659,7 +659,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 getPoints( std::vector<Point>& pts ) const
 {
   pts.clear();
-  for ( const Point & p : rationalD )
+  for ( const Point & p : latticeD )
     if ( isDomainPointInside( p ) ) pts.push_back( p );
 }
 //-----------------------------------------------------------------------------
@@ -669,7 +669,7 @@ void
 DGtal::BoundedRationalPolytope<TSpace>::
 insertPoints( PointSet& pts_set ) const
 {
-  for ( const Point & p : rationalD )
+  for ( const Point & p : latticeD )
     if ( isDomainPointInside( p ) ) pts_set.insert( p );
 }
 //-----------------------------------------------------------------------------
@@ -679,7 +679,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 getInteriorPoints( std::vector<Point>& pts ) const
 {
   pts.clear();
-  for ( const Point & p : rationalD )
+  for ( const Point & p : latticeD )
     if ( isInterior( p ) ) pts.push_back( p );
 }
 //-----------------------------------------------------------------------------
@@ -689,7 +689,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 getBoundaryPoints( std::vector<Point>& pts ) const
 {
   pts.clear();
-  for ( const Point & p : rationalD )
+  for ( const Point & p : latticeD )
     if ( isBoundary( p ) ) pts.push_back( p );
 }
 

--- a/src/DGtal/geometry/volumes/BoundedRationalPolytope.ih
+++ b/src/DGtal/geometry/volumes/BoundedRationalPolytope.ih
@@ -126,10 +126,10 @@ init( Integer denom,
   for ( Dimension s = 0; s < d; ++s )
     {
       Vector z = Vector::zero;
-      z[ s ]   = q;
+      z[ s ]   = 1;
       A.push_back( z );
       B.push_back( hi[ s ] );
-      z[ s ]   = -q;
+      z[ s ]   = -1;
       A.push_back( z );
       B.push_back( -lo[ s ] );
     }
@@ -147,13 +147,13 @@ init( Integer denom,
           const auto itF  = std::find( A.begin(), itAE, a );
           if ( itF == itAE )
             {
-              A.push_back( q * a );
-              B.push_back( b );
+              A.push_back( a );
+              B.push_back( q * b );
             }
           else
             {
               const auto k = itF - A.begin();
-              B[ k ] = std::min( B[ k ], b );
+              B[ k ] = std::min( B[ k ], q * b );
             }
         }
     }
@@ -161,8 +161,8 @@ init( Integer denom,
     { // Add other halfplanes
       for ( auto it = itB; it != itE; ++it )
         { 
-          A.push_back( q * it->N );
-          B.push_back( it->c );
+          A.push_back( it->N );
+          B.push_back( q * it->c );
           ++nb_hp;
         }
     }
@@ -181,22 +181,22 @@ internalInitFromTriangle3D( Point a, Point b, Point c )
   Vector  n = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ab, bc );
   if ( n == Vector::zero ) { clear(); return false; }
-  A.push_back(  q * n );
-  B.push_back(  a.dot( n ) );
-  A.push_back( -q * n );
-  B.push_back( -a.dot( n ) );
+  A.push_back(  n );
+  B.push_back(  q *a.dot( n ) );
+  A.push_back( -n );
+  B.push_back( -q * a.dot( n ) );
   Vector abn = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ab, n );
-  A.push_back( q * abn );
-  B.push_back( a.dot( abn ) );
+  A.push_back( abn );
+  B.push_back( q * a.dot( abn ) );
   Vector bcn = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( bc, n );
-  A.push_back( q * bcn );
-  B.push_back( b.dot( bcn ) );
+  A.push_back( bcn );
+  B.push_back( q * b.dot( bcn ) );
   Vector can = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ca, n );
-  A.push_back( q * can );
-  B.push_back( c.dot( can ) );
+  A.push_back( can );
+  B.push_back( q * c.dot( can ) );
   I = std::vector<bool>( 2*3+5, true ); // inequalities are large
   return true;
 }
@@ -218,16 +218,16 @@ internalInitFromSegment3D( Point a, Point b )
       n = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ab, t );
     }
-  A.push_back(  q * n );
-  B.push_back(  a.dot( n ) );
-  A.push_back( -q * n );
-  B.push_back( -a.dot( n ) );
+  A.push_back(  n );
+  B.push_back(  q * a.dot( n ) );
+  A.push_back( -n );
+  B.push_back( -q * a.dot( n ) );
   Vector w = detail::BoundedRationalPolytopeSpecializer< dimension, Integer >::
     crossProduct( ab, n );
-  A.push_back(  q * w );
-  B.push_back(  a.dot( w ) );
-  A.push_back( -q * w );
-  B.push_back( -a.dot( w ) );
+  A.push_back(  w );
+  B.push_back(  q* a.dot( w ) );
+  A.push_back( -w );
+  B.push_back( -q * a.dot( w ) );
   I = std::vector<bool>( 2*3+4, true ); // inequalities are large
   return true;
 }
@@ -241,10 +241,10 @@ internalInitFromSegment2D( Point a, Point b )
   Vector ab = b - a;
   if ( ab == Vector::zero ) return true; // domain and constraints already computed
   Vector  n( -ab[ 1 ], ab[ 0 ] );
-  A.push_back(  q * n );
-  B.push_back(  a.dot( n ) );
-  A.push_back( -q * n );
-  B.push_back( -a.dot( n ) );
+  A.push_back(  n );
+  B.push_back(  q * a.dot( n ) );
+  A.push_back( -n );
+  B.push_back( -q * a.dot( n ) );
   I = std::vector<bool>( 2*2+2, true ); // inequalities are large
   return true;
 }
@@ -302,10 +302,10 @@ init( Integer denom, PointIterator itB, PointIterator itE )
   for ( Dimension s = 0; s < d; ++s )
     {
       Vector z = Vector::zero;
-      z[ s ]   = q;
+      z[ s ]   = 1;
       A.push_back( z );
       B.push_back( hi[ s ] );
-      z[ s ]   = -q;
+      z[ s ]   = -1;
       A.push_back( z );
       B.push_back( -lo[ s ] );
     }
@@ -358,8 +358,8 @@ init( Integer denom, PointIterator itB, PointIterator itE )
       b       += a.dot( pts[ s ] );
       // Check sign
       if ( a.dot( pts[ s ] ) > b ) { a *= (Integer) -1; b *= (Integer) -1; }
-      A.push_back( q * a );
-      B.push_back( b );
+      A.push_back( a );
+      B.push_back( q * b );
     }
   myValidEdgeConstraints = true;
   if ( dimension >= 3 )
@@ -600,7 +600,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 count() const
 {
   Integer nb = 0;
-  for ( const Point & p : latticeD )
+  for ( const Point & p : rationalD )
     nb += isDomainPointInside( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
   return nb;
 }
@@ -612,7 +612,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 countInterior() const
 {
   Integer nb = 0;
-  for ( const Point & p : latticeD )
+  for ( const Point & p : rationalD )
     nb += isInterior( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
   return nb;
 }
@@ -623,7 +623,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 countBoundary() const
 {
   Integer nb = 0;
-  for ( const Point & p : latticeD )
+  for ( const Point & p : rationalD )
     nb += isBoundary( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
   return nb;
 }
@@ -634,7 +634,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 countWithin( Point lo, Point hi ) const
 {
   Integer nb = 0;
-  Domain D1( lo.sup( latticeD.lowerBound() ), hi.inf( latticeD.upperBound() ) );
+  Domain D1( lo.sup( rationalD.lowerBound() ), hi.inf( rationalD.upperBound() ) );
   for ( const Point & p : D1 )
     nb += isDomainPointInside( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
   return nb;
@@ -646,7 +646,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 countUpTo( Integer max) const
 {
   Integer nb = 0;
-  for ( const Point & p : latticeD ) {
+  for ( const Point & p : rationalD ) {
     nb += isDomainPointInside( p ) ? NumberTraits<Integer>::ONE : NumberTraits<Integer>::ZERO;
     if ( nb >= max ) return max;
   }
@@ -659,7 +659,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 getPoints( std::vector<Point>& pts ) const
 {
   pts.clear();
-  for ( const Point & p : latticeD )
+  for ( const Point & p : rationalD )
     if ( isDomainPointInside( p ) ) pts.push_back( p );
 }
 //-----------------------------------------------------------------------------
@@ -669,7 +669,7 @@ void
 DGtal::BoundedRationalPolytope<TSpace>::
 insertPoints( PointSet& pts_set ) const
 {
-  for ( const Point & p : latticeD )
+  for ( const Point & p : rationalD )
     if ( isDomainPointInside( p ) ) pts_set.insert( p );
 }
 //-----------------------------------------------------------------------------
@@ -679,7 +679,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 getInteriorPoints( std::vector<Point>& pts ) const
 {
   pts.clear();
-  for ( const Point & p : latticeD )
+  for ( const Point & p : rationalD )
     if ( isInterior( p ) ) pts.push_back( p );
 }
 //-----------------------------------------------------------------------------
@@ -689,7 +689,7 @@ DGtal::BoundedRationalPolytope<TSpace>::
 getBoundaryPoints( std::vector<Point>& pts ) const
 {
   pts.clear();
-  for ( const Point & p : latticeD )
+  for ( const Point & p : rationalD )
     if ( isBoundary( p ) ) pts.push_back( p );
 }
 
@@ -698,7 +698,7 @@ template <typename TSpace>
 const typename DGtal::BoundedRationalPolytope<TSpace>::Domain&
 DGtal::BoundedRationalPolytope<TSpace>::getDomain() const
 {
-  return latticeD;
+  return rationalD;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/DGtal/geometry/volumes/BoundedRationalPolytope.ih
+++ b/src/DGtal/geometry/volumes/BoundedRationalPolytope.ih
@@ -698,7 +698,7 @@ template <typename TSpace>
 const typename DGtal::BoundedRationalPolytope<TSpace>::Domain&
 DGtal::BoundedRationalPolytope<TSpace>::getDomain() const
 {
-  return rationalD;
+  return latticeD;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/DGtal/geometry/volumes/CellGeometry.h
+++ b/src/DGtal/geometry/volumes/CellGeometry.h
@@ -290,6 +290,12 @@ namespace DGtal
     /// Given a rational \a polytope, such that `polytope.canBeSummed()==true`,
     /// return the \a i-kpoints that intersect it.
     ///
+    /// @note The rational polytope is dilated to a denominator 1 so
+    /// that the cells/k-points have a meaning.
+    ///
+    /// @warning Do not use when the polytope's denominator is too big,
+    /// otherwise the returned set can be huge.
+    ///
     /// @param polytope any rational polytope such that `polytope.canBeSummed() == true`
     /// @param i any integer between 0 and KSpace::dimension
     /// @return the \a i-kpoints that intersect this polytope.
@@ -316,6 +322,12 @@ namespace DGtal
 
     /// Given a rational \a polytope, such that `polytope.canBeSummed()==true`,
     /// return the \a i-cells that intersect it.
+    ///
+    /// @note The rational polytope is dilated to a denominator 1 so
+    /// that the cells/k-points have a meaning.
+    ///
+    /// @warning Do not use when the polytope's denominator is too big,
+    /// otherwise the returned set can be huge.
     ///
     /// @param polytope any rational polytope such that `polytope.canBeSummed() == true`
     /// @param i any integer between 0 and KSpace::dimension

--- a/src/DGtal/geometry/volumes/CellGeometry.ih
+++ b/src/DGtal/geometry/volumes/CellGeometry.ih
@@ -256,8 +256,17 @@ DGtal::CellGeometry<TKSpace>::
 addCellsTouchingPolytopePoints( const RationalPolytope& polytope )
 {
   std::vector< Point > points;
-  polytope.getPoints( points );
-  addCellsTouchingPoints( points.cbegin(), points.cend() );
+  if ( polytope.denominator() == 1 )
+    { 
+      polytope.getPoints( points );
+      addCellsTouchingPoints( points.cbegin(), points.cend() );
+    }
+  else
+    {
+      auto Q = polytope.denominator() * polytope;
+      Q.getPoints( points );
+      addCellsTouchingPoints( points.cbegin(), points.cend() );
+    }
 }
 //-----------------------------------------------------------------------------
 template <typename TKSpace>
@@ -277,10 +286,20 @@ void
 DGtal::CellGeometry<TKSpace>::
 addCellsTouchingPolytope( const RationalPolytope& polytope )
 {
-  for ( Dimension i = myMinCellDim; i <= myMaxCellDim; ++i )
+  if ( polytope.denominator() == 1 )
+    for ( Dimension i = myMinCellDim; i <= myMaxCellDim; ++i )
+      {
+        auto kpoints = getIntersectedKPoints( polytope, i );
+        myKPoints.insert( kpoints.cbegin(), kpoints.cend() );
+      }
+  else
     {
-      auto kpoints = getIntersectedKPoints( polytope, i );
-      myKPoints.insert( kpoints.cbegin(), kpoints.cend() );
+      auto Q = polytope.denominator() * polytope;
+      for ( Dimension i = myMinCellDim; i <= myMaxCellDim; ++i )
+        {
+          auto kpoints = getIntersectedKPoints( Q, i );
+          myKPoints.insert( kpoints.cbegin(), kpoints.cend() );
+        }
     }
 }
 //-----------------------------------------------------------------------------
@@ -561,6 +580,14 @@ getIntersectedCells( const RationalPolytope& polytope,
                     << std::endl;
   static const Dimension d = KSpace::dimension;
   std::vector< Cell >      result;
+  if ( polytope.denominator() != 1 )
+    {
+      trace.warning() << "[CellGeometryFunctions::getIntersectedCells]"
+                      << "only valid for rational polytopes with denominator 1, i.e. lattice polytope."
+                      << std::endl;
+      return result;
+    }
+  
   std::vector< Point >     points;
   std::vector< RationalPolytope  > polytopes( i+1, polytope );
   std::vector< Dimension > extensions( i+1, 0 );
@@ -624,6 +651,13 @@ getIntersectedKPoints( const RationalPolytope& polytope,
                     << std::endl;
   static const Dimension d = KSpace::dimension;
   std::vector< Point >     result;
+  if ( polytope.denominator() != 1 )
+    {
+      trace.warning() << "[CellGeometryFunctions::getIntersectedKPoints]"
+                      << "only valid for rational polytopes with denominator 1, i.e. lattice polytope."
+                      << std::endl;
+      return result;
+    }
   std::vector< Point >     points;
   std::vector< RationalPolytope  > polytopes( i+1, polytope );
   std::vector< Dimension > extensions( i+1, 0 );

--- a/src/DGtal/geometry/volumes/DigitalConvexity.ih
+++ b/src/DGtal/geometry/volumes/DigitalConvexity.ih
@@ -1221,9 +1221,10 @@ DGtal::DigitalConvexity<TKSpace>::
 isKConvex( const RationalPolytope& P, const Dimension k ) const
 {
   if ( k == 0 ) return true;
-  auto S = insidePoints( P );
+  auto Q = P.denominator() * P;
+  auto S = insidePoints( Q );
   auto touched_cells     = makeCellCover( S.begin(), S.end(), k, k );
-  auto intersected_cells = makeCellCover( P, k, k );
+  auto intersected_cells = makeCellCover( Q, k, k );
   return intersected_cells.nbCells() == touched_cells.nbCells()
     && intersected_cells.subset( touched_cells );
 }
@@ -1234,12 +1235,13 @@ bool
 DGtal::DigitalConvexity<TKSpace>::
 isFullyConvex( const RationalPolytope& P ) const
 {
-  auto S = insidePoints( P );
+  auto Q = P.denominator() * P;
+  auto S = insidePoints( Q );
   if ( S.size() <= 1 ) return true;
   for ( Dimension k = 1; k < KSpace::dimension; ++ k )
     {
       auto touched_cells     = makeCellCover( S.begin(), S.end(), k, k );
-      auto intersected_cells = makeCellCover( P, k, k );
+      auto intersected_cells = makeCellCover( Q, k, k );
       if ( ( intersected_cells.nbCells() != touched_cells.nbCells() )
            || ( ! intersected_cells.subset( touched_cells ) ) )
         return false;
@@ -1254,6 +1256,7 @@ DGtal::DigitalConvexity<TKSpace>::
 isKSubconvex( const RationalPolytope& P, const CellGeometry& C,
               const Dimension k ) const
 {
+  // TODO
   auto intersected_cells = makeCellCover( P, k, k );
   return intersected_cells.subset( C );
 }

--- a/src/DGtal/geometry/volumes/DigitalConvexity.ih
+++ b/src/DGtal/geometry/volumes/DigitalConvexity.ih
@@ -1256,7 +1256,6 @@ DGtal::DigitalConvexity<TKSpace>::
 isKSubconvex( const RationalPolytope& P, const CellGeometry& C,
               const Dimension k ) const
 {
-  // TODO
   auto intersected_cells = makeCellCover( P, k, k );
   return intersected_cells.subset( C );
 }

--- a/tests/geometry/volumes/testDigitalConvexity.cpp
+++ b/tests/geometry/volumes/testDigitalConvexity.cpp
@@ -304,8 +304,6 @@ SCENARIO( "DigitalConvexity< Z3 > fully convex tetrahedra", "[convex_simplices][
   }
 }
 
-// JOL: 2025/07/07 temporary disabled
-//      class BoundedRationalPolytope must be refactored
 SCENARIO( "DigitalConvexity< Z3 > rational fully convex tetrahedra", "[convex_simplices][3d][rational]" )
 {
   typedef KhalimskySpaceND<3,int>          KSpace;
@@ -368,8 +366,6 @@ SCENARIO( "DigitalConvexity< Z3 > rational fully convex tetrahedra", "[convex_si
 }
 
 
-// JOL: 2025/07/07 temporary disabled
-//      class BoundedRationalPolytope must be refactored
 SCENARIO( "DigitalConvexity< Z2 > rational fully convex triangles", "[convex_simplices][2d][rational]" )
 {
   typedef KhalimskySpaceND<2,int>          KSpace;
@@ -402,26 +398,16 @@ SCENARIO( "DigitalConvexity< Z2 > rational fully convex triangles", "[convex_sim
         nb1       += cvx1 ? 1 : 0;
         nb2       += cvx2 ? 1 : 0;
         nbf       += cvxf ? 1 : 0;
-        std::cout << "Triangle " << a << b << c << " / "
-                  << "inside: ";
-        auto pts = dconv.insidePoints( triangle );
-        for ( auto p: pts ) std::cout << " " << p;
-        std::cout << std::endl;
-        if ( cvx0 && cvx1 && cvx2 )
-          std::cout << " => is 012-convex";
-        if ( cvxf )
-          std::cout << " => is fully convex";
-        std::cout << std::endl;
         nb012     += ( cvx0 && cvx1 && cvx2 ) ? 1 : 0;
         nb01_not2 += ( cvx0 && cvx1 && ! cvx2 ) ? 1 : 0;
       }
-    // THEN( "All valid tetrahedra are 0-convex." ) {
-    //   REQUIRE( nb0 == nbsimplex );
-    // }
-    // THEN( "There are less 1-convex, 2-convex than 0-convex." ) {
-    //   REQUIRE( nb1 < nb0 );
-    //   REQUIRE( nb2 < nb0 );
-    // }
+    THEN( "All valid tetrahedra are 0-convex." ) {
+      REQUIRE( nb0 == nbsimplex );
+    }
+    THEN( "There are less 1-convex, 2-convex than 0-convex." ) {
+      REQUIRE( nb1 <= nb0 );
+      REQUIRE( nb2 <= nb0 );
+    }
     THEN( "When the tetrahedron is 0-convex, and 1-convex, then it is 2-convex." ) {
       CAPTURE( nb0 );
       CAPTURE( nb1 );

--- a/tests/geometry/volumes/testDigitalConvexity.cpp
+++ b/tests/geometry/volumes/testDigitalConvexity.cpp
@@ -304,6 +304,8 @@ SCENARIO( "DigitalConvexity< Z3 > fully convex tetrahedra", "[convex_simplices][
   }
 }
 
+// JOL: 2025/07/07 temporary disabled
+//      class BoundedRationalPolytope must be refactored
 SCENARIO( "DigitalConvexity< Z3 > rational fully convex tetrahedra", "[convex_simplices][3d][rational]" )
 {
   typedef KhalimskySpaceND<3,int>          KSpace;
@@ -312,7 +314,7 @@ SCENARIO( "DigitalConvexity< Z3 > rational fully convex tetrahedra", "[convex_si
 
   DConvexity dconv( Point( -1, -1, -1 ), Point( 10, 10, 10 ) );
   WHEN( "Computing many tetrahedra in domain (0,0,0)-(4,4,4)." ) {
-    const unsigned int nb = 50;
+    const unsigned int nb = 0; // 50
     unsigned int nbsimplex= 0;
     unsigned int nb0      = 0;
     unsigned int nb1      = 0;
@@ -347,9 +349,9 @@ SCENARIO( "DigitalConvexity< Z3 > rational fully convex tetrahedra", "[convex_si
       REQUIRE( nb0 == nbsimplex );
     }
     THEN( "There are less 1-convex, 2-convex and 3-convex than 0-convex." ) {
-      REQUIRE( nb1 < nb0 );
-      REQUIRE( nb2 < nb0 );
-      REQUIRE( nb3 < nb0 );
+      REQUIRE( nb1 <= nb0 );
+      REQUIRE( nb2 <= nb0 );
+      REQUIRE( nb3 <= nb0 );
     }
     THEN( "When the tetrahedron is 0-convex, 1-convex and 2-convex, then it is 3-convex." ) {
       CAPTURE( nb0 );
@@ -366,15 +368,17 @@ SCENARIO( "DigitalConvexity< Z3 > rational fully convex tetrahedra", "[convex_si
 }
 
 
-SCENARIO( "DigitalConvexity< Z2 > rational fully convex tetrahedra", "[convex_simplices][2d][rational]" )
+// JOL: 2025/07/07 temporary disabled
+//      class BoundedRationalPolytope must be refactored
+SCENARIO( "DigitalConvexity< Z2 > rational fully convex triangles", "[convex_simplices][2d][rational]" )
 {
   typedef KhalimskySpaceND<2,int>          KSpace;
   typedef KSpace::Point                    Point;
   typedef DigitalConvexity< KSpace >       DConvexity;
 
-  DConvexity dconv( Point( -1, -1 ), Point( 10, 10 ) );
+  DConvexity dconv( Point( -1, -1 ), Point( 30, 30 ) );
   WHEN( "Computing many triangle in domain (0,0)-(9,9)." ) {
-    const unsigned int nb = 50;
+    const unsigned int nb = 0; // 20;
     unsigned int nbsimplex= 0;
     unsigned int nb0      = 0;
     unsigned int nb1      = 0;
@@ -388,26 +392,36 @@ SCENARIO( "DigitalConvexity< Z2 > rational fully convex tetrahedra", "[convex_si
         Point b(    rand() % 20 , 2*(rand() % 10) );
         Point c( 2*(rand() % 10), 2*(rand() % 10) );
         if ( ! dconv.isSimplexFullDimensional( { a, b, c } ) ) continue;
-        auto tetra = dconv.makeRationalSimplex( { Point(2,2), a, b, c } );
-        bool cvx0     = dconv.isKConvex( tetra, 0 );
-        bool cvx1     = dconv.isKConvex( tetra, 1 );
-        bool cvx2     = dconv.isKConvex( tetra, 2 );
-        bool cvxf     = dconv.isFullyConvex( tetra );
+        auto triangle = dconv.makeRationalSimplex( { Point(2,2), a, b, c } );
+        bool cvx0     = dconv.isKConvex( triangle, 0 );
+        bool cvx1     = dconv.isKConvex( triangle, 1 );
+        bool cvx2     = dconv.isKConvex( triangle, 2 );
+        bool cvxf     = dconv.isFullyConvex( triangle );
         nbsimplex += 1;
         nb0       += cvx0 ? 1 : 0;
         nb1       += cvx1 ? 1 : 0;
         nb2       += cvx2 ? 1 : 0;
         nbf       += cvxf ? 1 : 0;
+        std::cout << "Triangle " << a << b << c << " / "
+                  << "inside: ";
+        auto pts = dconv.insidePoints( triangle );
+        for ( auto p: pts ) std::cout << " " << p;
+        std::cout << std::endl;
+        if ( cvx0 && cvx1 && cvx2 )
+          std::cout << " => is 012-convex";
+        if ( cvxf )
+          std::cout << " => is fully convex";
+        std::cout << std::endl;
         nb012     += ( cvx0 && cvx1 && cvx2 ) ? 1 : 0;
         nb01_not2 += ( cvx0 && cvx1 && ! cvx2 ) ? 1 : 0;
       }
-    THEN( "All valid tetrahedra are 0-convex." ) {
-      REQUIRE( nb0 == nbsimplex );
-    }
-    THEN( "There are less 1-convex, 2-convex than 0-convex." ) {
-      REQUIRE( nb1 < nb0 );
-      REQUIRE( nb2 < nb0 );
-    }
+    // THEN( "All valid tetrahedra are 0-convex." ) {
+    //   REQUIRE( nb0 == nbsimplex );
+    // }
+    // THEN( "There are less 1-convex, 2-convex than 0-convex." ) {
+    //   REQUIRE( nb1 < nb0 );
+    //   REQUIRE( nb2 < nb0 );
+    // }
     THEN( "When the tetrahedron is 0-convex, and 1-convex, then it is 2-convex." ) {
       CAPTURE( nb0 );
       CAPTURE( nb1 );

--- a/tests/geometry/volumes/testDigitalConvexity.cpp
+++ b/tests/geometry/volumes/testDigitalConvexity.cpp
@@ -314,7 +314,7 @@ SCENARIO( "DigitalConvexity< Z3 > rational fully convex tetrahedra", "[convex_si
 
   DConvexity dconv( Point( -1, -1, -1 ), Point( 10, 10, 10 ) );
   WHEN( "Computing many tetrahedra in domain (0,0,0)-(4,4,4)." ) {
-    const unsigned int nb = 0; // 50
+    const unsigned int nb = 30;
     unsigned int nbsimplex= 0;
     unsigned int nb0      = 0;
     unsigned int nb1      = 0;
@@ -378,7 +378,7 @@ SCENARIO( "DigitalConvexity< Z2 > rational fully convex triangles", "[convex_sim
 
   DConvexity dconv( Point( -1, -1 ), Point( 30, 30 ) );
   WHEN( "Computing many triangle in domain (0,0)-(9,9)." ) {
-    const unsigned int nb = 0; // 20;
+    const unsigned int nb = 50;
     unsigned int nbsimplex= 0;
     unsigned int nb0      = 0;
     unsigned int nb1      = 0;


### PR DESCRIPTION
# PR Description

Fix rational polytopes full convexity tests. In DigitalConvexity, digital-k-convexity and full convexity / sub convexity tests were run on RationalPolytopes with their inside lattice points. This is invalid since we must dilate the polytope by its denominator before enumerating touching points or cells.

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions)
