### PR TITLE
Fix1797

### DIFF
--- a/src/DGtal/images/ConstImageAdapter.h
+++ b/src/DGtal/images/ConstImageAdapter.h
@@ -283,7 +283,7 @@ public:
      * @return the point in the source domain  
      */
 
-   TImageContainer::Point sourceDomainPoint (const Point &aPoint) const
+   typename TImageContainer::Point sourceDomainPoint (const Point &aPoint) const
     {
       return  myFD->operator()(aPoint);
     }

--- a/tests/geometry/volumes/testCellGeometry.cpp
+++ b/tests/geometry/volumes/testCellGeometry.cpp
@@ -339,7 +339,7 @@ SCENARIO( "CellGeometry< Z2 > rational intersections",
 
   GIVEN( "A rational simplex P={ Point(0/4,0/4), Point(17/4,8/4), Point(-5/4,15/4) }" ) {
     KSpace K;
-    K.init( Point( -5, -5 ), Point( 10, 10 ), true );
+    K.init( Point( -50, -50 ), Point( 100, 100 ), true );
     std::vector< Point > V = { Point(0,0), Point(17,8), Point(-5,15) };
     Polytope P( 4, V.begin(), V.end() );
     CGeometry intersected_cover( K, 0, 2, false );
@@ -361,7 +361,7 @@ SCENARIO( "CellGeometry< Z2 > rational intersections",
   }
   GIVEN( "A thin rational simplex P={ Point(6/4,6/4), Point(17/4,8/4), Point(-5/4,15/4) }" ) {
     KSpace K;
-    K.init( Point( -5, -5 ), Point( 10, 10 ), true );
+    K.init( Point( -50, -50 ), Point( 100, 100 ), true );
     std::vector< Point > V = { Point(6,6), Point(17,8), Point(-5,15) };
     Polytope P( 4, V.begin(), V.end() );
     CGeometry intersected_cover( K, 0, 2, false );
@@ -395,7 +395,7 @@ SCENARIO( "CellGeometry< Z3 > rational intersections",
 
   GIVEN( "A simplex P={ Point(1/2,0/2,-1/2), Point(7/2,3/2,1/2), Point(-2/2,9/2,3/2), Point(6/2,7/2,10/2) }" ) {
     KSpace K;
-    K.init( Point( -5, -5, -5 ), Point( 10, 10, 10 ), true );
+    K.init( Point( -50, -50, -50 ), Point( 100, 100, 100 ), true );
     CGeometry intersected_cover( K, 0, 3, false );
     Polytope P = { Point(2,2,2),
                    Point(1,0,-1), Point(7,3,1), Point(-2,9,3), Point(6,7,10) };

--- a/tests/geometry/volumes/testDigitalConvexity.cpp
+++ b/tests/geometry/volumes/testDigitalConvexity.cpp
@@ -310,7 +310,7 @@ SCENARIO( "DigitalConvexity< Z3 > rational fully convex tetrahedra", "[convex_si
   typedef KSpace::Point                    Point;
   typedef DigitalConvexity< KSpace >       DConvexity;
 
-  DConvexity dconv( Point( -1, -1, -1 ), Point( 10, 10, 10 ) );
+  DConvexity dconv( Point( -10, -10, -10 ), Point( 100, 100, 100 ) );
   WHEN( "Computing many tetrahedra in domain (0,0,0)-(4,4,4)." ) {
     const unsigned int nb = 30;
     unsigned int nbsimplex= 0;


### PR DESCRIPTION
# PR Description

Fix #1797 : 
- testCellGeometry and testDigitalConvexity in Debug mode
- Both fail because of assertions in KhalimskySpaceND.
- it was because the digital space was too small for the examples
- in both tests, the digital space was extended.
- fixed also a typename in ConstImageAdapter (unrelated), which was preventing compilation).

# Checklist

- [ ] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Documentation module page added or updated.
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [ ] No warning raised in Debug mode.
- [ ] All continuous integration tests pass (Github Actions)
